### PR TITLE
fix: prevent race condition between spurious flight deletion and fix …

### DIFF
--- a/src/flight_tracker/mod.rs
+++ b/src/flight_tracker/mod.rs
@@ -333,8 +333,13 @@ impl FlightTracker {
             }
             Err(e) => {
                 error!(
-                    "Failed to save fix to database for fix: {:?}\ncause:{:?}",
-                    updated_fix, e
+                    "Failed to save fix: device={}, flight_id={:?}, speed={:?}kts, alt_msl={:?}ft, aircraft_type={:?}, error={}",
+                    updated_fix.device_id,
+                    updated_fix.flight_id,
+                    updated_fix.ground_speed_knots,
+                    updated_fix.altitude_msl_feet,
+                    updated_fix.aircraft_type_ogn,
+                    e
                 );
                 None
             }


### PR DESCRIPTION
…assignment

The race condition occurred when:
1. A flight was detected as spurious and deleted in complete_flight()
2. The flight remained in active_flights map during deletion
3. New fixes arriving would see the flight in active_flights
4. These fixes would get assigned the deleted flight_id
5. Database insertion would fail with foreign key constraint error

The fix:
- Remove flight from active_flights BEFORE deleting it from database
- This prevents new fixes from being assigned the about-to-be-deleted flight_id
- Added clear comments explaining the critical ordering

Also improved logging:
- Spurious flight warnings now list specific reasons for classification
- Fix insertion errors now show concise debugging info (device_id, flight_id, speed, altitude, aircraft_type) instead of dumping entire Fix struct