### PR TITLE
perf: optimize JetStream publishing with fire-and-forget mode

### DIFF
--- a/src/queue_config.rs
+++ b/src/queue_config.rs
@@ -33,10 +33,10 @@ pub const SOAR_RUN_CONSUMER_STAGING: &str = "soar-run-staging";
 // ============================================================================
 
 /// Raw APRS message queue from APRS-IS connection to JetStream publisher
-/// Small queue (50 messages) since messages are immediately published to durable JetStream
-/// At ~500 msg/s, this represents ~100ms of buffering
-/// Intentionally small to minimize message loss during crashes (JetStream provides durability)
-pub const RAW_MESSAGE_QUEUE_SIZE: usize = 50;
+/// Medium queue (1000 messages) to buffer during JetStream publish latency
+/// At ~500 msg/s, this represents ~2 seconds of buffering
+/// Provides headroom for network latency while JetStream provides durability
+pub const RAW_MESSAGE_QUEUE_SIZE: usize = 1000;
 
 /// Archive queue for writing raw APRS messages to compressed files
 /// Large queue (10,000 messages) since file I/O is slower and batched


### PR DESCRIPTION
## Summary
Optimizes APRS-to-JetStream publishing throughput by using fire-and-forget mode instead of synchronous acknowledgment waiting.

## Problem
The APRS ingestion service (`aprs-ingest`) was experiencing queue overflows and dropping messages:
- JetStream publishing was limited to ~110 msg/s due to waiting for acknowledgments
- APRS message rate from OGN network is 300-500+ msg/s
- Raw message queue was only 50 messages (~100ms buffer)
- Queue filled up constantly, causing message drops

## Changes

### 1. Increased Queue Size
- `RAW_MESSAGE_QUEUE_SIZE`: 50 → 1000 messages
- Provides ~2 seconds of buffering instead of ~100ms
- Reduces sensitivity to publish latency spikes

### 2. Fire-and-Forget Publishing
- Added `publish_fire_and_forget()` method to `JetStreamPublisher`
- Sends messages without waiting for JetStream acknowledgments
- Eliminates network RTT bottleneck
- Expected throughput: 300-500+ msg/s (3-5x improvement)

### 3. Fixed Error Messages
- Changed hardcoded "10,000 messages" to use `RAW_MESSAGE_QUEUE_SIZE` constant
- Updated warning threshold message accuracy (50% → 80%)

## Rationale
APRS is a continuous real-time data stream where:
1. Message loss during process crashes/restarts is already acceptable
2. New data arrives continuously - brief gaps are tolerable
3. JetStream still provides durability once messages reach the server
4. Maximizing throughput is more important than guaranteed delivery of every message

The fire-and-forget approach trades acknowledgment certainty for higher throughput, which is appropriate for this streaming use case.

## Testing
- [x] Code compiles and passes clippy
- [x] Pre-commit hooks pass
- [ ] Deploy to production and monitor metrics:
  - `aprs.jetstream.published` (should increase to 300-500 msg/s)
  - `aprs.raw_message_queue.full` (should decrease to zero)
  - `aprs.jetstream.queue_depth` (should stay near zero)
  - `aprs.jetstream.publish_error` (new messages should be minimal)