### PR TITLE
fix: correct compass and direction arrow behavior on mobile devices

### DIFF
--- a/web/src/lib/components/AircraftStatusModal.svelte
+++ b/web/src/lib/components/AircraftStatusModal.svelte
@@ -176,7 +176,7 @@
 			return;
 		}
 
-		// Calculate bearing from user to aircraft
+		// Calculate bearing from user to aircraft (absolute bearing from north)
 		const bearing = calculateBearing(
 			userLocation.lat,
 			userLocation.lng,
@@ -184,11 +184,11 @@
 			latestFix.longitude
 		);
 
-		// The arrow should point toward the aircraft
-		// Subtract device heading to compensate for phone rotation
-		// When phone points north (deviceHeading = 0), arrow rotation = bearing
-		// When phone rotates, arrow counter-rotates to keep pointing at aircraft
-		directionToAircraft = (bearing - deviceHeading + 360) % 360;
+		// The arrow should point toward the aircraft and stay pointing there as phone rotates
+		// Add device heading to rotate arrow opposite to phone rotation
+		// When phone points north (deviceHeading = 0), arrow shows absolute bearing
+		// When phone rotates clockwise, arrow rotates counter-clockwise to keep pointing at aircraft
+		directionToAircraft = (bearing + deviceHeading) % 360;
 	}
 
 	// Handle device orientation changes

--- a/web/src/routes/operations/+page.svelte
+++ b/web/src/routes/operations/+page.svelte
@@ -796,17 +796,19 @@
 	function handleOrientationChange(event: DeviceOrientationEvent): void {
 		if (event.alpha !== null) {
 			isCompassActive = true;
-			// Normalize the heading to ensure it's always between 0 and 360
+			// Store the raw device heading
 			deviceHeading = event.alpha;
 			displayHeading = Math.round(deviceHeading);
 
-			// Calculate the new compass heading (inverted to keep north arrow pointing north)
-			let newHeading = -deviceHeading;
+			// Use deviceHeading directly (not inverted) to keep north arrow pointing north
+			// When phone rotates clockwise (alpha increases), we rotate compass counter-clockwise
+			// by using the heading value directly in the CSS transform
+			let newHeading = deviceHeading;
 
 			// Normalize to 0-360 range
 			newHeading = ((newHeading % 360) + 360) % 360;
 
-			// Calculate the shortest rotation path
+			// Calculate the shortest rotation path to avoid spinning around unnecessarily
 			// If the difference is greater than 180°, we should wrap around
 			let delta = newHeading - previousCompassHeading;
 


### PR DESCRIPTION
Fixed two critical compass orientation issues on Android devices:

1. **Operations page compass rose**: Changed from inverting the device heading (which caused the compass to rotate WITH the phone) to using the heading directly. Now when the phone rotates clockwise, the compass rose rotates counter-clockwise, keeping the north arrow pointing north.

2. **Aircraft status modal direction arrow**: Changed from subtracting device heading to adding it. This ensures the arrow continues to point toward the aircraft as the phone rotates. When the phone rotates clockwise, the arrow rotates counter-clockwise to maintain its direction toward the target aircraft.

The root cause was the inversion logic being backwards - we were rotating the UI elements in the same direction as the phone rotation instead of opposite to it.

Generated with [Claude Code](https://claude.com/claude-code)