### PR TITLE
fix: initialize APRS metrics and correct NATS client naming

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -404,6 +404,31 @@ async fn handle_ingest_aprs(
         );
     }
 
+    // Initialize all APRS ingester metrics to zero so they appear in Grafana even before events occur
+    info!("Initializing APRS ingester metrics...");
+
+    // Connection metrics
+    metrics::counter!("aprs.connection.established").absolute(0);
+    metrics::counter!("aprs.connection.ended").absolute(0);
+    metrics::counter!("aprs.connection.failed").absolute(0);
+    metrics::counter!("aprs.connection.operation_failed").absolute(0);
+    metrics::gauge!("aprs.connection.connected").set(0.0);
+
+    // Keepalive metrics
+    metrics::counter!("aprs.keepalive.sent").absolute(0);
+
+    // Message processing metrics
+    metrics::counter!("aprs.raw_message.processed").absolute(0);
+    metrics::counter!("aprs.raw_message_queue.full").absolute(0);
+    metrics::gauge!("aprs.raw_message_queue.depth").set(0.0);
+
+    // JetStream publishing metrics
+    metrics::counter!("aprs.jetstream.published").absolute(0);
+    metrics::counter!("aprs.jetstream.publish_error").absolute(0);
+    metrics::gauge!("aprs.jetstream.queue_depth").set(0.0);
+
+    info!("APRS ingester metrics initialized");
+
     // Acquire instance lock to prevent multiple ingest instances from running
     let lock_name = if is_production {
         "aprs-ingest-production"
@@ -531,6 +556,22 @@ async fn handle_run(archive_dir: Option<String>, nats_url: String) -> Result<()>
             .instrument(tracing::info_span!("metrics_server")),
         );
     }
+
+    // Initialize all soar-run metrics to zero so they appear in Grafana even before events occur
+    info!("Initializing soar-run metrics...");
+
+    // JetStream consumer metrics
+    metrics::counter!("aprs.jetstream.consumed").absolute(0);
+    metrics::counter!("aprs.jetstream.consumer_error").absolute(0);
+
+    // Receiver cache metrics
+    metrics::counter!("generic_processor.receiver_cache.hit").absolute(0);
+    metrics::counter!("generic_processor.receiver_cache.miss").absolute(0);
+
+    // Flight tracker metrics
+    metrics::counter!("flight_tracker_timeouts_detected").absolute(0);
+
+    info!("soar-run metrics initialized");
 
     let lock_name = if is_production {
         "soar-run-production"

--- a/src/nats_publisher.rs
+++ b/src/nats_publisher.rs
@@ -70,9 +70,9 @@ impl NatsFixPublisher {
     pub async fn new(nats_url: &str) -> Result<Self> {
         info!("Connecting to NATS server at {}", nats_url);
         let nats_client_name = if std::env::var("SOAR_ENV") == Ok("production".into()) {
-            "soar-run"
+            "soar-aprs-ingester"
         } else {
-            "soar-run-dev"
+            "soar-aprs-ingester-staging"
         };
         let nats_client = async_nats::ConnectOptions::new()
             .name(nats_client_name)


### PR DESCRIPTION
## Summary
This PR fixes metrics initialization for Grafana monitoring and corrects the NATS client naming for the APRS ingester.

## Changes

### 1. Initialize APRS Ingester Metrics (`src/main.rs`)
Added zero-initialization for all APRS ingester metrics so they appear in Grafana dashboards from startup:
- **Connection metrics**: `aprs.connection.established`, `aprs.connection.ended`, `aprs.connection.failed`, `aprs.connection.operation_failed`, `aprs.connection.connected`
- **Keepalive metrics**: `aprs.keepalive.sent`
- **Message processing**: `aprs.raw_message.processed`, `aprs.raw_message_queue.full`, `aprs.raw_message_queue.depth`
- **JetStream publishing**: `aprs.jetstream.published`, `aprs.jetstream.publish_error`, `aprs.jetstream.queue_depth`

### 2. Initialize SOAR Run Metrics (`src/main.rs`)
Added zero-initialization for all soar-run metrics:
- **JetStream consumer**: `aprs.jetstream.consumed`, `aprs.jetstream.consumer_error`
- **Receiver cache**: `generic_processor.receiver_cache.hit`, `generic_processor.receiver_cache.miss`
- **Flight tracker**: `flight_tracker_timeouts_detected`

### 3. Fix NATS Client Name (`src/nats_publisher.rs`)
Corrected the NATS client name in `NatsFixPublisher`:
- **Before**: Used incorrect names "soar-run" / "soar-run-dev"
- **After**: Uses proper names "soar-aprs-ingester" (production) / "soar-aprs-ingester-staging" (non-production)

## Benefits
- Metrics now appear in Grafana dashboards immediately on service startup, even before any events occur
- NATS client naming is now consistent and makes it easy to identify the APRS ingester in monitoring tools
- Better observability for debugging APRS ingestion and processing issues

## Test plan
- [x] Build succeeds
- [x] Pre-commit hooks pass (cargo fmt, clippy, tests)
- [ ] Verify metrics appear in Grafana after deployment
- [ ] Verify NATS client shows correct name in NATS monitoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)