### PR TITLE
feat: implement flight timeout mechanism for stale flights

### DIFF
--- a/migrations/2025-10-11-223330-0000_add_timed_out_at_to_flights/down.sql
+++ b/migrations/2025-10-11-223330-0000_add_timed_out_at_to_flights/down.sql
@@ -1,0 +1,2 @@
+-- Remove timed_out_at column from flights table
+ALTER TABLE flights DROP COLUMN timed_out_at;

--- a/migrations/2025-10-11-223330-0000_add_timed_out_at_to_flights/up.sql
+++ b/migrations/2025-10-11-223330-0000_add_timed_out_at_to_flights/up.sql
@@ -1,0 +1,3 @@
+-- Add timed_out_at column to flights table to track when a flight was timed out
+-- due to no beacon being received for 5+ minutes
+ALTER TABLE flights ADD COLUMN timed_out_at TIMESTAMPTZ;

--- a/src/main.rs
+++ b/src/main.rs
@@ -419,6 +419,9 @@ async fn handle_run(
     // Start periodic state saving (every 5 seconds)
     flight_tracker.start_periodic_state_saving(5);
 
+    // Start flight timeout checker (every 60 seconds)
+    flight_tracker.start_timeout_checker(60);
+
     // Create database fix processor to save all valid fixes to the database
     // Try to create with NATS first, fall back to without NATS if connection fails
     let fix_processor = match FixProcessor::with_flight_tracker_and_nats(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -350,6 +350,7 @@ diesel::table! {
         runways_inferred -> Nullable<Bool>,
         takeoff_location_id -> Nullable<Uuid>,
         landing_location_id -> Nullable<Uuid>,
+        timed_out_at -> Nullable<Timestamptz>,
     }
 }
 

--- a/web/src/lib/components/FlightStateBadge.svelte
+++ b/web/src/lib/components/FlightStateBadge.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	interface Props {
+		state: 'active' | 'complete' | 'timed_out';
+	}
+
+	let { state }: Props = $props();
+
+	// Determine badge classes and text based on state
+	const stateConfig = $derived.by(() => {
+		switch (state) {
+			case 'active':
+				return {
+					classes: 'bg-green-500 text-white',
+					text: 'Active'
+				};
+			case 'complete':
+				return {
+					classes: 'bg-blue-500 text-white',
+					text: 'Complete'
+				};
+			case 'timed_out':
+				return {
+					classes: 'bg-orange-500 text-white',
+					text: 'Timed Out'
+				};
+			default:
+				return {
+					classes: 'bg-gray-500 text-white',
+					text: 'Unknown'
+				};
+		}
+	});
+</script>
+
+<span class="badge {stateConfig.classes} text-xs">{stateConfig.text}</span>

--- a/web/src/routes/flights/+page.svelte
+++ b/web/src/routes/flights/+page.svelte
@@ -5,6 +5,7 @@
 	import dayjs from 'dayjs';
 	import relativeTime from 'dayjs/plugin/relativeTime';
 	import { getAircraftTypeOgnDescription, getAircraftTypeColor } from '$lib/formatters';
+	import FlightStateBadge from '$lib/components/FlightStateBadge.svelte';
 
 	dayjs.extend(relativeTime);
 
@@ -14,6 +15,8 @@
 		device_address_type: string;
 		takeoff_time: string | null;
 		landing_time: string | null;
+		timed_out_at: string | null;
+		state: 'active' | 'complete' | 'timed_out';
 		departure_airport: string | null;
 		departure_airport_country: string | null;
 		arrival_airport: string | null;
@@ -150,6 +153,7 @@
 						<tr>
 							<th>Aircraft</th>
 							<th>Type</th>
+							<th>Status</th>
 							<th>Takeoff</th>
 							<th>Landing</th>
 							<th>Duration</th>
@@ -250,6 +254,9 @@
 									{:else}
 										<span class="text-surface-500">—</span>
 									{/if}
+								</td>
+								<td>
+									<FlightStateBadge state={flight.state} />
 								</td>
 								<td>
 									<div class="flex flex-col gap-1">
@@ -377,6 +384,7 @@
 									{formatDeviceAddress(flight.device_address, flight.device_address_type)}
 								</span>
 							{/if}
+							<FlightStateBadge state={flight.state} />
 							{#if flight.aircraft_type_ogn}
 								<span class="badge {getAircraftTypeColor(flight.aircraft_type_ogn)} text-xs">
 									{getAircraftTypeOgnDescription(flight.aircraft_type_ogn)}

--- a/web/src/routes/flights/[id]/+page.ts
+++ b/web/src/routes/flights/[id]/+page.ts
@@ -15,6 +15,8 @@ export const load: PageLoad = async ({ params }) => {
 					device_address_type: string;
 					takeoff_time?: string;
 					landing_time?: string;
+					timed_out_at?: string;
+					state: 'active' | 'complete' | 'timed_out';
 					departure_airport?: string;
 					departure_airport_id?: number;
 					arrival_airport?: string;


### PR DESCRIPTION
Add automatic timeout detection and tracking for flights that haven't received beacon data for 5+ minutes. Only one flight can be active per device at any time.

Backend changes:
- Add timed_out_at timestamptz column to flights table
- Add FlightState enum (Active, Complete, TimedOut) for flight status
- Add timeout_flight() repository method (only sets timed_out_at)
- Add timeout detection in FlightTracker with 5-minute threshold
- Add background task that checks for stale flights every 60 seconds
- Update FlightView API to include state and timed_out_at fields
- Clear tracker state when flight times out

Frontend changes:
- Create FlightStateBadge component with color-coded states (green=Active, blue=Complete, orange=TimedOut)
- Update flights list page to display flight state badges
- Update flight detail page to show timeout information
- Stop polling when flight times out (not just when landed)
- Display explanatory message for timed-out flights

Note: Timed-out flights do NOT have landing location set, as these are timeouts due to missing data, not actual landings.