### PR TITLE
fix: separate console output and tokio-console trace filtering

### DIFF
--- a/src/fix_processor.rs
+++ b/src/fix_processor.rs
@@ -257,8 +257,11 @@ impl FixProcessor {
                     {
                         Ok(device_model) => {
                             // Extract ICAO model code and ADS-B emitter category from packet for device update
-                            // TODO: ICAO model code is not currently in ogn_parser - extract from ADS-B data when available
-                            let icao_model_code: Option<String> = None;
+                            let icao_model_code: Option<String> = pos_packet
+                                .comment
+                                .model
+                                .as_ref()
+                                .map(|model| model.to_string());
                             let adsb_emitter_category = pos_packet
                                 .comment
                                 .adsb_emitter_category


### PR DESCRIPTION
Previously, setting RUST_LOG=warn,tokio=trace,runtime=trace would enable tokio-console task visibility but also flood the console output with tokio trace logs. Now, each layer has its own filter:

- fmt_layer (console output): Uses RUST_LOG env var, defaults to 'debug' in development and 'warn' in production
- console_layer (tokio-console): Always includes tokio=trace and runtime=trace for task visibility

This allows clean console output while tokio-console still sees all the task instrumentation it needs.

Also fixes ICAO model code extraction in fix_processor.rs to use .as_ref().map() instead of moving the Option value, and extracts the model field which is now available in ogn_parser.