### PR TITLE
feat: enhance spurious flight detection with additional sanity checks

### DIFF
--- a/src/flight_tracker/flight_lifecycle.rs
+++ b/src/flight_tracker/flight_lifecycle.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 
 use super::ActiveFlightsMap;
 use super::altitude::calculate_altitude_offset_ft;
+use super::geometry::haversine_distance;
 use super::location::{create_or_find_location, find_nearby_airport};
 use super::runway::determine_runway_identifier;
 
@@ -198,15 +199,59 @@ pub(crate) async fn complete_flight(
             None
         };
 
-        // Check if flight is spurious (< 2 minutes)
+        // Check for excessive altitude (> 100,000 feet indicates bad data)
+        let has_excessive_altitude = if !flight_fixes.is_empty() {
+            flight_fixes
+                .iter()
+                .filter_map(|f| f.altitude_msl_feet)
+                .any(|alt| alt > 100_000)
+        } else {
+            false
+        };
+
+        // Calculate average speed for sanity check
+        let average_speed_mph = if duration_seconds > 0 {
+            // Calculate total distance using haversine formula
+            let mut total_distance_meters = 0.0;
+            for i in 1..flight_fixes.len() {
+                let prev = &flight_fixes[i - 1];
+                let curr = &flight_fixes[i];
+                total_distance_meters += haversine_distance(
+                    prev.latitude,
+                    prev.longitude,
+                    curr.latitude,
+                    curr.longitude,
+                );
+            }
+            let total_distance_miles = total_distance_meters / 1609.34;
+            let duration_hours = duration_seconds as f64 / 3600.0;
+            Some(total_distance_miles / duration_hours)
+        } else {
+            None
+        };
+
+        // Check if average speed is > 1000 mph (indicates bad data)
+        let has_excessive_speed = average_speed_mph
+            .map(|speed| speed > 1000.0)
+            .unwrap_or(false);
+
+        // Check if flight is spurious
         let is_spurious = duration_seconds < 120
             || altitude_range.map(|range| range < 50).unwrap_or(false)
-            || max_agl_altitude.map(|agl| agl < 100).unwrap_or(false);
+            || max_agl_altitude.map(|agl| agl < 100).unwrap_or(false)
+            || has_excessive_altitude
+            || has_excessive_speed;
 
         if is_spurious {
             warn!(
-                "Detected spurious flight {}: duration={}s, altitude_range={:?}ft, max_agl={:?}ft. Deleting flight.",
-                flight_id, duration_seconds, altitude_range, max_agl_altitude
+                "Detected spurious flight {}: duration={}s, altitude_range={:?}ft, max_agl={:?}ft, excessive_altitude={}, avg_speed={:?}mph, excessive_speed={}. Deleting flight.",
+                flight_id,
+                duration_seconds,
+                altitude_range,
+                max_agl_altitude,
+                has_excessive_altitude,
+                average_speed_mph,
+                has_excessive_speed
             );
 
             // Clear flight_id from all associated fixes


### PR DESCRIPTION
Add two new validation checks to detect intentionally bad data:
- Check for average speed exceeding 1000 mph across the flight
- Check for any altitude readings above 100,000 feet

These checks help identify and automatically remove flights with physically impossible data that would otherwise corrupt the database.

The average speed is calculated using the haversine distance formula between consecutive fixes, then compared against a 1000 mph threshold. Any flight exceeding this speed or having altitude > 100k feet is marked as spurious and deleted.