### PR TITLE
fix: add ON DELETE SET NULL to fixes_flight_id_fkey constraint

### DIFF
--- a/migrations/2025-10-19-024649-0000_fix_fixes_flight_id_fkey_on_delete/down.sql
+++ b/migrations/2025-10-19-024649-0000_fix_fixes_flight_id_fkey_on_delete/down.sql
@@ -1,0 +1,8 @@
+-- Revert to the original foreign key constraint without ON DELETE SET NULL
+ALTER TABLE fixes DROP CONSTRAINT IF EXISTS fixes_flight_id_fkey;
+
+-- Re-add the original foreign key constraint (no ON DELETE action)
+ALTER TABLE fixes
+    ADD CONSTRAINT fixes_flight_id_fkey
+    FOREIGN KEY (flight_id)
+    REFERENCES flights(id);

--- a/migrations/2025-10-19-024649-0000_fix_fixes_flight_id_fkey_on_delete/up.sql
+++ b/migrations/2025-10-19-024649-0000_fix_fixes_flight_id_fkey_on_delete/up.sql
@@ -1,0 +1,9 @@
+-- Drop the existing foreign key constraint
+ALTER TABLE fixes DROP CONSTRAINT IF EXISTS fixes_flight_id_fkey;
+
+-- Re-add the foreign key constraint with ON DELETE SET NULL
+ALTER TABLE fixes
+    ADD CONSTRAINT fixes_flight_id_fkey
+    FOREIGN KEY (flight_id)
+    REFERENCES flights(id)
+    ON DELETE SET NULL;


### PR DESCRIPTION
This prevents foreign key constraint violations when deleting spurious flights. Instead of failing, the database will automatically set flight_id to NULL on any fixes that reference the deleted flight.

Fixes the error:
update or delete on table "flights" violates foreign key constraint "fixes_flight_id_fkey" on table "fixes"