### PR TITLE
fix: improve receiver geocoding error handling in daily pull-data

### DIFF
--- a/src/email_reporter.rs
+++ b/src/email_reporter.rs
@@ -48,6 +48,7 @@ pub struct EntityMetrics {
     pub records_in_db: Option<i64>,
     pub success: bool,
     pub error_message: Option<String>,
+    pub failed_items: Option<Vec<String>>, // For tracking specific items that failed (e.g., receiver callsigns)
 }
 
 impl EntityMetrics {
@@ -59,6 +60,7 @@ impl EntityMetrics {
             records_in_db: None,
             success: true,
             error_message: None,
+            failed_items: None,
         }
     }
 
@@ -70,6 +72,7 @@ impl EntityMetrics {
             records_in_db: None,
             success: false,
             error_message: Some(error),
+            failed_items: None,
         }
     }
 }
@@ -205,6 +208,24 @@ impl DataLoadReport {
                 </td>
             </tr>"#,
                     error
+                ));
+            }
+
+            if let Some(failed_items) = &entity.failed_items
+                && !failed_items.is_empty()
+            {
+                let items_list = failed_items.join(", ");
+                html.push_str(&format!(
+                    r#"
+            <tr>
+                <td colspan="5">
+                    <div class="error-box">
+                        <strong>Failed Items ({}):</strong> {}
+                    </div>
+                </td>
+            </tr>"#,
+                    failed_items.len(),
+                    items_list
                 ));
             }
         }


### PR DESCRIPTION
## Summary
- Changes receiver geocoding to treat individual failures as normal rather than job failures
- Failed receiver callsigns are now tracked and included in the summary email
- Only one daily summary email is sent, which includes failed receivers
- No more separate failure emails for geocoding issues

## Changes
- **`receiver_geocoding.rs`**: Modified to track failed receiver callsigns and no longer mark stage as failed for individual geocoding failures
- **`email_reporter.rs`**: Added `failed_items` field to `EntityMetrics` and updated HTML template to display failed items
- **`load_data/mod.rs`**: Removed immediate failure email for receiver geocoding stage

## Motivation
Individual receiver geocoding failures are expected and normal (e.g., coordinates in oceans, remote areas, or temporary geocoding service issues). These should not cause the entire daily pull-data job to be marked as failed, and should not trigger separate failure emails.

## Test Plan
- [x] Cargo fmt passes
- [x] Cargo clippy passes  
- [x] All tests pass
- [ ] Verify summary email format includes failed receivers
- [ ] Confirm job success even with some geocoding failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)