### PR TITLE
feat: implement AGL altitude backfill system with metrics

### DIFF
--- a/infrastructure/grafana-dashboard.json
+++ b/infrastructure/grafana-dashboard.json
@@ -97,7 +97,11 @@
       "id": 2,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -186,7 +190,11 @@
       "id": 3,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -271,7 +279,9 @@
         "orientation": "auto",
         "reduceOptions": {
           "values": false,
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "textMode": "auto"
@@ -339,7 +349,9 @@
         "orientation": "auto",
         "reduceOptions": {
           "values": false,
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "textMode": "auto"
@@ -407,7 +419,9 @@
         "orientation": "auto",
         "reduceOptions": {
           "values": false,
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "textMode": "auto"
@@ -492,7 +506,11 @@
       "id": 8,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -603,7 +621,11 @@
       "id": 9,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -703,7 +725,11 @@
       "id": 10,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -816,7 +842,11 @@
       "id": 101,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -938,7 +968,11 @@
       "id": 102,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1027,7 +1061,11 @@
       "id": 103,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1140,7 +1178,11 @@
       "id": 201,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1251,7 +1293,11 @@
       "id": 202,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1353,7 +1399,11 @@
       "id": 301,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1464,7 +1514,11 @@
       "id": 302,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1575,7 +1629,11 @@
       "id": 303,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1677,7 +1735,11 @@
       "id": 401,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1759,7 +1821,9 @@
         "orientation": "auto",
         "reduceOptions": {
           "values": false,
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "showThresholdLabels": false,
@@ -1828,7 +1892,9 @@
         "orientation": "auto",
         "reduceOptions": {
           "values": false,
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "textMode": "auto"
@@ -1913,7 +1979,11 @@
       "id": 404,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -1998,7 +2068,9 @@
         "orientation": "auto",
         "reduceOptions": {
           "values": false,
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "textMode": "auto"
@@ -2083,7 +2155,11 @@
       "id": 406,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -2207,7 +2283,11 @@
       "id": 501,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -2290,7 +2370,9 @@
         "orientation": "auto",
         "reduceOptions": {
           "values": false,
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "textMode": "auto"
@@ -2375,7 +2457,11 @@
       "id": 503,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -2460,7 +2546,9 @@
         "orientation": "auto",
         "reduceOptions": {
           "values": false,
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "textMode": "auto"
@@ -2528,7 +2616,9 @@
         "orientation": "auto",
         "reduceOptions": {
           "values": false,
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": ""
         },
         "textMode": "auto"
@@ -2613,7 +2703,11 @@
       "id": 602,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -2702,7 +2796,11 @@
       "id": 603,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -2815,7 +2913,11 @@
       "id": 701,
       "options": {
         "legend": {
-          "calcs": ["mean", "lastNotNull", "max"],
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -2840,11 +2942,446 @@
       ],
       "title": "Receiver Status Updates",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 138
+      },
+      "id": 400,
+      "panels": [],
+      "title": "SOAR Run - AGL Backfill",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 139
+      },
+      "id": 401,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "agl_backfill_altitudes_per_minute",
+          "legendFormat": "Altitudes/min",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "AGL Backfill - Altitudes Computed per Minute",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 139
+      },
+      "id": 402,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "agl_backfill_pending_fixes",
+          "legendFormat": "Pending Fixes",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "AGL Backfill - Pending Fixes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 147
+      },
+      "id": 403,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(agl_backfill_fixes_processed_total[5m]) * 60",
+          "legendFormat": "Fixes Processed/min",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(agl_backfill_altitudes_computed_total[5m]) * 60",
+          "legendFormat": "Altitudes Computed/min",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(agl_backfill_no_elevation_data_total[5m]) * 60",
+          "legendFormat": "No Elevation Data/min",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "AGL Backfill - Processing Breakdown",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Errors/min"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 147
+      },
+      "id": 404,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, rate(agl_backfill_batch_duration_seconds_bucket[5m]))",
+          "legendFormat": "P95 Batch Duration",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(agl_backfill_errors_total[5m]) * 60",
+          "legendFormat": "Errors/min",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "AGL Backfill - Batch Duration & Errors",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",
   "schemaVersion": 38,
-  "tags": ["soar", "monitoring", "performance"],
+  "tags": [
+    "soar",
+    "monitoring",
+    "performance"
+  ],
   "templating": {
     "list": [
       {

--- a/migrations/2025-10-27-024849-0000_drop_unparsed_data_rename_altitude_agl_add_valid/down.sql
+++ b/migrations/2025-10-27-024849-0000_drop_unparsed_data_rename_altitude_agl_add_valid/down.sql
@@ -1,0 +1,15 @@
+-- Remove the altitude_agl_valid indexes
+DROP INDEX IF EXISTS idx_fixes_altitude_agl_valid;
+DROP INDEX IF EXISTS idx_fixes_altitude_agl_feet;
+
+-- Re-create the old index name
+CREATE INDEX IF NOT EXISTS idx_fixes_altitude_agl ON fixes(altitude_agl_feet);
+
+-- Drop altitude_agl_valid column
+ALTER TABLE fixes DROP COLUMN IF EXISTS altitude_agl_valid;
+
+-- Rename altitude_agl_feet back to altitude_agl
+ALTER TABLE fixes RENAME COLUMN altitude_agl_feet TO altitude_agl;
+
+-- Re-add unparsed_data column (will be empty)
+ALTER TABLE fixes ADD COLUMN IF NOT EXISTS unparsed_data VARCHAR;

--- a/migrations/2025-10-27-024849-0000_drop_unparsed_data_rename_altitude_agl_add_valid/up.sql
+++ b/migrations/2025-10-27-024849-0000_drop_unparsed_data_rename_altitude_agl_add_valid/up.sql
@@ -1,0 +1,23 @@
+-- Drop unparsed_data column from fixes table (it's already in aprs_messages)
+ALTER TABLE fixes DROP COLUMN IF EXISTS unparsed_data;
+
+-- Rename altitude_agl to altitude_agl_feet for consistency
+ALTER TABLE fixes RENAME COLUMN altitude_agl TO altitude_agl_feet;
+
+-- Add altitude_agl_valid boolean column
+-- Set to true if altitude_agl_feet is not null (meaning it was already calculated)
+-- Default to false for new rows
+ALTER TABLE fixes
+ADD COLUMN altitude_agl_valid BOOLEAN NOT NULL DEFAULT false;
+
+-- Set altitude_agl_valid to true for all existing rows where altitude_agl_feet is not null
+UPDATE fixes
+SET altitude_agl_valid = true
+WHERE altitude_agl_feet IS NOT NULL;
+
+-- Update the index name to match the new column name
+DROP INDEX IF EXISTS idx_fixes_altitude_agl;
+CREATE INDEX IF NOT EXISTS idx_fixes_altitude_agl_feet ON fixes(altitude_agl_feet);
+
+-- Add index for querying by altitude_agl_valid
+CREATE INDEX IF NOT EXISTS idx_fixes_altitude_agl_valid ON fixes(altitude_agl_valid) WHERE altitude_agl_valid = false;

--- a/src/actions/flights.rs
+++ b/src/actions/flights.rs
@@ -329,7 +329,7 @@ pub async fn search_flights(
                                 .get_latest_fix_for_device(device_id, start_time)
                                 .await
                             {
-                                Ok(Some(fix)) => (fix.altitude_msl_feet, fix.altitude_agl),
+                                Ok(Some(fix)) => (fix.altitude_msl_feet, fix.altitude_agl_feet),
                                 _ => (None, None),
                             }
                         } else {

--- a/src/agl_backfill.rs
+++ b/src/agl_backfill.rs
@@ -1,0 +1,139 @@
+use anyhow::Result;
+use chrono::{DateTime, Duration, Utc};
+use metrics::{counter, gauge, histogram};
+use tokio::time::sleep;
+use tracing::{debug, info, warn};
+
+use crate::Fix;
+use crate::elevation::ElevationDB;
+use crate::fixes_repo::FixesRepository;
+use crate::flight_tracker::altitude::calculate_altitude_agl;
+
+/// Background task that backfills AGL altitudes for old fixes that were missed
+/// due to elevation processor queue overflow or system restarts
+pub async fn agl_backfill_task(fixes_repo: FixesRepository, elevation_db: ElevationDB) {
+    info!("Starting AGL backfill background task");
+
+    loop {
+        // Find fixes that are:
+        // 1. At least one hour old
+        // 2. Have altitude_msl_feet (can calculate AGL)
+        // 3. Don't have altitude_agl_valid = true (haven't been looked up yet)
+        // 4. is_active = true (only backfill active aircraft)
+        let one_hour_ago = Utc::now() - Duration::hours(1);
+
+        match fetch_fixes_needing_backfill(&fixes_repo, one_hour_ago, 1000).await {
+            Ok(fixes) => {
+                if fixes.is_empty() {
+                    // Caught up! Sleep for an hour before checking again
+                    info!(
+                        "AGL backfill caught up - no more fixes need backfilling. Sleeping for 1 hour."
+                    );
+                    gauge!("agl_backfill_pending_fixes").set(0.0);
+                    sleep(tokio::time::Duration::from_secs(3600)).await;
+                    continue;
+                }
+
+                info!(
+                    "Found {} fixes needing AGL backfill (oldest: {})",
+                    fixes.len(),
+                    fixes
+                        .first()
+                        .map(|f| f.timestamp.to_rfc3339())
+                        .unwrap_or_default()
+                );
+
+                // Record number of pending fixes
+                gauge!("agl_backfill_pending_fixes").set(fixes.len() as f64);
+
+                // Process each fix
+                let mut processed_count = 0;
+                let mut success_count = 0;
+                let mut agl_computed_count = 0;
+                let total_count = fixes.len();
+                let batch_start = std::time::Instant::now();
+
+                for fix in fixes {
+                    // Calculate AGL
+                    let agl = calculate_altitude_agl(&elevation_db, &fix).await;
+
+                    // Update the database (sets both altitude_agl_feet and altitude_agl_valid=true)
+                    match fixes_repo.update_altitude_agl(fix.id, agl).await {
+                        Ok(_) => {
+                            success_count += 1;
+                            counter!("agl_backfill_fixes_processed_total").increment(1);
+
+                            if let Some(agl_val) = agl {
+                                agl_computed_count += 1;
+                                counter!("agl_backfill_altitudes_computed_total").increment(1);
+                                debug!(
+                                    "Backfilled AGL for fix {} ({} MSL -> {} AGL)",
+                                    fix.id,
+                                    fix.altitude_msl_feet.unwrap_or(0),
+                                    agl_val
+                                );
+                            } else {
+                                counter!("agl_backfill_no_elevation_data_total").increment(1);
+                                debug!(
+                                    "Backfilled AGL for fix {} (no elevation data available)",
+                                    fix.id
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            counter!("agl_backfill_errors_total").increment(1);
+                            warn!("Failed to update AGL for fix {}: {}", fix.id, e);
+                        }
+                    }
+
+                    processed_count += 1;
+
+                    // Small delay to avoid overwhelming the database
+                    if processed_count % 100 == 0 {
+                        info!("Backfilled {} / {} fixes", processed_count, total_count);
+                        sleep(tokio::time::Duration::from_millis(100)).await;
+                    }
+                }
+
+                let batch_duration = batch_start.elapsed();
+                let altitudes_per_minute = if batch_duration.as_secs() > 0 {
+                    (agl_computed_count as f64 / batch_duration.as_secs() as f64) * 60.0
+                } else {
+                    agl_computed_count as f64
+                };
+
+                info!(
+                    "Backfill batch complete: {} processed, {} successful, {} altitudes computed ({:.1} alt/min)",
+                    processed_count, success_count, agl_computed_count, altitudes_per_minute
+                );
+
+                // Record batch processing rate
+                histogram!("agl_backfill_batch_duration_seconds")
+                    .record(batch_duration.as_secs_f64());
+                gauge!("agl_backfill_altitudes_per_minute").set(altitudes_per_minute);
+
+                // Small delay before next batch
+                sleep(tokio::time::Duration::from_secs(1)).await;
+            }
+            Err(e) => {
+                counter!("agl_backfill_fetch_errors_total").increment(1);
+                warn!("Failed to fetch fixes for backfill: {}", e);
+                // Sleep for a bit before retrying
+                sleep(tokio::time::Duration::from_secs(60)).await;
+            }
+        }
+    }
+}
+
+/// Fetch fixes that need AGL backfilling
+/// Returns fixes ordered by timestamp (oldest first)
+async fn fetch_fixes_needing_backfill(
+    fixes_repo: &FixesRepository,
+    before_timestamp: DateTime<Utc>,
+    limit: i64,
+) -> Result<Vec<Fix>> {
+    // Use the public method instead of accessing private pool field
+    fixes_repo
+        .get_fixes_needing_backfill(before_timestamp, limit)
+        .await
+}

--- a/src/fixes.rs
+++ b/src/fixes.rs
@@ -64,7 +64,7 @@ pub struct Fix {
     #[serde(rename = "altitude_msl_feet")]
     pub altitude_msl_feet: Option<i32>,
     #[serde(rename = "altitude_agl_feet")]
-    pub altitude_agl: Option<i32>,
+    pub altitude_agl_feet: Option<i32>,
 
     /// Aircraft identification - canonically a 24-bit unsigned integer stored as i32 in DB
     pub device_address: i32,
@@ -93,7 +93,6 @@ pub struct Fix {
 
     /// Associations
     pub flight_id: Option<Uuid>,
-    pub unparsed_data: Option<String>,
     pub device_id: Uuid,
 
     /// Timestamp when we received/processed the packet
@@ -108,6 +107,9 @@ pub struct Fix {
 
     /// Reference to the APRS message that contains the raw packet data
     pub aprs_message_id: Option<Uuid>,
+
+    /// Whether altitude_agl_feet has been looked up (true even if NULL due to no data)
+    pub altitude_agl_valid: bool,
 }
 
 /// Extended Fix struct that includes raw packet data from aprs_messages table
@@ -271,7 +273,7 @@ impl Fix {
                     latitude,
                     longitude,
                     altitude_msl_feet: altitude_feet,
-                    altitude_agl: None, // Will be calculated by processors
+                    altitude_agl_feet: None, // Will be calculated by processors
                     device_address,
                     address_type,
                     aircraft_type_ogn,
@@ -288,12 +290,12 @@ impl Fix {
                     gnss_horizontal_resolution,
                     gnss_vertical_resolution,
                     flight_id: None, // Will be set by flight detection processor
-                    unparsed_data: pos_packet.comment.unparsed.clone(),
                     device_id,
                     received_at,
                     is_active,
-                    receiver_id: None,     // Will be set during fix insertion
-                    aprs_message_id: None, // Will be populated during fix processing
+                    receiver_id: None,         // Will be set during fix insertion
+                    aprs_message_id: None,     // Will be populated during fix processing
+                    altitude_agl_valid: false, // Will be set to true when elevation is looked up
                 }))
             }
             _ => {

--- a/src/flight_tracker/flight_lifecycle.rs
+++ b/src/flight_tracker/flight_lifecycle.rs
@@ -215,7 +215,10 @@ pub(crate) async fn complete_flight(
         };
 
         let max_agl_altitude = if !flight_fixes.is_empty() {
-            flight_fixes.iter().filter_map(|f| f.altitude_agl).max()
+            flight_fixes
+                .iter()
+                .filter_map(|f| f.altitude_agl_feet)
+                .max()
         } else {
             None
         };

--- a/src/flight_tracker/state_transitions.rs
+++ b/src/flight_tracker/state_transitions.rs
@@ -34,7 +34,7 @@ async fn update_flight_timestamp(
 pub(crate) fn should_be_active(fix: &Fix) -> bool {
     // Special case: If no altitude data and speed < 80 knots, consider inactive
     // This handles cases where altitude data is missing but we can still infer ground state from speed
-    if fix.altitude_agl.is_none() && fix.altitude_msl_feet.is_none() {
+    if fix.altitude_agl_feet.is_none() && fix.altitude_msl_feet.is_none() {
         let speed_knots = fix.ground_speed_knots.unwrap_or(0.0);
         if speed_knots < 80.0 {
             // No altitude data and slow speed - likely on ground
@@ -53,7 +53,7 @@ pub(crate) fn should_be_active(fix: &Fix) -> bool {
 
     // Speed is low - check altitude to see if still airborne
     // Don't register landing if AGL altitude is >= 250 feet (hovering helicopter, slow glider)
-    if let Some(altitude_agl) = fix.altitude_agl
+    if let Some(altitude_agl) = fix.altitude_agl_feet
         && altitude_agl >= 250
     {
         // Still too high to land - remain active
@@ -242,8 +242,8 @@ pub(crate) async fn process_state_transition(
                     // Update last_fix_at in database
                     update_flight_timestamp(flights_repo, flight_id, fix.timestamp).await;
 
-                    // Update altitude_agl on the fix
-                    fix.altitude_agl = Some(altitude_agl);
+                    // Update altitude_agl_feet on the fix
+                    fix.altitude_agl_feet = Some(altitude_agl);
 
                     // Update state (still treat as active even though speed is low)
                     state.update(fix.timestamp, true); // Force active since airborne
@@ -266,9 +266,9 @@ pub(crate) async fn process_state_transition(
                         // Assign flight_id to this landing fix
                         fix.flight_id = Some(flight_id);
 
-                        // Update altitude_agl if we have it
+                        // Update altitude_agl_feet if we have it
                         if let Some(altitude_agl) = agl {
-                            fix.altitude_agl = Some(altitude_agl);
+                            fix.altitude_agl_feet = Some(altitude_agl);
                         }
 
                         // Complete flight (includes airport/runway lookup for landing)
@@ -342,9 +342,9 @@ pub(crate) async fn process_state_transition(
                         // Update last_fix_at in database
                         update_flight_timestamp(flights_repo, flight_id, fix.timestamp).await;
 
-                        // Update altitude_agl if we have it
+                        // Update altitude_agl_feet if we have it
                         if let Some(altitude_agl) = agl {
-                            fix.altitude_agl = Some(altitude_agl);
+                            fix.altitude_agl_feet = Some(altitude_agl);
                         }
 
                         // Keep the updated state in the map

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 //! and optionally archive all incoming messages to daily log files.
 
 pub mod actions;
+pub mod agl_backfill;
 pub mod aircraft_registrations;
 pub mod aircraft_registrations_repo;
 pub mod aircraft_types;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -268,16 +268,16 @@ diesel::table! {
         bit_errors_corrected -> Nullable<Int4>,
         freq_offset_khz -> Nullable<Float4>,
         flight_id -> Nullable<Uuid>,
-        unparsed_data -> Nullable<Varchar>,
         device_id -> Uuid,
         received_at -> Timestamptz,
         device_address -> Int4,
         is_active -> Bool,
-        altitude_agl -> Nullable<Int4>,
+        altitude_agl_feet -> Nullable<Int4>,
         receiver_id -> Nullable<Uuid>,
         gnss_horizontal_resolution -> Nullable<Int2>,
         gnss_vertical_resolution -> Nullable<Int2>,
         aprs_message_id -> Nullable<Uuid>,
+        altitude_agl_valid -> Bool,
     }
 }
 


### PR DESCRIPTION
Database Changes:
- Drop unparsed_data column from fixes (already in aprs_messages)
- Rename altitude_agl to altitude_agl_feet for consistency
- Add altitude_agl_valid boolean to track lookup status
- Add indexes for efficient backfill queries

Backend Implementation:
- Create agl_backfill module with background task
- Process fixes in batches of 1000, oldest first
- Set altitude_agl_valid=true even when elevation data unavailable
- Sleep for 1 hour when caught up to "one hour ago"
- Update elevation processor to set valid flag on all lookups

Prometheus Metrics:
- agl_backfill_fixes_processed_total counter
- agl_backfill_altitudes_computed_total counter
- agl_backfill_no_elevation_data_total counter
- agl_backfill_errors_total counter
- agl_backfill_pending_fixes gauge
- agl_backfill_altitudes_per_minute gauge
- agl_backfill_batch_duration_seconds histogram

Grafana Dashboard:
- Add "SOAR Run - AGL Backfill" section
- Panel: Altitudes Computed per Minute
- Panel: Pending Fixes (queue depth)
- Panel: Processing Breakdown (rates)
- Panel: Batch Duration & Errors (P95, error rate)

This ensures missed AGL calculations during busy periods are backfilled automatically, with full observability via metrics.