### PR TITLE
chore: upgrade @googlemaps/js-api-loader from v1.16.10 to v2.0.2

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "web",
 			"version": "0.1.2",
 			"dependencies": {
-				"@googlemaps/js-api-loader": "^1.16.10",
+				"@googlemaps/js-api-loader": "^2.0.2",
 				"@lucide/svelte": "^0.545.0",
 				"@sentry/sveltekit": "^10.22.0",
 				"@skeletonlabs/skeleton": "^3.2",
@@ -1001,10 +1001,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@googlemaps/js-api-loader": {
-			"version": "1.16.10",
-			"resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.10.tgz",
-			"integrity": "sha512-c2erv2k7P2ilYzMmtYcMgAR21AULosQuUHJbStnrvRk2dG93k5cqptDrh9A8p+ZNlyhiqEOgHW7N9PAizdUM7Q==",
-			"license": "Apache-2.0"
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-2.0.2.tgz",
+			"integrity": "sha512-bKVuTqatS8Jven5aFqVB7rCHF1VFEzpzyi0ruzO0GUR+A7m9oMqMgtnmpANj7kMYEvvhty8Fk7TnJ1MKjWHu+Q==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/google.maps": "^3.53.1"
+			}
 		},
 		"node_modules/@humanfs/core": {
 			"version": "0.19.1",
@@ -3032,7 +3035,6 @@
 			"version": "3.58.1",
 			"resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
 			"integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {

--- a/web/package.json
+++ b/web/package.json
@@ -44,7 +44,7 @@
 		"vite-plugin-devtools-json": "^1.0.0"
 	},
 	"dependencies": {
-		"@googlemaps/js-api-loader": "^1.16.10",
+		"@googlemaps/js-api-loader": "^2.0.2",
 		"@lucide/svelte": "^0.545.0",
 		"@sentry/sveltekit": "^10.22.0",
 		"@skeletonlabs/skeleton": "^3.2",

--- a/web/src/routes/flights/[id]/+page.svelte
+++ b/web/src/routes/flights/[id]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	/// <reference types="@types/google.maps" />
 	import { onMount, onDestroy } from 'svelte';
-	import { Loader } from '@googlemaps/js-api-loader';
+	import { setOptions, importLibrary } from '@googlemaps/js-api-loader';
 	import Plotly from 'plotly.js-dist-min';
 	import {
 		Download,
@@ -438,13 +438,13 @@
 		if (data.fixes.length === 0 || !mapContainer) return;
 
 		try {
-			const loader = new Loader({
-				apiKey: GOOGLE_MAPS_API_KEY,
-				version: 'weekly'
+			setOptions({
+				key: GOOGLE_MAPS_API_KEY,
+				v: 'weekly'
 			});
 
-			await loader.importLibrary('maps');
-			await loader.importLibrary('marker');
+			await importLibrary('maps');
+			await importLibrary('marker');
 
 			// Use reversed fixes for chronological order (earliest to latest)
 			const fixesInOrder = [...data.fixes].reverse();

--- a/web/src/routes/operations/+page.svelte
+++ b/web/src/routes/operations/+page.svelte
@@ -3,7 +3,7 @@
 	import { onMount } from 'svelte';
 	import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 	import { serverCall } from '$lib/api/server';
-	import { Loader } from '@googlemaps/js-api-loader';
+	import { setOptions, importLibrary } from '@googlemaps/js-api-loader';
 	import { Settings, ListChecks, MapPlus, MapMinus } from '@lucide/svelte';
 	import WatchlistModal from '$lib/components/WatchlistModal.svelte';
 	import SettingsModal from '$lib/components/SettingsModal.svelte';
@@ -398,15 +398,15 @@
 	});
 
 	async function loadGoogleMapsScript(): Promise<void> {
-		const loader = new Loader({
-			apiKey: GOOGLE_MAPS_API_KEY,
-			version: 'weekly'
+		setOptions({
+			key: GOOGLE_MAPS_API_KEY,
+			v: 'weekly'
 		});
 
 		// Import the required libraries
-		await loader.importLibrary('maps');
-		await loader.importLibrary('geometry');
-		await loader.importLibrary('marker');
+		await importLibrary('maps');
+		await importLibrary('geometry');
+		await importLibrary('marker');
 	}
 
 	function initializeMap(): void {

--- a/web/src/routes/receivers/+page.svelte
+++ b/web/src/routes/receivers/+page.svelte
@@ -3,7 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { serverCall } from '$lib/api/server';
 	import { GOOGLE_MAPS_API_KEY } from '$lib/config';
-	import { Loader } from '@googlemaps/js-api-loader';
+	import { setOptions, importLibrary } from '@googlemaps/js-api-loader';
 	import { onMount } from 'svelte';
 	import dayjs from 'dayjs';
 	import relativeTime from 'dayjs/plugin/relativeTime';
@@ -161,13 +161,13 @@
 	}
 
 	async function loadGoogleMapsScript(): Promise<void> {
-		const loader = new Loader({
-			apiKey: GOOGLE_MAPS_API_KEY,
-			version: 'weekly'
+		setOptions({
+			key: GOOGLE_MAPS_API_KEY,
+			v: 'weekly'
 		});
 
 		// Import the places library for autocomplete
-		await loader.importLibrary('places');
+		await importLibrary('places');
 	}
 
 	async function loadRecentReceivers() {


### PR DESCRIPTION
## Summary
Upgraded `@googlemaps/js-api-loader` from version **1.16.10** to **2.0.2** to get the latest features and improvements.

## Breaking Changes Addressed

Version 2.0.0 (released September 29, 2025) introduced a major API redesign:

### API Structure Change
- **Old**: Used `Loader` class with constructor pattern
- **New**: Uses functional API with `setOptions()` and `importLibrary()` functions

### Property Name Changes
- `apiKey` → `key`
- `version` → `v`

### Migration Example

**Before (v1.16.10):**
```typescript
import { Loader } from '@googlemaps/js-api-loader';

const loader = new Loader({
  apiKey: GOOGLE_MAPS_API_KEY,
  version: 'weekly'
});

await loader.importLibrary('maps');
```

**After (v2.0.2):**
```typescript
import { setOptions, importLibrary } from '@googlemaps/js-api-loader';

setOptions({
  key: GOOGLE_MAPS_API_KEY,
  v: 'weekly'
});

await importLibrary('maps');
```

## Files Modified
- ✅ `web/package.json` - Updated dependency version
- ✅ `web/src/routes/receivers/+page.svelte` - Migrated to new API
- ✅ `web/src/routes/operations/+page.svelte` - Migrated to new API  
- ✅ `web/src/routes/flights/[id]/+page.svelte` - Migrated to new API

## Testing
- ✅ All pre-commit hooks passed
- ✅ Linting passed with no errors
- ✅ TypeScript checks passed (0 errors)
- ✅ Production build succeeded
- ✅ No changes to functionality - purely API migration

## Benefits
- On-demand dynamic loading of individual Maps API libraries
- Improved initial page performance by deferring feature downloads
- Simpler, more modern functional API
- Latest bug fixes and improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)