### PR TITLE
fix: resolve 'Text file busy' error when deploying running binary

### DIFF
--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -123,10 +123,13 @@ else
 fi
 
 # Install new binary
+# Copy to temp location first, then atomically move to avoid "Text file busy" errors
 log_info "Installing new binary..."
-cp "$DEPLOY_DIR/soar" /usr/local/bin/soar
-chmod +x /usr/local/bin/soar
-chown root:root /usr/local/bin/soar
+TEMP_BINARY="/usr/local/bin/soar.new.$$"
+cp "$DEPLOY_DIR/soar" "$TEMP_BINARY"
+chmod +x "$TEMP_BINARY"
+chown root:root "$TEMP_BINARY"
+mv -f "$TEMP_BINARY" /usr/local/bin/soar
 log_info "Binary installed successfully"
 
 # Install service files


### PR DESCRIPTION
## Summary
Fixes deployment failure with "Text file busy" error when trying to replace the soar binary while it's running.

## Problem
The deployment script was failing with:
```
cp: cannot create regular file '/usr/local/bin/soar': Text file busy
```

This occurs because `cp` cannot directly overwrite an executable file that is currently in use by the kernel. The running process has the file locked, preventing direct file content modification.

## Solution
Changed the binary installation process to use an atomic move operation instead of direct copy:

1. Copy new binary to temporary file with unique PID suffix (`soar.new.$$`)
2. Set permissions and ownership on temp file
3. Use `mv -f` to atomically replace the old binary

The `mv` operation works because it updates the inode reference rather than trying to overwrite the file content. This allows:
- Running processes to continue using the old inode until they exit
- New processes to immediately use the new binary
- Zero-downtime deployment

## Changes
- **infrastructure/soar-deploy:126-133** - Updated binary installation to use temp file + atomic move

## Testing
- [x] Bash syntax validation passed
- [x] Pre-commit hooks passed

The fix ensures deployments can proceed without requiring services to be stopped first, maintaining the current zero-downtime deployment strategy.