### PR TITLE
feat: refine active state definition for fixes without altitude data

### DIFF
--- a/src/flight_tracker/state_transitions.rs
+++ b/src/flight_tracker/state_transitions.rs
@@ -31,7 +31,7 @@ async fn update_flight_timestamp(
 
 /// Determine if aircraft should be active based on fix data
 /// This checks ground speed first, then altitude (if available)
-fn should_be_active(fix: &Fix) -> bool {
+pub(crate) fn should_be_active(fix: &Fix) -> bool {
     // Special case: If no altitude data and speed < 80 knots, consider inactive
     // This handles cases where altitude data is missing but we can still infer ground state from speed
     if fix.altitude_agl.is_none() && fix.altitude_msl_feet.is_none() {


### PR DESCRIPTION
Add special handling for position fixes that lack altitude information. If a fix has no altitude data (both altitude_agl and altitude_msl_feet are None) and the ground speed is less than 80 knots, the aircraft is now considered inactive/on-ground.

This prevents spurious flight creation for aircraft that:
- Have missing or unreliable altitude data
- Are moving slowly on the ground (taxiing, towing, etc.)
- Would otherwise be incorrectly classified as airborne

Changes:
- Updated should_be_active() in state_transitions.rs
- Updated AircraftTracker::should_be_active() in aircraft_tracker.rs
- Both functions now check for missing altitude data first
- If no altitude AND speed < 80 knots → inactive (on ground)
- If no altitude AND speed >= 80 knots → active (assume airborne)
- Existing altitude-based logic remains unchanged

This improves flight detection accuracy for receivers with unreliable altitude reporting while maintaining correct behavior for aircraft with proper altitude data.