### PR TITLE
feat: enhance Grafana dashboard with total rates and dual-axis queue panel

### DIFF
--- a/infrastructure/grafana-dashboard-run.json
+++ b/infrastructure/grafana-dashboard-run.json
@@ -608,16 +608,39 @@
         "overrides": [
           {
             "matcher": {
-              "id": "byName",
-              "options": "Queue Full/sec"
+              "id": "byRegexp",
+              "options": ".*Dropped.*"
             },
             "properties": [
               {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "Dropped/sec"
+              },
+              {
                 "id": "color",
                 "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
+                  "mode": "palette-classic"
                 }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Enqueued.*"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "left"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "Enqueued/sec"
               }
             ]
           }
@@ -655,8 +678,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_aircraft_queue_full[1m])",
-          "legendFormat": "Aircraft Queue Full/sec",
+          "expr": "rate(aprs_aircraft_processed[1m])",
+          "legendFormat": "Aircraft Enqueued",
           "range": true,
           "refId": "A"
         },
@@ -666,8 +689,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_receiver_status_queue_full[1m])",
-          "legendFormat": "Receiver Status Queue Full/sec",
+          "expr": "rate(aprs_receiver_status_processed[1m])",
+          "legendFormat": "Receiver Status Enqueued",
           "range": true,
           "refId": "B"
         },
@@ -677,8 +700,8 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_receiver_position_queue_full[1m])",
-          "legendFormat": "Receiver Position Queue Full/sec",
+          "expr": "rate(aprs_receiver_position_processed[1m])",
+          "legendFormat": "Receiver Position Enqueued",
           "range": true,
           "refId": "C"
         },
@@ -688,13 +711,68 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_server_status_queue_full[1m])",
-          "legendFormat": "Server Status Queue Full/sec",
+          "expr": "rate(aprs_server_status_processed[1m])",
+          "legendFormat": "Server Status Enqueued",
           "range": true,
           "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_aircraft_queue_full[1m]) + rate(aprs_receiver_status_queue_full[1m]) + rate(aprs_receiver_position_queue_full[1m]) + rate(aprs_server_status_queue_full[1m])",
+          "legendFormat": "Total Dropped",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_aircraft_queue_full[1m])",
+          "legendFormat": "Aircraft Dropped",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_receiver_status_queue_full[1m])",
+          "legendFormat": "Receiver Status Dropped",
+          "range": true,
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_receiver_position_queue_full[1m])",
+          "legendFormat": "Receiver Position Dropped",
+          "range": true,
+          "refId": "H"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_server_status_queue_full[1m])",
+          "legendFormat": "Server Status Dropped",
+          "range": true,
+          "refId": "I"
         }
       ],
-      "title": "APRS Queue Drops by Processor",
+      "title": "Packet Queue",
       "type": "timeseries"
     },
     {
@@ -1057,6 +1135,17 @@
           "legendFormat": "Server Status/sec",
           "range": true,
           "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_aircraft_processed[5m]) + rate(aprs_receiver_status_processed[5m]) + rate(aprs_receiver_position_processed[5m]) + rate(aprs_server_status_processed[5m])",
+          "legendFormat": "Total/sec",
+          "range": true,
+          "refId": "E"
         }
       ],
       "title": "APRS Processing Rate by Type",


### PR DESCRIPTION
## Summary
Enhances the SOAR Run Grafana dashboard with improved visibility into overall system throughput and redesigns the queue monitoring panel with dual Y-axes for better data comparison.

## Changes Made

### 1. Added Total Processing Rate
**Panel: "APRS Processing Rate by Type"**
- Added new metric: `Total/sec` - sum of all processor types
- Provides at-a-glance view of overall APRS packet processing throughput
- Complements the existing per-processor breakdown

### 2. Redesigned Queue Panel with Dual Y-Axes
**Panel: "Packet Queue" (formerly "APRS Queue Drops by Processor")**

**Left Y-axis (Enqueued/sec):** Shows successful packet processing by type
- Aircraft Enqueued
- Receiver Status Enqueued
- Receiver Position Enqueued
- Server Status Enqueued

**Right Y-axis (Dropped/sec):** Shows packet drops
- Total Dropped (aggregate of all types)
- Aircraft Dropped
- Receiver Status Dropped
- Receiver Position Dropped
- Server Status Dropped

This dual-axis design makes it easy to:
- Compare enqueue rates (left) vs drop rates (right) at different scales
- Identify which processor types are experiencing queue pressure
- Monitor overall system health with the "Total Dropped" metric

## Benefits
- **Better system health visibility**: Total processing rate shows overall throughput at a glance
- **Improved troubleshooting**: Dual-axis design makes it easier to correlate enqueue rates with drops
- **Maintained granularity**: Per-processor breakdowns remain available for detailed analysis

## Test plan
- [ ] Import updated dashboard to Grafana
- [ ] Run `soar run` command
- [ ] Verify total processing rate displays correctly and matches sum of individual rates
- [ ] Confirm left axis shows enqueued packets and right axis shows dropped packets
- [ ] Check that axis labels are clear and metrics are on appropriate scales