### PR TITLE
fix: force-kill processes blocking symlink creation during deployment

### DIFF
--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -129,9 +129,41 @@ for timer in "${TIMERS[@]}"; do
     fi
 done
 
+# Wait for services to fully terminate and release file handles
+log_info "Waiting for services to fully terminate..."
+sleep 3
+
 # Update /usr/local/bin/soar symlink to point to new version
 # This allows non-APRS services to use the new binary when they restart
 log_info "Updating /usr/local/bin/soar symlink to point to new version..."
+
+# If /usr/local/bin/soar is a regular file (not a symlink), we need to handle it specially
+if [ -f /usr/local/bin/soar ] && [ ! -L /usr/local/bin/soar ]; then
+    log_warn "/usr/local/bin/soar is a regular file, not a symlink. Converting to symlink..."
+
+    # Check if any process is using it
+    if command -v lsof >/dev/null 2>&1; then
+        PROCESSES_USING_BINARY=$(lsof /usr/local/bin/soar 2>/dev/null | tail -n +2 || true)
+        if [ -n "$PROCESSES_USING_BINARY" ]; then
+            log_warn "Processes still using /usr/local/bin/soar:"
+            echo "$PROCESSES_USING_BINARY"
+            log_warn "Force-killing processes to allow symlink creation..."
+            lsof -t /usr/local/bin/soar 2>/dev/null | xargs -r kill -9 || true
+            sleep 2
+        fi
+    fi
+
+    # Remove the old file and create symlink
+    rm -f /usr/local/bin/soar || {
+        log_error "Cannot remove /usr/local/bin/soar - still in use"
+        log_error "Trying one more time with force kill..."
+        pkill -9 -f /usr/local/bin/soar || true
+        sleep 2
+        rm -f /usr/local/bin/soar
+    }
+fi
+
+# Create or update the symlink
 ln -sf "${VERSIONED_BINARY}" /usr/local/bin/soar
 log_info "Symlink updated successfully"
 


### PR DESCRIPTION
## Problem
After merging PR #245 (zero-downtime deployment with versioned binaries), the first deployment fails with:
```
[INFO] Installing new binary to /usr/local/bin/soar-20250102-150405...
[INFO] Updating /usr/local/bin/soar symlink to point to new version...
cp: cannot create regular file '/usr/local/bin/soar': Text file busy
```

## Root Cause
On the **first deployment** with the new versioned binary approach:
- `/usr/local/bin/soar` is still a **regular binary file** (old approach)
- After `systemctl stop`, some processes may still have the file open
- Cannot remove the file to convert it to a symlink → "Text file busy" error

On **subsequent deployments**:
- `/usr/local/bin/soar` is already a **symlink**
- `ln -sf` just updates the symlink target
- No "Text file busy" errors occur

## Solution
Add robust handling for the migration from regular file to symlink:

### 1. Wait for Processes to Terminate
```bash
# After stopping services, wait 3 seconds
sleep 3
```

### 2. Detect Migration Scenario
```bash
if [ -f /usr/local/bin/soar ] && [ ! -L /usr/local/bin/soar ]; then
    # It's a regular file, not a symlink
    # Need special handling
fi
```

### 3. Multi-Layer Force-Kill
```bash
# First: Use lsof to find processes and kill -9 them
lsof -t /usr/local/bin/soar | xargs -r kill -9

# Second: Fallback to pkill if needed
pkill -9 -f /usr/local/bin/soar

# Third: Remove file and create symlink
rm -f /usr/local/bin/soar
ln -sf "${VERSIONED_BINARY}" /usr/local/bin/soar
```

## Why This Works
- **First deployment**: Forces migration from file to symlink
- **Subsequent deployments**: Just updates symlink (no force-kill needed)
- **Diagnostic info**: Shows which processes were holding the file
- **Robust**: Multiple fallback layers ensure success

## Testing
- [x] Bash syntax validation passed
- [x] Pre-commit hooks passed
- [ ] Test first deployment with regular file
- [ ] Verify subsequent deployments work without force-kill

## Related
- Fixes the issue reported after merging PR #245
- Completes the zero-downtime deployment implementation
- One-time migration issue, won't occur on future deployments

## Migration Path
```
Before: /usr/local/bin/soar (regular file)
         ↓ First deployment with this fix
After:  /usr/local/bin/soar -> /usr/local/bin/soar-20250102-150405 (symlink)
         ↓ Subsequent deployments
        /usr/local/bin/soar -> /usr/local/bin/soar-20250103-120000 (updated symlink)
```