### PR TITLE
refactor: simplify aircraft_registrations

### DIFF
--- a/migrations/2025-10-16-222545-0000_simplify_aircraft_registrations/down.sql
+++ b/migrations/2025-10-16-222545-0000_simplify_aircraft_registrations/down.sql
@@ -1,0 +1,35 @@
+-- Re-add all op_* columns to aircraft_registrations
+ALTER TABLE aircraft_registrations
+    ADD COLUMN op_restricted_other BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_restricted_ag_pest_control BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_restricted_aerial_surveying BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_restricted_aerial_advertising BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_restricted_forest BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_restricted_patrolling BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_restricted_weather_control BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_restricted_carriage_of_cargo BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_show_compliance BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_research_development BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_amateur_built BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_exhibition BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_racing BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_crew_training BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_market_survey BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_operating_kit_built BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_light_sport_reg_prior_2008 BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_light_sport_operating_kit_built BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_light_sport_prev_21_190 BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_uas_research_development BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_uas_market_survey BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_uas_crew_training BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_uas_exhibition BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_experimental_uas_compliance_with_cfr BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_sfp_ferry_for_repairs_alterations_storage BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_sfp_evacuate_impending_danger BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_sfp_excess_of_max_certificated BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_sfp_delivery_or_export BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_sfp_production_flight_testing BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN op_sfp_customer_demo BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Drop the new aircraft_approved_operations table
+DROP TABLE IF EXISTS aircraft_approved_operations;

--- a/migrations/2025-10-16-222545-0000_simplify_aircraft_registrations/up.sql
+++ b/migrations/2025-10-16-222545-0000_simplify_aircraft_registrations/up.sql
@@ -1,0 +1,48 @@
+-- Create the new aircraft_approved_operations table
+CREATE TABLE aircraft_approved_operations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    aircraft_registration_id VARCHAR(6) NOT NULL,
+    operation VARCHAR NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_aircraft_registration
+        FOREIGN KEY (aircraft_registration_id)
+        REFERENCES aircraft_registrations(registration_number)
+        ON DELETE CASCADE
+);
+
+-- Create index for faster lookups by registration
+CREATE INDEX idx_aircraft_approved_operations_registration_id
+    ON aircraft_approved_operations(aircraft_registration_id);
+
+-- Drop all op_* columns from aircraft_registrations
+ALTER TABLE aircraft_registrations
+    DROP COLUMN op_restricted_other,
+    DROP COLUMN op_restricted_ag_pest_control,
+    DROP COLUMN op_restricted_aerial_surveying,
+    DROP COLUMN op_restricted_aerial_advertising,
+    DROP COLUMN op_restricted_forest,
+    DROP COLUMN op_restricted_patrolling,
+    DROP COLUMN op_restricted_weather_control,
+    DROP COLUMN op_restricted_carriage_of_cargo,
+    DROP COLUMN op_experimental_show_compliance,
+    DROP COLUMN op_experimental_research_development,
+    DROP COLUMN op_experimental_amateur_built,
+    DROP COLUMN op_experimental_exhibition,
+    DROP COLUMN op_experimental_racing,
+    DROP COLUMN op_experimental_crew_training,
+    DROP COLUMN op_experimental_market_survey,
+    DROP COLUMN op_experimental_operating_kit_built,
+    DROP COLUMN op_experimental_light_sport_reg_prior_2008,
+    DROP COLUMN op_experimental_light_sport_operating_kit_built,
+    DROP COLUMN op_experimental_light_sport_prev_21_190,
+    DROP COLUMN op_experimental_uas_research_development,
+    DROP COLUMN op_experimental_uas_market_survey,
+    DROP COLUMN op_experimental_uas_crew_training,
+    DROP COLUMN op_experimental_uas_exhibition,
+    DROP COLUMN op_experimental_uas_compliance_with_cfr,
+    DROP COLUMN op_sfp_ferry_for_repairs_alterations_storage,
+    DROP COLUMN op_sfp_evacuate_impending_danger,
+    DROP COLUMN op_sfp_excess_of_max_certificated,
+    DROP COLUMN op_sfp_delivery_or_export,
+    DROP COLUMN op_sfp_production_flight_testing,
+    DROP COLUMN op_sfp_customer_demo;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -39,6 +39,16 @@ pub mod sql_types {
 }
 
 diesel::table! {
+    aircraft_approved_operations (id) {
+        id -> Uuid,
+        #[max_length = 6]
+        aircraft_registration_id -> Varchar,
+        operation -> Varchar,
+        created_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
     aircraft_models (manufacturer_code, model_code, series_code) {
         manufacturer_code -> Text,
         model_code -> Text,
@@ -86,36 +96,6 @@ diesel::table! {
         registrant_name -> Nullable<Varchar>,
         last_action_date -> Nullable<Date>,
         certificate_issue_date -> Nullable<Date>,
-        op_restricted_other -> Bool,
-        op_restricted_ag_pest_control -> Bool,
-        op_restricted_aerial_surveying -> Bool,
-        op_restricted_aerial_advertising -> Bool,
-        op_restricted_forest -> Bool,
-        op_restricted_patrolling -> Bool,
-        op_restricted_weather_control -> Bool,
-        op_restricted_carriage_of_cargo -> Bool,
-        op_experimental_show_compliance -> Bool,
-        op_experimental_research_development -> Bool,
-        op_experimental_amateur_built -> Bool,
-        op_experimental_exhibition -> Bool,
-        op_experimental_racing -> Bool,
-        op_experimental_crew_training -> Bool,
-        op_experimental_market_survey -> Bool,
-        op_experimental_operating_kit_built -> Bool,
-        op_experimental_light_sport_reg_prior_2008 -> Bool,
-        op_experimental_light_sport_operating_kit_built -> Bool,
-        op_experimental_light_sport_prev_21_190 -> Bool,
-        op_experimental_uas_research_development -> Bool,
-        op_experimental_uas_market_survey -> Bool,
-        op_experimental_uas_crew_training -> Bool,
-        op_experimental_uas_exhibition -> Bool,
-        op_experimental_uas_compliance_with_cfr -> Bool,
-        op_sfp_ferry_for_repairs_alterations_storage -> Bool,
-        op_sfp_evacuate_impending_danger -> Bool,
-        op_sfp_excess_of_max_certificated -> Bool,
-        op_sfp_delivery_or_export -> Bool,
-        op_sfp_production_flight_testing -> Bool,
-        op_sfp_customer_demo -> Bool,
         type_engine_code -> Nullable<Int2>,
         status_code -> Nullable<Text>,
         transponder_code -> Nullable<Int8>,
@@ -591,6 +571,7 @@ diesel::table! {
     }
 }
 
+diesel::joinable!(aircraft_approved_operations -> aircraft_registrations (aircraft_registration_id));
 diesel::joinable!(aircraft_other_names -> aircraft_registrations (registration_number));
 diesel::joinable!(aircraft_registrations -> airports (home_base_airport_id));
 diesel::joinable!(aircraft_registrations -> devices (device_id));
@@ -618,6 +599,7 @@ diesel::joinable!(receivers_photos -> receivers (receiver_id));
 diesel::joinable!(users -> clubs (club_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
+    aircraft_approved_operations,
     aircraft_models,
     aircraft_other_names,
     aircraft_registrations,


### PR DESCRIPTION
Replace 30 boolean op_* columns in aircraft_registrations with a new aircraft_approved_operations table that stores human-readable operation descriptions.

Database changes:
- Create aircraft_approved_operations table with aircraft_registration_id FK
- Remove all op_* boolean columns from aircraft_registrations
- Operations now stored as human-readable strings (e.g. "Experimental: Show Compliance")

Code changes:
- Add AircraftApprovedOperation and NewAircraftApprovedOperation models
- Add ApprovedOps::to_human_readable_operations() method for conversion
- Update repository to insert approved operations after aircraft registration
- Remove all op_* fields from AircraftRegistrationModel and NewAircraftRegistration
- Simplify upsert query by removing ~90 lines of op_* field updates

The approved operations parsing logic remains intact for FAA data ingestion. Operations will be populated by pull-data in the new normalized table structure.