### PR TITLE
feat: add nearby flights feature to flight detail page

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -418,6 +418,7 @@ pub async fn start_web_server(interface: String, port: u16, pool: PgPool) -> Res
         .route("/flights/{id}", get(actions::get_flight_by_id))
         .route("/flights/{id}/kml", get(actions::get_flight_kml))
         .route("/flights/{id}/fixes", get(actions::get_flight_fixes))
+        .route("/flights/{id}/nearby", get(actions::get_nearby_flights))
         // Pilot routes
         .route("/pilots/{id}", get(actions::get_pilot_by_id))
         .route("/clubs/{id}/pilots", get(actions::get_pilots_by_club))


### PR DESCRIPTION
Add functionality to show flights that occurred during the same time period and within the same geographic area as the current flight being viewed.

Backend changes:
- Add get_nearby_flights repository method that queries for flights with overlapping time ranges and bounding boxes
- Add /flights/{id}/nearby API endpoint that returns nearby flights with device information
- Use Diesel query builder for type-safe queries where possible

Frontend changes:
- Add "Include Nearby Flights" checkbox toggle on flight detail map
- Fetch and display nearby flights on the map with distinct colors
- Show list of nearby flights below the map with key details
- Support async loading of nearby flight paths