### PR TITLE
perf: add GDAL Dataset cache to eliminate repeated file opens

### DIFF
--- a/src/elevation.rs
+++ b/src/elevation.rs
@@ -17,6 +17,41 @@ fn round_coord_for_cache(coord: f64) -> i32 {
 /// Cache key for elevation lookups: (lat_millidegrees, lon_millidegrees)
 type CacheKey = (i32, i32);
 
+/// Cached GDAL Dataset with metadata
+/// Keeps the TIFF file open and parsed to avoid repeated Dataset::open() calls
+/// SAFETY: GDAL Dataset is not thread-safe, so we wrap it in a Mutex to ensure
+/// exclusive access during reads.
+struct CachedDataset {
+    dataset: Mutex<Dataset>,
+    geo_transform: [f64; 6],
+    raster_width: usize,
+    raster_height: usize,
+    no_data_value: Option<f64>,
+}
+
+impl CachedDataset {
+    fn new(dataset: Dataset) -> Result<Self> {
+        let band = dataset.rasterband(1)?;
+        let (raster_width, raster_height) = band.size();
+        let geo_transform = dataset.geo_transform()?;
+        let no_data_value = band.no_data_value();
+
+        Ok(Self {
+            dataset: Mutex::new(dataset),
+            geo_transform,
+            raster_width,
+            raster_height,
+            no_data_value,
+        })
+    }
+}
+
+// SAFETY: CachedDataset can be safely shared between threads because:
+// 1. The Dataset is protected by a Mutex ensuring exclusive access
+// 2. All other fields (geo_transform, dimensions, no_data_value) are immutable primitives
+unsafe impl Send for CachedDataset {}
+unsafe impl Sync for CachedDataset {}
+
 /// Database for elevation data using Copernicus DEM tiles
 #[derive(Clone)]
 pub struct ElevationDB {
@@ -26,6 +61,9 @@ pub struct ElevationDB {
     /// LRU cache for elevation results: (rounded_lat, rounded_lon) -> elevation_meters
     /// 500,000 entries ≈ 28MB of memory, provides excellent hit rate for multi-aircraft operations
     elevation_cache: Arc<Mutex<LruCache<CacheKey, Option<f64>>>>,
+    /// LRU cache for open GDAL Datasets: tile_path -> CachedDataset
+    /// 100 entries ≈ 1-2GB memory (10-20MB per TIFF), eliminates repeated Dataset::open() calls
+    dataset_cache: Arc<Mutex<LruCache<PathBuf, Arc<CachedDataset>>>>,
 }
 
 impl ElevationDB {
@@ -54,6 +92,7 @@ impl ElevationDB {
             elevation_cache: Arc::new(Mutex::new(LruCache::new(
                 NonZeroUsize::new(500_000).unwrap(),
             ))),
+            dataset_cache: Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(100).unwrap()))),
         })
     }
 
@@ -71,6 +110,7 @@ impl ElevationDB {
             elevation_cache: Arc::new(Mutex::new(LruCache::new(
                 NonZeroUsize::new(500_000).unwrap(),
             ))),
+            dataset_cache: Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(100).unwrap()))),
         })
     }
 
@@ -91,7 +131,7 @@ impl ElevationDB {
         // Create cache key by rounding coordinates to ~100m grid
         let cache_key = (round_coord_for_cache(lat), round_coord_for_cache(lon));
 
-        // Check cache first
+        // Check elevation cache first (fastest path)
         {
             let mut cache = self.elevation_cache.lock().await;
             if let Some(cached_elevation) = cache.get(&cache_key) {
@@ -110,7 +150,7 @@ impl ElevationDB {
             }
         }
 
-        // Cache miss - perform actual lookup
+        // Elevation cache miss - need to look up from GDAL dataset
         counter!("elevation_cache_misses").increment(1);
 
         // Try GLO-30 first, automatically fall back to GLO-90 if unavailable
@@ -119,22 +159,52 @@ impl ElevationDB {
             .ensure_cached_with_fallback(lat, lon)
             .await?;
 
-        // Perform GDAL operations in a scope to ensure they complete before any await
-        let elevation = {
-            let ds = Dataset::open(&path)?;
-            let band = ds.rasterband(1)?;
-            let (raster_width, raster_height) = band.size();
+        // Check if we have this dataset cached, or load it
+        let dataset_open_start = Instant::now();
+        let cached_ds = {
+            let mut ds_cache = self.dataset_cache.lock().await;
 
-            // GeoTransform: [origin_x, pixel_w, 0, origin_y, 0, pixel_h(negative)]
-            let gt = ds.geo_transform()?;
+            if let Some(cached) = ds_cache.get(&path) {
+                counter!("elevation_dataset_cache_hits").increment(1);
+                cached.clone()
+            } else {
+                // Dataset cache miss - need to open the file
+                counter!("elevation_dataset_cache_misses").increment(1);
+
+                let ds = Dataset::open(&path)?;
+                let cached = Arc::new(CachedDataset::new(ds)?);
+                ds_cache.put(path.clone(), cached.clone());
+
+                // Record dataset open time
+                histogram!("elevation_dataset_open_duration_seconds")
+                    .record(dataset_open_start.elapsed().as_secs_f64());
+
+                // Update dataset cache size metric
+                gauge!("elevation_dataset_cache_size").set(ds_cache.len() as f64);
+
+                cached
+            }
+        }; // Release dataset cache lock
+
+        // Perform GDAL read operation using the cached dataset
+        let gdal_read_start = Instant::now();
+        let elevation = {
+            let gt = &cached_ds.geo_transform;
             let px = (lon - gt[0]) / gt[1];
             let py = (lat - gt[3]) / gt[5]; // gt[5] is negative, so this works
 
             // Clamp pixel coordinates to ensure we can read a 2x2 window for bilinear interpolation
             // For a raster of size (width, height), valid starting positions for a 2x2 window
             // are (0 to width-2, 0 to height-2) to avoid reading out of bounds
-            let px_clamped = px.floor().max(0.0).min((raster_width - 2) as f64) as isize;
-            let py_clamped = py.floor().max(0.0).min((raster_height - 2) as f64) as isize;
+            let px_clamped = px.floor().max(0.0).min((cached_ds.raster_width - 2) as f64) as isize;
+            let py_clamped = py
+                .floor()
+                .max(0.0)
+                .min((cached_ds.raster_height - 2) as f64) as isize;
+
+            // Lock the dataset for reading (GDAL is not thread-safe)
+            let dataset = cached_ds.dataset.lock().await;
+            let band = dataset.rasterband(1)?;
 
             // Bilinear resample from a 2x2 window into a single value
             let out = band.read_as::<f64>(
@@ -145,16 +215,20 @@ impl ElevationDB {
             )?;
 
             // Handle NoData (Copernicus uses -32767 for nodata)
-            if let Some(nd) = band.no_data_value()
+            if let Some(nd) = cached_ds.no_data_value
                 && out[(0, 0)] == nd
             {
                 None
             } else {
                 Some(out[(0, 0)])
             }
-        }; // GDAL objects (ds, band) dropped here before any await
+        };
 
-        // Store in cache
+        // Record GDAL read time
+        histogram!("elevation_gdal_read_duration_seconds")
+            .record(gdal_read_start.elapsed().as_secs_f64());
+
+        // Store in elevation cache for future lookups
         {
             let mut cache = self.elevation_cache.lock().await;
             cache.put(cache_key, elevation);
@@ -164,7 +238,7 @@ impl ElevationDB {
             gauge!("elevation_cache_size_mb").set(size_mb);
         }
 
-        // Record metric for elevation lookup duration
+        // Record total elevation lookup duration
         histogram!("elevation_lookup_duration_seconds").record(start.elapsed().as_secs_f64());
 
         Ok(elevation)


### PR DESCRIPTION
Add LRU cache for open GDAL Datasets to dramatically reduce CPU time spent in elevation lookups. Previously, every elevation cache miss would call Dataset::open() and re-parse the entire TIFF file.

Changes:
- Add CachedDataset struct wrapping Dataset with metadata
- Add dataset_cache: LRU cache of 100 open Datasets (~1-2GB memory)
- Wrap Dataset in Mutex for thread-safety (GDAL is not thread-safe)
- Implement Send+Sync for CachedDataset with unsafe blocks
- Reuse open Datasets when available instead of re-opening files
- Add new metrics:
  - elevation_dataset_cache_hits/misses
  - elevation_dataset_open_duration_seconds
  - elevation_gdal_read_duration_seconds
  - elevation_dataset_cache_size

Performance impact:
- Eliminates Dataset::open() call (file I/O + TIFF header parsing)
- Eliminates repeated TIFFReadEncodedTile operations
- Expected 50-80% reduction in CPU time for elevation cache misses
- Trades ~1-2GB memory for massive CPU savings

SAFETY: The unsafe Send+Sync implementation is safe because:
1. Dataset is protected by Mutex ensuring exclusive access
2. All other fields are immutable Copy types
3. No concurrent access to GDAL objects is possible