### PR TITLE
fix: add defensive null/undefined checks for toFixed() calls in recei…

### DIFF
--- a/web/src/routes/receivers/[id]/+page.svelte
+++ b/web/src/routes/receivers/[id]/+page.svelte
@@ -544,15 +544,23 @@
 										</td>
 										<td class="font-mono text-sm">{fix.registration || '—'}</td>
 										<td class="font-mono text-xs">
-											{fix.latitude.toFixed(4)}, {fix.longitude.toFixed(4)}
+											{fix.latitude?.toFixed(4) ?? '—'}, {fix.longitude?.toFixed(4) ?? '—'}
 										</td>
-										<td>{fix.altitude_msl_feet !== null ? `${fix.altitude_msl_feet} ft` : '—'}</td>
 										<td
-											>{fix.ground_speed_knots !== null
+											>{fix.altitude_msl_feet !== null && fix.altitude_msl_feet !== undefined
+												? `${fix.altitude_msl_feet} ft`
+												: '—'}</td
+										>
+										<td
+											>{fix.ground_speed_knots !== null && fix.ground_speed_knots !== undefined
 												? `${fix.ground_speed_knots.toFixed(0)} kt`
 												: '—'}</td
 										>
-										<td>{fix.snr_db !== null ? `${fix.snr_db.toFixed(1)} dB` : '—'}</td>
+										<td
+											>{fix.snr_db !== null && fix.snr_db !== undefined
+												? `${fix.snr_db.toFixed(1)} dB`
+												: '—'}</td
+										>
 									</tr>
 								{/each}
 							</tbody>


### PR DESCRIPTION
…ver detail page

Fixed 'Cannot read properties of undefined (reading toFixed)' error by:
- Using optional chaining (?.) and nullish coalescing (??) for latitude/longitude
- Adding explicit null AND undefined checks before calling toFixed() on:
  - altitude_msl_feet
  - ground_speed_knots
  - snr_db

This prevents runtime errors when the API returns undefined values instead of null, or when the runtime data doesn't match the TypeScript interface expectations.