### PR TITLE
feat: add country_code field to devices table

### DIFF
--- a/migrations/2025-11-01-065545-0000_add_devices_country_code/down.sql
+++ b/migrations/2025-11-01-065545-0000_add_devices_country_code/down.sql
@@ -1,0 +1,6 @@
+-- Drop the index first
+DROP INDEX IF EXISTS idx_devices_country_code;
+
+-- Remove the country_code column
+ALTER TABLE devices
+DROP COLUMN country_code;

--- a/migrations/2025-11-01-065545-0000_add_devices_country_code/up.sql
+++ b/migrations/2025-11-01-065545-0000_add_devices_country_code/up.sql
@@ -1,0 +1,8 @@
+-- Add country_code column to devices table
+-- Two-letter country code (ISO 3166-1 alpha-2), nullable
+-- Will be populated from ICAO addresses using flydent crate
+ALTER TABLE devices
+ADD COLUMN country_code CHAR(2) NULL;
+
+-- Create index for filtering/querying by country
+CREATE INDEX idx_devices_country_code ON devices(country_code);

--- a/src/device_repo.rs
+++ b/src/device_repo.rs
@@ -111,6 +111,9 @@ impl DeviceRepository {
     ) -> Result<DeviceModel> {
         let mut conn = self.get_connection()?;
 
+        // Extract country code from ICAO address if applicable
+        let country_code = Device::extract_country_code_from_icao(address as u32, address_type);
+
         let new_device = NewDevice {
             address,
             address_type,
@@ -129,6 +132,7 @@ impl DeviceRepository {
             icao_model_code: None,
             adsb_emitter_category: None,
             tracker_device_type: None,
+            country_code,
         };
 
         // Use INSERT ... ON CONFLICT ... DO UPDATE RETURNING to atomically handle race conditions

--- a/src/fixes_repo.rs
+++ b/src/fixes_repo.rs
@@ -736,6 +736,8 @@ impl FixesRepository {
                 adsb_emitter_category: Option<crate::ogn_aprs_aircraft::AdsbEmitterCategory>,
                 #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
                 tracker_device_type: Option<String>,
+                #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Bpchar>)]
+                country_code: Option<String>,
             }
 
             let device_rows: Vec<DeviceRow> = diesel::sql_query(devices_sql)
@@ -779,6 +781,7 @@ impl FixesRepository {
                     icao_model_code: row.icao_model_code,
                     adsb_emitter_category: row.adsb_emitter_category,
                     tracker_device_type: row.tracker_device_type,
+                    country_code: row.country_code,
                 })
                 .collect();
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -231,6 +231,8 @@ diesel::table! {
         icao_model_code -> Nullable<Text>,
         adsb_emitter_category -> Nullable<AdsbEmitterCategory>,
         tracker_device_type -> Nullable<Text>,
+        #[max_length = 2]
+        country_code -> Nullable<Bpchar>,
     }
 }
 


### PR DESCRIPTION
## Summary
Adds a two-letter ISO 3166-1 alpha-2 country code field to the devices table that automatically extracts country information from ICAO addresses using the flydent crate.

## Changes
- **Database Migration**: Added nullable `country_code CHAR(2)` column to devices table with index for efficient filtering
- **Country Code Extraction**: Added `Device::extract_country_code_from_icao()` method that uses flydent to parse ICAO 24-bit addresses
- **Automatic Population**: Country codes are automatically extracted when creating or updating devices through the `From<Device> for NewDevice` implementation
- **Model Updates**: Updated Device, DeviceModel, and NewDevice structs with the new field
- **Test Coverage**: Added comprehensive unit tests for country code extraction

## Implementation Details
- Only ICAO address types are processed (not FLARM or OGN)
- Uses the flydent crate's ICAO 24-bit address parsing capability
- Country codes are extracted at device creation/update time
- Nullable design allows for gradual population

## Examples
- `0xA00001` → `"US"` (United States)
- `0x3C0001` → `"DE"` (Germany)
- `0x400001` → `"GB"` (United Kingdom)
- `0xC00001` → `"CA"` (Canada)

## Test plan
- [x] Unit tests pass for country code extraction
- [x] All existing device tests continue to pass (15/15)
- [x] Migration applied successfully to dev database
- [x] Schema updated correctly with new column and index
- [ ] Verify country codes are populated for ICAO devices in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)