### PR TITLE
fix: remove blocking UPDATE from migration and enhance make-worktree

### DIFF
--- a/make-worktree
+++ b/make-worktree
@@ -87,6 +87,13 @@ if [ "$SOURCED" = true ]; then
     echo -e "${YELLOW}Changing directory to worktree...${NC}"
     cd "$WORKTREE_DIR"
     echo -e "${GREEN}✓ Now in: ${CYAN}$(pwd)${NC}"
+
+    # Run mise trust if mise is installed
+    if command -v mise &> /dev/null; then
+        echo -e "${BLUE}Running mise trust...${NC}"
+        mise trust
+        echo -e "${GREEN}✓ mise trust complete${NC}"
+    fi
 else
     echo -e "${YELLOW}To start working:${NC}"
     echo -e "  ${CYAN}cd $WORKTREE_DIR${NC}"

--- a/migrations/2025-10-27-024849-0000_drop_unparsed_data_rename_altitude_agl_add_valid/up.sql
+++ b/migrations/2025-10-27-024849-0000_drop_unparsed_data_rename_altitude_agl_add_valid/up.sql
@@ -18,10 +18,9 @@ END $$;
 ALTER TABLE fixes
 ADD COLUMN IF NOT EXISTS altitude_agl_valid BOOLEAN NOT NULL DEFAULT false;
 
--- Set altitude_agl_valid to true for all existing rows where altitude_agl_feet is not null
-UPDATE fixes
-SET altitude_agl_valid = true
-WHERE altitude_agl_feet IS NOT NULL AND altitude_agl_valid = false;
+-- NOTE: The following UPDATE has been removed as it would block on large tables.
+-- Run manually after migration if needed:
+-- UPDATE fixes SET altitude_agl_valid = true WHERE altitude_agl_feet IS NOT NULL AND altitude_agl_valid = false;
 
 -- Rename the index to match the new column name (idempotent)
 DO $$


### PR DESCRIPTION
- Remove blocking UPDATE statement from altitude_agl migration that would lock the fixes table on large datasets
- Add comment with manual UPDATE command for post-migration execution
- Add mise trust support to make-worktree script when sourced