### PR TITLE
feat: add aircraft other names import and fix NATS provisioning

### DIFF
--- a/provision
+++ b/provision
@@ -55,6 +55,7 @@ sudo cp soar-pull-data.service /etc/systemd/system/
 sudo cp soar-pull-data.timer /etc/systemd/system/
 sudo cp soar-sitemap.service /etc/systemd/system/
 sudo cp soar-sitemap.timer /etc/systemd/system/
+sudo cp infrastructure/nats-server.service /etc/systemd/system/
 
 # Reload systemd daemon
 echo "Reloading systemd daemon..."
@@ -66,6 +67,7 @@ sudo systemctl enable soar.target
 sudo systemctl enable soar-run.service
 sudo systemctl enable soar-web.service
 sudo systemctl enable soar-pull-data.timer
+sudo systemctl enable nats-server.service
 
 # Create necessary directories
 echo -e "${BLUE}Creating directories...${NC}"
@@ -92,8 +94,10 @@ echo -e "${YELLOW}Individual service control:${NC}"
 echo "  sudo systemctl start soar-web.service"
 echo "  sudo systemctl stop soar-run.service"
 echo "  sudo systemctl restart soar-pull-data.timer"
+echo "  sudo systemctl start nats-server.service"
 echo
 echo -e "${YELLOW}Check logs:${NC}"
 echo "  sudo journalctl -u soar-run.service -f"
 echo "  sudo journalctl -u soar-web.service -f"
 echo "  sudo journalctl -u soar-pull-data.service -f"
+echo "  sudo journalctl -u nats-server.service -f"


### PR DESCRIPTION
- Add aircraft_other_names table support to aircraft registration import
  - Created NewAircraftOtherName struct for database insertions
  - Added to_other_names() method to convert Aircraft.other_names to DB records
  - Batch insert/delete other names during upsert_aircraft_registrations
  - Follows same pattern as aircraft_approved_operations

- Fix provision script to properly deploy NATS server
  - Added nats-server.service to systemd service installation
  - Enabled nats-server.service to start on boot
  - Updated usage instructions with NATS service commands
  - Required since soar.target depends on nats-server.service