### PR TITLE
fix: auto-switch to port 10152 when no APRS filter specified

### DIFF
--- a/src/commands/ingest_aprs.rs
+++ b/src/commands/ingest_aprs.rs
@@ -7,7 +7,7 @@ use tracing::info;
 
 pub async fn handle_ingest_aprs(
     server: String,
-    port: u16,
+    mut port: u16,
     callsign: String,
     filter: Option<String>,
     max_retries: u32,
@@ -21,6 +21,13 @@ pub async fn handle_ingest_aprs(
     sentry::configure_scope(|scope| {
         scope.set_tag("operation", "ingest-aprs");
     });
+
+    // Automatically switch to port 10152 for full feed if no filter specified
+    // Port 14580 requires a filter, port 10152 provides the full global feed
+    if filter.is_none() && port == 14580 {
+        info!("No filter specified, switching from port 14580 to 10152 for full feed");
+        port = 10152;
+    }
 
     // Determine environment and use appropriate stream/subject names
     // Production: "APRS_RAW" and "aprs.raw"


### PR DESCRIPTION
## Problem

The APRS ingester was only receiving ~3 messages/minute (server keepalives) in production instead of the expected hundreds per minute.

## Root Cause

When the APRS ingestion was split into a separate service (commit c023f15a), the `handle_run` function had port-switching logic that was NOT copied to the new `handle_ingest_aprs` function.

**Original `handle_run` (that worked):**
```rust
// Use port 10152 (full feed) if no filter is specified
let actual_port = if filter.is_none() {
    info!("No filter specified, using full feed port 10152");
    10152
} else {
    port
};
```

**New `handle_ingest_aprs` (missing this logic):**
Just used the port directly without checking filter.

## APRS-IS Server Behavior

- **Port 14580**: Requires a filter, provides NO data without one
- **Port 10152**: Provides full global feed without requiring a filter

Production was connecting to port 14580 with no filter = no data.

## Fix

Added the same port-switching logic to `handle_ingest_aprs`:
```rust
if filter.is_none() && port == 14580 {
    info!("No filter specified, switching from port 14580 to 10152 for full feed");
    port = 10152;
}
```

## Testing

Once deployed, the ingester should immediately start receiving hundreds of messages per minute instead of just 3 (server keepalives).

Monitor these metrics in Grafana:
- `aprs.raw_message.received.aprs` should jump from 0 to ~hundreds/min
- `aprs.jetstream.published.aprs` should match received rate
