### PR TITLE
feat: redesign front page with 6-column grid layout

### DIFF
--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -23,27 +23,14 @@
 <!-- Video Overlay for Text Legibility -->
 <div class="fixed top-0 left-0 z-[-1] h-full w-full bg-black/40"></div>
 
-<div class="relative z-10 flex min-h-screen flex-col justify-center space-y-12">
-	<!-- Hero Section -->
-	<section class="space-y-8 text-center">
-		<!-- Hero Content -->
-		<div class="space-y-6">
-			<h1 class="text-4xl font-bold text-white drop-shadow-lg md:text-6xl">
-				Welcome to Glider.flights
-			</h1>
-			<p class="mx-auto max-w-3xl text-xl text-white/90 drop-shadow-lg md:text-2xl">
-				Discover soaring clubs, track glider operations, and connect with the soaring community
-			</p>
-		</div>
-	</section>
-
+<div class="relative z-10 flex min-h-screen flex-col">
 	<!-- Main Navigation -->
-	<section class="mx-auto max-w-6xl">
-		<div class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+	<section class="flex-1">
+		<div class="grid h-full grid-cols-1 gap-0 md:grid-cols-3 md:grid-rows-2">
 			<!-- Clubs Button -->
 			<a
 				href={clubsPath}
-				class="group block rounded-lg border border-white/30 bg-white/20 p-8 backdrop-blur-md transition-all duration-200 hover:scale-105 hover:bg-white/30 hover:shadow-xl"
+				class="group flex items-center justify-center border border-white/30 bg-white/20 p-8 backdrop-blur-md transition-all duration-200 hover:bg-white/30 hover:shadow-xl"
 			>
 				<div class="space-y-6 text-center">
 					<div class="flex justify-center">
@@ -62,7 +49,7 @@
 			<!-- Operations Button -->
 			<a
 				href={operationsPath}
-				class="group block rounded-lg border border-white/30 bg-white/20 p-8 backdrop-blur-md transition-all duration-200 hover:scale-105 hover:bg-white/30 hover:shadow-xl"
+				class="group flex items-center justify-center border border-white/30 bg-white/20 p-8 backdrop-blur-md transition-all duration-200 hover:bg-white/30 hover:shadow-xl"
 			>
 				<div class="space-y-6 text-center">
 					<div class="flex justify-center">
@@ -81,7 +68,7 @@
 			<!-- Aircraft Button -->
 			<a
 				href={devicesPath}
-				class="group block rounded-lg border border-white/30 bg-white/20 p-8 backdrop-blur-md transition-all duration-200 hover:scale-105 hover:bg-white/30 hover:shadow-xl"
+				class="group flex items-center justify-center border border-white/30 bg-white/20 p-8 backdrop-blur-md transition-all duration-200 hover:bg-white/30 hover:shadow-xl"
 			>
 				<div class="space-y-6 text-center">
 					<div class="flex justify-center">
@@ -100,7 +87,7 @@
 			<!-- Receivers Button -->
 			<a
 				href={receiversPath}
-				class="group block rounded-lg border border-white/30 bg-white/20 p-8 backdrop-blur-md transition-all duration-200 hover:scale-105 hover:bg-white/30 hover:shadow-xl"
+				class="group flex items-center justify-center border border-white/30 bg-white/20 p-8 backdrop-blur-md transition-all duration-200 hover:bg-white/30 hover:shadow-xl"
 			>
 				<div class="space-y-6 text-center">
 					<div class="flex justify-center">
@@ -119,7 +106,7 @@
 			<!-- Airports Button -->
 			<a
 				href={airportsPath}
-				class="group block rounded-lg border border-white/30 bg-white/20 p-8 backdrop-blur-md transition-all duration-200 hover:scale-105 hover:bg-white/30 hover:shadow-xl"
+				class="group flex items-center justify-center border border-white/30 bg-white/20 p-8 backdrop-blur-md transition-all duration-200 hover:bg-white/30 hover:shadow-xl"
 			>
 				<div class="space-y-6 text-center">
 					<div class="flex justify-center">
@@ -138,7 +125,7 @@
 			<!-- Flights Button -->
 			<a
 				href={flightsPath}
-				class="group block rounded-lg border border-white/30 bg-white/20 p-8 backdrop-blur-md transition-all duration-200 hover:scale-105 hover:bg-white/30 hover:shadow-xl"
+				class="group flex items-center justify-center border border-white/30 bg-white/20 p-8 backdrop-blur-md transition-all duration-200 hover:bg-white/30 hover:shadow-xl"
 			>
 				<div class="space-y-6 text-center">
 					<div class="flex justify-center">


### PR DESCRIPTION
- Remove welcome heading and tagline text
- Implement 3x2 grid layout for navigation tiles on desktop
- Center navigation tiles within each grid cell
- Remove rounded corners and gaps between tiles for seamless grid
- Remove scale-on-hover effect for cleaner interaction
- Maintain responsive design for mobile (single column)