### PR TITLE
refactor: migrate receivers to use PostGIS geography column and enfor…

### DIFF
--- a/migrations/2025-10-22-170948-0000_add_location_to_receivers_and_make_receiver_id_not_null/down.sql
+++ b/migrations/2025-10-22-170948-0000_add_location_to_receivers_and_make_receiver_id_not_null/down.sql
@@ -1,0 +1,18 @@
+-- Revert changes: restore location_id foreign key and make receiver_id nullable
+
+-- Step 1: Drop indexes we created
+DROP INDEX IF EXISTS idx_aprs_messages_receiver_id;
+DROP INDEX IF EXISTS idx_receivers_location;
+
+-- Step 2: Make receiver_id nullable again in aprs_messages
+ALTER TABLE aprs_messages ALTER COLUMN receiver_id DROP NOT NULL;
+
+-- Step 3: Add back location_id column to receivers
+ALTER TABLE receivers ADD COLUMN location_id UUID;
+
+-- Step 4: Add back the foreign key constraint
+ALTER TABLE receivers ADD CONSTRAINT receivers_location_id_fkey
+    FOREIGN KEY (location_id) REFERENCES locations(id);
+
+-- Step 5: Drop the location column from receivers
+ALTER TABLE receivers DROP COLUMN location;

--- a/migrations/2025-10-22-170948-0000_add_location_to_receivers_and_make_receiver_id_not_null/up.sql
+++ b/migrations/2025-10-22-170948-0000_add_location_to_receivers_and_make_receiver_id_not_null/up.sql
@@ -1,0 +1,36 @@
+-- Replace location_id foreign key with direct geography column in receivers
+-- Make receiver_id NOT NULL in aprs_messages
+
+-- Step 1: Add location geography column to receivers
+ALTER TABLE receivers ADD COLUMN location geography(Point, 4326);
+
+-- Step 2: Copy existing location data from locations table to receivers
+UPDATE receivers r
+SET location = (
+    SELECT ST_SetSRID(ST_MakePoint(
+        ST_X(l.geolocation::geometry),
+        ST_Y(l.geolocation::geometry)
+    ), 4326)::geography
+    FROM locations l
+    WHERE l.id = r.location_id
+    AND l.geolocation IS NOT NULL
+);
+
+-- Step 3: Drop the foreign key constraint
+ALTER TABLE receivers DROP CONSTRAINT IF EXISTS receivers_location_id_fkey;
+
+-- Step 4: Drop the location_id column
+ALTER TABLE receivers DROP COLUMN location_id;
+
+-- Step 5: Make receiver_id NOT NULL in aprs_messages
+-- First delete any orphaned messages
+DELETE FROM aprs_messages WHERE receiver_id IS NULL;
+
+-- Make it NOT NULL
+ALTER TABLE aprs_messages ALTER COLUMN receiver_id SET NOT NULL;
+
+-- Step 6: Create spatial index on receivers.location
+CREATE INDEX idx_receivers_location ON receivers USING GIST (location);
+
+-- Step 7: Create index on aprs_messages.receiver_id for faster lookups
+CREATE INDEX IF NOT EXISTS idx_aprs_messages_receiver_id ON aprs_messages (receiver_id);

--- a/src/aprs_messages_repo.rs
+++ b/src/aprs_messages_repo.rs
@@ -13,7 +13,7 @@ pub struct NewAprsMessage {
     pub id: Uuid,
     pub raw_message: String,
     pub received_at: DateTime<Utc>,
-    pub receiver_id: Option<Uuid>,
+    pub receiver_id: Uuid,
     pub unparsed: Option<String>,
 }
 

--- a/src/fix_processor.rs
+++ b/src/fix_processor.rs
@@ -196,8 +196,8 @@ impl FixProcessor {
                 None
             };
 
-            // Create and insert the APRS message
-            let aprs_message_id = {
+            // Create and insert the APRS message - receiver_id is now NOT NULL, so we skip if None
+            let aprs_message_id = if let Some(receiver_id) = receiver_id {
                 let new_aprs_message = NewAprsMessage {
                     id: Uuid::new_v4(),
                     raw_message: raw_message.clone(),
@@ -213,6 +213,11 @@ impl FixProcessor {
                         None
                     }
                 }
+            } else {
+                error!(
+                    "Cannot insert APRS message without receiver_id (receiver_id is now NOT NULL)"
+                );
+                None
             };
 
             // Try to create a fix from the packet

--- a/src/main.rs
+++ b/src/main.rs
@@ -478,9 +478,7 @@ async fn handle_run(
     );
 
     // Create receiver position processor for receiver position messages
-    let locations_repo = soar::locations_repo::LocationsRepository::new(diesel_pool.clone());
-    let receiver_position_processor =
-        ReceiverPositionProcessor::new(receiver_repo.clone(), locations_repo);
+    let receiver_position_processor = ReceiverPositionProcessor::new(receiver_repo.clone());
 
     // Create aircraft position processor
     // Note: FlightDetectionProcessor is now handled inside FixProcessor

--- a/src/packet_processors/receiver_status.rs
+++ b/src/packet_processors/receiver_status.rs
@@ -89,7 +89,7 @@ impl ReceiverStatusProcessor {
                             id: Uuid::new_v4(),
                             raw_message: raw_data.clone(),
                             received_at,
-                            receiver_id: Some(receiver_id),
+                            receiver_id,
                             unparsed,
                         };
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -179,7 +179,7 @@ diesel::table! {
         id -> Uuid,
         raw_message -> Text,
         received_at -> Timestamptz,
-        receiver_id -> Nullable<Uuid>,
+        receiver_id -> Uuid,
         unparsed -> Nullable<Text>,
     }
 }
@@ -398,6 +398,9 @@ diesel::table! {
 }
 
 diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::Geography;
+
     receivers (id) {
         callsign -> Text,
         description -> Nullable<Text>,
@@ -409,7 +412,7 @@ diesel::table! {
         id -> Uuid,
         latest_packet_at -> Nullable<Timestamptz>,
         from_ogn_db -> Bool,
-        location_id -> Nullable<Uuid>,
+        location -> Nullable<Geography>,
     }
 }
 
@@ -586,7 +589,6 @@ diesel::joinable!(flights -> clubs (club_id));
 diesel::joinable!(pilots -> clubs (club_id));
 diesel::joinable!(receiver_statuses -> aprs_messages (aprs_message_id));
 diesel::joinable!(receiver_statuses -> receivers (receiver_id));
-diesel::joinable!(receivers -> locations (location_id));
 diesel::joinable!(receivers_links -> receivers (receiver_id));
 diesel::joinable!(receivers_photos -> receivers (receiver_id));
 diesel::joinable!(users -> clubs (club_id));


### PR DESCRIPTION
…ce NOT NULL receiver_id

Replace location_id foreign key relationship with direct geography(Point, 4326) column in receivers table. Make aprs_messages.receiver_id NOT NULL to enforce data integrity.

Database changes:
- Add location geography(Point, 4326) column to receivers table
- Migrate existing location data from locations table via ST_MakePoint
- Drop location_id foreign key and column from receivers table
- Make aprs_messages.receiver_id NOT NULL (delete orphaned messages first)
- Add spatial GIST index on receivers.location for efficient queries
- Add index on aprs_messages.receiver_id for faster lookups

Code changes:
- Update receiver models to skip location field (Geography type not easily deserializable)
- Use raw SQL for receiver location updates via ST_MakePoint
- Remove LocationsRepository dependency from ReceiverPositionProcessor
- Update spatial queries to use receivers.location directly instead of joining with locations
- Change NewAprsMessage.receiver_id from Option<Uuid> to Uuid (NOT NULL)
- Handle receiver_id properly in fix_processor and receiver_status processor
- Skip APRS message insert when receiver_id is None (log error instead)

Benefits:
- Simplified schema: no more location_id foreign key indirection
- Better performance: direct geography queries without joins
- Data integrity: all APRS messages must have valid receiver
- Cleaner code: one less table to manage for receiver locations