### PR TITLE
feat: expose Grafana at grafana.glider.flights

### DIFF
--- a/infrastructure/Caddyfile
+++ b/infrastructure/Caddyfile
@@ -1,0 +1,21 @@
+# Caddy configuration for glider.flights
+# This file should be imported by the main Caddyfile on the server.
+#
+# Import this file by adding to /usr/local/etc/caddy/Caddyfile:
+#   import /path/to/soar/infrastructure/Caddyfile
+
+# Main SOAR application
+glider.flights {
+	reverse_proxy localhost:61225
+	log {
+		output file /var/log/caddy/glider.flights.log
+	}
+}
+
+# Grafana monitoring dashboard
+grafana.glider.flights {
+	reverse_proxy localhost:3000
+	log {
+		output file /var/log/caddy/grafana.glider.flights.log
+	}
+}


### PR DESCRIPTION
## Summary

- Add version-controlled Caddy configuration in `infrastructure/Caddyfile`
- Separate glider.flights-specific configuration from multi-site server Caddyfile
- Expose Grafana monitoring dashboard at grafana.glider.flights (port 3000)

## Changes

- Created `infrastructure/Caddyfile` with configurations for:
  - `glider.flights`: main SOAR application (port 61225)
  - `grafana.glider.flights`: Grafana dashboard (port 3000)

## Deployment

The main server Caddyfile has been updated to import this file from `/var/soar/infrastructure/Caddyfile`. When this branch is deployed, the configuration will be automatically used.

## Test plan

- [x] Validate Caddy configuration syntax
- [x] Test glider.flights continues to work (currently showing 502 as expected when app is down)
- [x] Test grafana.glider.flights redirects to /login (Grafana is accessible)
- [x] Verify SSL certificate auto-provisioning via Let's Encrypt
- [ ] After merge: Verify Grafana dashboard is accessible at https://grafana.glider.flights
- [ ] After merge: Confirm main site remains functional at https://glider.flights