### PR TITLE
feat: increase elevation workers from 4 to 8 with shared cache

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -547,7 +547,8 @@ async fn handle_run(
     // Spawn multiple dedicated elevation processing workers
     // These workers handle AGL calculations separately to prevent them from blocking main processing
     // Using multiple workers allows parallel elevation lookups, which can be I/O intensive
-    let num_elevation_workers = 4;
+    // The ElevationDB uses Arc<Mutex<LruCache>> internally, so all workers share the same cache
+    let num_elevation_workers = 8;
     let elevation_db = flight_tracker.elevation_db().clone();
 
     // Wrap elevation receiver in Arc<Mutex> to share among elevation workers
@@ -593,7 +594,7 @@ async fn handle_run(
     }
 
     info!(
-        "Spawned {} dedicated elevation processing workers",
+        "Spawned {} dedicated elevation processing workers (sharing elevation and dataset caches)",
         num_elevation_workers
     );
 


### PR DESCRIPTION
Doubled the number of elevation processing workers from 4 to 8 to handle increased throughput during high-traffic periods. All workers share the same elevation and dataset caches via Arc<Mutex<LruCache>>, ensuring efficient memory usage and high cache hit rates.

Key implementation details:
- ElevationDB uses Arc internally for both elevation_cache and dataset_cache (500K elevation entries, 100 dataset entries)
- When cloning elevation_db, Arc pointers are cloned (not data), so all 8 workers share the same underlying caches
- This prevents cache thrashing and reduces memory overhead
- Cache sharing is thread-safe via Mutex protection

The increased parallelism allows better utilization of I/O resources for elevation tile lookups without sacrificing cache efficiency.

Generated with [Claude Code](https://claude.com/claude-code)