### PR TITLE
feat: replace AppBar loading indicator with blue-to-orange gradient

### DIFF
--- a/web/src/lib/components/LoadingBar.svelte
+++ b/web/src/lib/components/LoadingBar.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import { loading } from '$lib/stores/loading';
+	import { fade } from 'svelte/transition';
 
 	// Reactive subscription to loading state
 	let isLoading = $derived($loading.activeRequests > 0);
 </script>
 
 {#if isLoading}
-	<div class="loading-bar-overlay"></div>
+	<div class="loading-bar-overlay" transition:fade={{ duration: 300 }}></div>
 {/if}
 
 <style>
@@ -17,50 +18,41 @@
 		right: 0;
 		bottom: 0;
 		pointer-events: none;
-		animation: fadeIn 150ms ease-in;
 		z-index: 1;
+		animation: slide 2.5s ease-in-out infinite;
 	}
 
-	/* Light mode - soft blue gradient */
+	/* Light mode - blue to orange gradient */
 	.loading-bar-overlay {
 		background: linear-gradient(
 			90deg,
-			rgba(96, 165, 250, 0.15) 0%,
-			rgba(147, 197, 253, 0.25) 50%,
-			rgba(96, 165, 250, 0.15) 100%
+			rgba(59, 130, 246, 0.3) 0%,
+			rgba(251, 146, 60, 0.3) 50%,
+			rgba(59, 130, 246, 0.3) 100%
 		);
 		background-size: 200% 100%;
-		animation:
-			slide 2s ease-in-out infinite,
-			fadeIn 150ms ease-in;
 	}
 
-	/* Dark mode - subtle cyan/blue gradient */
+	/* Dark mode - blue to orange gradient with adjusted opacity */
 	:global(.dark) .loading-bar-overlay {
 		background: linear-gradient(
 			90deg,
-			rgba(34, 211, 238, 0.08) 0%,
-			rgba(56, 189, 248, 0.12) 50%,
-			rgba(34, 211, 238, 0.08) 100%
+			rgba(59, 130, 246, 0.25) 0%,
+			rgba(251, 146, 60, 0.25) 50%,
+			rgba(59, 130, 246, 0.25) 100%
 		);
 		background-size: 200% 100%;
 	}
 
 	@keyframes slide {
 		0% {
+			background-position: 0% 0;
+		}
+		50% {
 			background-position: 100% 0;
 		}
 		100% {
-			background-position: -100% 0;
-		}
-	}
-
-	@keyframes fadeIn {
-		from {
-			opacity: 0;
-		}
-		to {
-			opacity: 1;
+			background-position: 0% 0;
 		}
 	}
 </style>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -11,6 +11,7 @@
 	import { websocketStatus, debugStatus } from '$lib/stores/watchlist';
 	import { onMount } from 'svelte';
 	import RadarLoader from '$lib/components/RadarLoader.svelte';
+	import LoadingBar from '$lib/components/LoadingBar.svelte';
 	import {
 		Radar,
 		Users,
@@ -99,6 +100,7 @@
 
 <div class="flex h-full min-h-screen flex-col">
 	<AppBar background="bg-orange-400 dark:bg-orange-900" classes="relative z-[70]">
+		<LoadingBar />
 		{#snippet lead()}
 			<a href={base} class="btn flex items-center space-x-2 preset-filled-primary-500">
 				<div class="flex items-center gap-3 font-bold">


### PR DESCRIPTION
## Summary
- Replaced the subtle blue loading indicator with a more visible animated gradient
- Gradient transitions between blue (#3B82F6) and orange (#FB923C) colors
- Covers the entire AppBar background with smooth fade-in/fade-out transitions

## Changes
- Updated LoadingBar.svelte to use blue-to-orange gradient animation
- Implemented 300ms fade transitions using Svelte's fade directive
- Added continuous sliding animation (2.5s cycle) across the AppBar
- Integrated LoadingBar into AppBar component for full-width coverage
- Adjusted gradient opacity for optimal visibility in both light (0.3) and dark (0.25) modes

## Visual Design
The loading indicator now uses a layered approach:
1. **Background layer**: Orange AppBar background
2. **Gradient layer**: Animated blue-to-orange gradient (only visible during loading)
3. **Content layer**: All AppBar buttons and elements on top

## Test plan
- [x] TypeScript validation passes
- [x] ESLint and Prettier checks pass
- [x] Build completes successfully
- [x] Pre-commit hooks pass
- [ ] Visual verification of gradient animation in browser
- [ ] Test fade-in transition when loading starts
- [ ] Test fade-out transition when loading completes
- [ ] Verify appearance in both light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)