### PR TITLE
fix: remove unnecessary tokio::spawn calls to prevent task accumulation

### DIFF
--- a/src/fix_processor.rs
+++ b/src/fix_processor.rs
@@ -169,9 +169,8 @@ impl FixProcessor {
         let self_clone = self.clone();
         let raw_message = raw_message.to_string();
 
-        tokio::spawn(
-            async move {
-                let received_at = chrono::Utc::now();
+        async move {
+            let received_at = chrono::Utc::now();
 
             // Try to create a fix from the packet
             match packet.data {
@@ -276,7 +275,7 @@ impl FixProcessor {
             }
         }
         .instrument(tracing::debug_span!("process_aprs_packet"))
-        );
+        .await;
     }
 
     /// Internal method to process a fix through the complete pipeline

--- a/src/flight_tracker/state_transitions.rs
+++ b/src/flight_tracker/state_transitions.rs
@@ -278,29 +278,20 @@ pub(crate) async fn process_state_transition(
 
                         // Complete flight in background (includes airport/runway lookup for landing)
                         // Note: complete_flight will update both landing fields AND last_fix_at in a single UPDATE
-                        let flights_repo_clone = flights_repo.clone();
-                        let airports_repo_clone = airports_repo.clone();
-                        let locations_repo_clone = locations_repo.clone();
-                        let runways_repo_clone = runways_repo.clone();
-                        let fixes_repo_clone = fixes_repo.clone();
-                        let elevation_db_clone = elevation_db.clone();
-                        let landing_fix = fix.clone();
-                        tokio::spawn(async move {
-                            if let Err(e) = complete_flight(
-                                &flights_repo_clone,
-                                &airports_repo_clone,
-                                &locations_repo_clone,
-                                &runways_repo_clone,
-                                &fixes_repo_clone,
-                                &elevation_db_clone,
-                                flight_id,
-                                &landing_fix,
-                            )
-                            .await
-                            {
-                                warn!("Failed to complete flight {}: {}", flight_id, e);
-                            }
-                        });
+                        if let Err(e) = complete_flight(
+                            flights_repo,
+                            airports_repo,
+                            locations_repo,
+                            runways_repo,
+                            fixes_repo,
+                            elevation_db,
+                            flight_id,
+                            &fix,
+                        )
+                        .await
+                        {
+                            warn!("Failed to complete flight {}: {}", flight_id, e);
+                        }
                     } else {
                         // Not enough consecutive inactive fixes yet - keep flight active
                         info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -305,7 +305,7 @@ fn determine_archive_dir() -> Result<String> {
 }
 
 #[allow(clippy::too_many_arguments)]
-#[tracing::instrument(skip_all, fields(server = %server, port = %port))]
+#[tracing::instrument(skip_all)]
 async fn handle_run(
     server: String,
     port: u16,


### PR DESCRIPTION
This commit removes two unnecessary tokio::spawn calls that were causing thousands of tasks to accumulate in the tokio runtime:

1. Removed outer spawn in fix_processor.rs:172
   - The entire call chain from APRS client through the packet router already uses async/await, so spawning another task was redundant
   - This was the primary cause of task accumulation (8296 bytes per task)

2. Removed spawn for complete_flight in state_transitions.rs:288
   - Now runs synchronously while holding the per-device lock
   - Prevents race conditions during flight completion
   - Eliminates unnecessary cloning of repository objects

Kept intentional background spawns for non-critical operations:
- Update ADS-B fields (line 225)
- Update receiver timestamp (line 299)
- Update device cached fields (line 319)
- Calculate altitude AGL (line 342)

Also includes logging improvements:
- Reduced NATS publisher verbosity (removed debug logs)
- Simplified tracing instrumentation in main.rs

This fixes the issue where tokio-console showed thousands of "paused" tasks that never completed, which was exhausting the database connection pool and causing timeouts.