### PR TITLE
fix: make device address unique and improve spontaneous device creation

### DIFF
--- a/migrations/2025-10-16-232436-0000_fix_device_address_unique/down.sql
+++ b/migrations/2025-10-16-232436-0000_fix_device_address_unique/down.sql
@@ -1,0 +1,11 @@
+-- Remove unique constraint on address column
+DROP INDEX IF EXISTS idx_devices_address_unique;
+
+-- Delete any orphaned fixes with NULL device_id before restoring NOT NULL constraint
+DELETE FROM fixes WHERE device_id IS NULL;
+
+-- Make device_id NOT NULL again in fixes table
+ALTER TABLE fixes ALTER COLUMN device_id SET NOT NULL;
+
+-- Note: We cannot restore the deleted devices that had from_ddb = FALSE
+-- This migration is not fully reversible

--- a/migrations/2025-10-16-232436-0000_fix_device_address_unique/up.sql
+++ b/migrations/2025-10-16-232436-0000_fix_device_address_unique/up.sql
@@ -1,0 +1,16 @@
+-- First, make device_id nullable in fixes table to allow CASCADE delete to set null
+ALTER TABLE fixes ALTER COLUMN device_id DROP NOT NULL;
+
+-- Delete all devices that were not from the DDB (spontaneously created devices)
+-- This will also delete all fixes and flights associated with these devices via CASCADE
+DELETE FROM devices WHERE from_ddb = FALSE;
+
+-- Delete any orphaned fixes with NULL device_id (shouldn't happen but clean up just in case)
+DELETE FROM fixes WHERE device_id IS NULL;
+
+-- Restore NOT NULL constraint on device_id
+ALTER TABLE fixes ALTER COLUMN device_id SET NOT NULL;
+
+-- Add unique constraint on address column
+-- This ensures that each device address is unique in the system
+CREATE UNIQUE INDEX idx_devices_address_unique ON devices(address);

--- a/src/fix_processor.rs
+++ b/src/fix_processor.rs
@@ -233,9 +233,19 @@ impl FixProcessor {
                         };
                     }
 
-                    // Look up or create device based on device_address and address_type
+                    // When creating devices spontaneously (not from DDB), determine address_type from aprs_type
+                    // aprs_type is the packet destination (e.g., "OGFLR", "OGADSB")
+                    let aprs_type = packet.to.to_string();
+                    let spontaneous_address_type = match aprs_type.as_str() {
+                        "OGFLR" => crate::devices::AddressType::Flarm,
+                        "OGADSB" => crate::devices::AddressType::Icao,
+                        _ => crate::devices::AddressType::Unknown,
+                    };
+
+                    // Look up or create device based on device_address
+                    // When creating spontaneously, use address_type derived from aprs_type
                     match device_repo
-                        .get_or_insert_device_by_address(device_address, address_type)
+                        .get_or_insert_device_by_address(device_address, spontaneous_address_type)
                         .await
                     {
                         Ok(device_model) => {


### PR DESCRIPTION
Changes:
- Make device.address unique across the system (remove tuple-based lookups)
- Stop using (address_type, address) tuple everywhere - just use address
- Improve spontaneous device creation to determine address_type from aprs_type:
  - "OGFLR" → AddressType::Flarm
  - "OGADSB" → AddressType::Icao
  - other → AddressType::Unknown

Database migration:
- Delete devices with from_ddb=false (spontaneously created devices)
- Add unique index on devices.address column
- Temporarily drop fixes.device_id NOT NULL constraint for cascade cleanup
- Clean up orphaned fixes, then restore NOT NULL constraint

Code changes:
- device_repo: Update all lookup methods to use address only
  - get_device_by_address(address) - removed address_type param
  - get_device_model_by_address(address) - removed address_type param
  - get_or_insert_device_by_address() - now uses on_conflict(address) only
  - search_by_address() - returns Option instead of Vec (address is unique)
  - Removed search_by_address_and_type() method
  - upsert_devices() - changed conflict from tuple to address only

- fixes_repo: Updated device UUID lookup methods
  - lookup_device_uuid_by_address() - removed address_type param
  - lookup_device_uuid() - uses address filter only

- fix_processor: Implement address_type mapping from aprs_type
  - Determine address_type from packet destination (aprs_type)
  - Pass mapped address_type to get_or_insert_device_by_address()

- actions/devices: Update API endpoint
  - search_devices_by_address() - address_type_str param ignored (backwards compat)
  - Use new search_by_address() that returns Option

🤖 Generated with [Claude Code](https://claude.com/claude-code)