### PR TITLE
feat: configure GDAL with larger cache settings for elevation database

### DIFF
--- a/src/elevation.rs
+++ b/src/elevation.rs
@@ -69,6 +69,10 @@ pub struct ElevationDB {
 impl ElevationDB {
     /// Create a new ElevationDB using ELEVATION_DATA_PATH env var or default cache directory
     pub fn new() -> Result<Self> {
+        // Configure GDAL with larger cache settings before opening any datasets
+        gdal::config::set_config_option("GDAL_MAX_DATASET_POOL_SIZE", "512")?;
+        gdal::config::set_config_option("GDAL_CACHEMAX", "512")?; // MB
+
         let storage_path = match env::var("ELEVATION_DATA_PATH") {
             Ok(path) => PathBuf::from(path),
             Err(_) => {
@@ -98,6 +102,10 @@ impl ElevationDB {
 
     /// Create a new ElevationDB with an explicit storage path
     pub fn with_path(storage_path: PathBuf) -> Result<Self> {
+        // Configure GDAL with larger cache settings before opening any datasets
+        gdal::config::set_config_option("GDAL_MAX_DATASET_POOL_SIZE", "512")?;
+        gdal::config::set_config_option("GDAL_CACHEMAX", "512")?; // MB
+
         std::fs::create_dir_all(&storage_path).with_context(|| {
             format!(
                 "Failed to create elevation storage directory: {:?}",


### PR DESCRIPTION
Configure GDAL_MAX_DATASET_POOL_SIZE to 512 and GDAL_CACHEMAX to 512 MB before opening any datasets in ElevationDB. This improves performance by allowing GDAL to keep more datasets in its internal pool and use more memory for raster caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)