### PR TITLE
feat: link devices to clubs and aircraft during pull-data

### DIFF
--- a/src/loader/device_linking.rs
+++ b/src/loader/device_linking.rs
@@ -1,0 +1,110 @@
+use anyhow::Result;
+use diesel::prelude::*;
+use diesel::r2d2::ConnectionManager;
+use r2d2::Pool;
+use std::time::Instant;
+use tracing::info;
+
+use crate::email_reporter::EntityMetrics;
+
+type PgPool = Pool<ConnectionManager<PgConnection>>;
+
+/// Link aircraft_registrations.device_id by matching registration numbers
+/// This should be called after both devices and aircraft_registrations are loaded
+pub async fn link_aircraft_to_devices_with_metrics(pool: PgPool) -> EntityMetrics {
+    let start = Instant::now();
+    let mut metrics = EntityMetrics::new("Link Aircraft to Devices");
+
+    info!("Linking aircraft registrations to devices by registration number...");
+
+    match link_aircraft_to_devices(&pool).await {
+        Ok(count) => {
+            info!("Successfully linked {} aircraft to devices", count);
+            metrics.records_loaded = count;
+            metrics.records_in_db = Some(count as i64);
+            metrics.success = true;
+        }
+        Err(e) => {
+            metrics.success = false;
+            metrics.error_message = Some(e.to_string());
+        }
+    }
+
+    metrics.duration_secs = start.elapsed().as_secs_f64();
+    metrics
+}
+
+/// Link devices.club_id from linked aircraft_registrations
+/// This should be called after aircraft have been linked to devices
+pub async fn link_devices_to_clubs_with_metrics(pool: PgPool) -> EntityMetrics {
+    let start = Instant::now();
+    let mut metrics = EntityMetrics::new("Link Devices to Clubs");
+
+    info!("Linking devices to clubs from aircraft registrations...");
+
+    match link_devices_to_clubs(&pool).await {
+        Ok(count) => {
+            info!("Successfully linked {} devices to clubs", count);
+            metrics.records_loaded = count;
+            metrics.records_in_db = Some(count as i64);
+            metrics.success = true;
+        }
+        Err(e) => {
+            metrics.success = false;
+            metrics.error_message = Some(e.to_string());
+        }
+    }
+
+    metrics.duration_secs = start.elapsed().as_secs_f64();
+    metrics
+}
+
+/// Link aircraft_registrations.device_id by matching with devices.registration
+async fn link_aircraft_to_devices(pool: &PgPool) -> Result<usize> {
+    let pool = pool.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let mut conn = pool.get()?;
+
+        // Update aircraft_registrations.device_id by matching registration numbers
+        let count = diesel::sql_query(
+            r#"
+            UPDATE aircraft_registrations
+            SET device_id = devices.id
+            FROM devices
+            WHERE aircraft_registrations.registration_number = devices.registration
+              AND aircraft_registrations.device_id IS NULL
+              AND devices.registration != ''
+            "#,
+        )
+        .execute(&mut conn)?;
+
+        Ok(count)
+    })
+    .await?
+}
+
+/// Link devices.club_id from linked aircraft_registrations
+async fn link_devices_to_clubs(pool: &PgPool) -> Result<usize> {
+    let pool = pool.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let mut conn = pool.get()?;
+
+        // Update devices.club_id from linked aircraft_registrations
+        let count = diesel::sql_query(
+            r#"
+            UPDATE devices
+            SET club_id = aircraft_registrations.club_id
+            FROM aircraft_registrations
+            WHERE devices.id = aircraft_registrations.device_id
+              AND aircraft_registrations.club_id IS NOT NULL
+              AND devices.club_id IS NULL
+            "#,
+        )
+        .execute(&mut conn)?;
+
+        Ok(count)
+    })
+    .await?
+}


### PR DESCRIPTION
Add device linking logic to the pull-data process that runs after both devices and aircraft_registrations are loaded:

1. Link aircraft_registrations.device_id by matching registration numbers
   - Matches aircraft_registrations.registration_number with devices.registration
   - Only updates records where device_id is NULL and registration is not empty

2. Link devices.club_id from linked aircraft_registrations
   - Propagates club_id from aircraft to their linked devices
   - Only updates devices where club_id is NULL

This approach ensures linking happens automatically during data import rather than requiring a one-time migration. The linking will run every time pull-data is executed, keeping the relationships up to date.

Created new module: src/loader/device_linking.rs
Updated: src/loader/mod.rs to call linking functions after devices load

🤖 Generated with [Claude Code](https://claude.com/claude-code)