### PR TITLE
feat: automate Grafana dashboard deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,19 @@ jobs:
             echo "Prometheus job files included in deployment package"
           fi
 
+          # Copy Grafana provisioning configuration
+          if [ -d infrastructure/grafana-provisioning ]; then
+            cp -r infrastructure/grafana-provisioning deploy-pkg/
+            echo "Grafana provisioning configuration included in deployment package"
+          fi
+
+          # Copy Grafana dashboard files
+          if compgen -G "infrastructure/grafana-dashboard-*.json" > /dev/null; then
+            cp infrastructure/grafana-dashboard-*.json deploy-pkg/
+            DASHBOARD_COUNT=$(ls -1 infrastructure/grafana-dashboard-*.json | wc -l)
+            echo "Grafana dashboards included in deployment package: $DASHBOARD_COUNT"
+          fi
+
           # Create version file with commit SHA (short form for Sentry)
           echo "${GITHUB_SHA:0:7}" > deploy-pkg/VERSION
 
@@ -349,6 +362,10 @@ jobs:
           if [ -d deploy-pkg/prometheus-jobs ]; then
             echo "Prometheus jobs:"
             ls -lh deploy-pkg/prometheus-jobs/
+          fi
+          if [ -d deploy-pkg/grafana-provisioning ]; then
+            echo "Grafana provisioning:"
+            ls -lh deploy-pkg/grafana-provisioning/dashboards/
           fi
 
       - name: Upload deployment package

--- a/infrastructure/grafana-provisioning/dashboards/dashboards.yml
+++ b/infrastructure/grafana-provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: 'SOAR Dashboards'
+    orgId: 1
+    folder: 'SOAR'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -12,6 +12,8 @@
 #   - *.service files
 #   - *.timer files
 #   - prometheus-jobs/ directory (optional, contains Prometheus job configs)
+#   - grafana-provisioning/ directory (optional, contains Grafana provisioning configs)
+#   - grafana-dashboard-*.json files (optional, Grafana dashboards)
 #
 
 set -e
@@ -154,6 +156,57 @@ if [ -d "$DEPLOY_DIR/prometheus-jobs" ]; then
     fi
 else
     log_warn "prometheus-jobs directory not found in deployment, skipping Prometheus configuration"
+fi
+
+# Install Grafana dashboards and provisioning configuration
+GRAFANA_NEEDS_RESTART=false
+
+if [ -d "$DEPLOY_DIR/grafana-provisioning" ]; then
+    log_info "Installing Grafana provisioning configuration..."
+    mkdir -p /etc/grafana/provisioning/dashboards
+    cp -r "$DEPLOY_DIR/grafana-provisioning/dashboards"/*.yml /etc/grafana/provisioning/dashboards/
+    chmod 644 /etc/grafana/provisioning/dashboards/*.yml
+
+    # Set ownership to grafana user if it exists
+    if id "grafana" &>/dev/null; then
+        chown -R grafana:grafana /etc/grafana/provisioning/dashboards
+        log_info "Grafana provisioning configuration installed"
+        GRAFANA_NEEDS_RESTART=true
+    else
+        log_warn "grafana user not found, skipping ownership change"
+    fi
+fi
+
+# Install Grafana dashboard JSON files
+DASHBOARD_COUNT=0
+if compgen -G "$DEPLOY_DIR/grafana-dashboard-*.json" > /dev/null; then
+    log_info "Installing Grafana dashboard files..."
+    mkdir -p /etc/grafana/dashboards
+    cp "$DEPLOY_DIR"/grafana-dashboard-*.json /etc/grafana/dashboards/
+    chmod 644 /etc/grafana/dashboards/*.json
+
+    # Set ownership to grafana user if it exists
+    if id "grafana" &>/dev/null; then
+        chown -R grafana:grafana /etc/grafana/dashboards
+        DASHBOARD_COUNT=$(ls -1 "$DEPLOY_DIR"/grafana-dashboard-*.json | wc -l)
+        log_info "Installed $DASHBOARD_COUNT Grafana dashboard(s)"
+        GRAFANA_NEEDS_RESTART=true
+    else
+        log_warn "grafana user not found, skipping ownership change"
+    fi
+else
+    log_warn "No Grafana dashboard files found in deployment, skipping dashboard installation"
+fi
+
+# Restart Grafana if dashboards or provisioning was updated
+if [ "$GRAFANA_NEEDS_RESTART" = true ]; then
+    if systemctl is-active --quiet grafana-server; then
+        log_info "Restarting Grafana to load new dashboards..."
+        systemctl restart grafana-server || log_warn "Failed to restart Grafana"
+        log_info "Grafana restarted successfully"
+    else
+        log_warn "Grafana is not running, skipping restart"
+    fi
 fi
 
 # Reload systemd daemon


### PR DESCRIPTION
## Summary
Automates Grafana dashboard deployment as part of the standard SOAR deployment process, eliminating the need for manual copy-paste of dashboard JSON files.

## Changes
- **Added Grafana provisioning configuration** (`infrastructure/grafana-provisioning/dashboards/dashboards.yml`)
  - Configures Grafana to auto-load dashboards from `/etc/grafana/dashboards/`
  - Dashboards update automatically every 10 seconds when files change
  - Creates dashboards in "SOAR" folder in Grafana UI

- **Updated `soar-deploy` script** to install Grafana files:
  - Copies provisioning configuration to `/etc/grafana/provisioning/dashboards/`
  - Copies all `grafana-dashboard-*.json` files to `/etc/grafana/dashboards/`
  - Sets proper ownership (`grafana:grafana`)
  - Restarts Grafana service to load new dashboards

- **Updated CI/CD pipeline** (`.github/workflows/ci.yml`):
  - Includes Grafana provisioning directory in deployment package
  - Includes all 4 dashboard JSON files in deployment package
  - Added logging to show Grafana files being deployed

- **Updated documentation** (`infrastructure/grafana-README.md`):
  - Added "Automated Deployment" section explaining the new process
  - Listed all 4 dashboards (web, run, pull-data, aprs-ingest)
  - Updated Prometheus configuration reference
  - Kept manual import instructions for troubleshooting

## How It Works
1. CI/CD pipeline packages Grafana files with deployment
2. `soar-deploy` installs them to `/etc/grafana/` directories
3. Grafana automatically loads dashboards via provisioning system
4. Dashboards appear under "SOAR" folder in Grafana UI

## Benefits
- ✅ No manual dashboard import needed
- ✅ Dashboards version-controlled in Git
- ✅ Consistent with Prometheus job deployment pattern
- ✅ Easy rollback (dashboards in each deployment package)
- ✅ Still allows UI edits to dashboards

## Test plan
- [x] Verify provisioning configuration syntax
- [x] Update deployment script with proper error handling
- [x] Update CI/CD to include Grafana files
- [ ] Test deployment on server
- [ ] Verify dashboards load in Grafana
- [ ] Confirm dashboards appear in "SOAR" folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)