### PR TITLE
fix: change aprs_messages.receiver_id foreign key to ON DELETE CASCADE

### DIFF
--- a/migrations/2025-11-03-231124-0000_fix_aprs_messages_receiver_fk_constraint/down.sql
+++ b/migrations/2025-11-03-231124-0000_fix_aprs_messages_receiver_fk_constraint/down.sql
@@ -1,0 +1,13 @@
+-- Revert foreign key constraint back to ON DELETE SET NULL
+-- Note: This down migration will fail if receiver_id is still NOT NULL
+-- You would need to make receiver_id nullable first
+
+-- Drop the CASCADE constraint
+ALTER TABLE aprs_messages
+    DROP CONSTRAINT IF EXISTS aprs_messages_receiver_id_fkey;
+
+-- Add back the SET NULL constraint
+-- WARNING: This will fail if receiver_id is NOT NULL
+ALTER TABLE aprs_messages
+    ADD CONSTRAINT aprs_messages_receiver_id_fkey
+    FOREIGN KEY (receiver_id) REFERENCES receivers(id) ON DELETE SET NULL;

--- a/migrations/2025-11-03-231124-0000_fix_aprs_messages_receiver_fk_constraint/up.sql
+++ b/migrations/2025-11-03-231124-0000_fix_aprs_messages_receiver_fk_constraint/up.sql
@@ -1,0 +1,13 @@
+-- Fix foreign key constraint on aprs_messages.receiver_id
+-- The constraint was ON DELETE SET NULL but receiver_id is now NOT NULL
+-- This caused errors when deleting receivers
+-- Change to ON DELETE CASCADE since receiver_id is required
+
+-- Drop the old constraint
+ALTER TABLE aprs_messages
+    DROP CONSTRAINT IF EXISTS aprs_messages_receiver_id_fkey;
+
+-- Add new constraint with ON DELETE CASCADE
+ALTER TABLE aprs_messages
+    ADD CONSTRAINT aprs_messages_receiver_id_fkey
+    FOREIGN KEY (receiver_id) REFERENCES receivers(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Summary
- Fixed failing test `test_insert_and_get_by_id` in `aprs_messages_repo`
- Changed foreign key constraint on `aprs_messages.receiver_id` from `ON DELETE SET NULL` to `ON DELETE CASCADE`
- Created migration `2025-11-03-231124-0000_fix_aprs_messages_receiver_fk_constraint`

## Problem
The test was failing during cleanup with:
```
DatabaseError(NotNullViolation, "null value in column \"receiver_id\" of relation \"aprs_messages\" violates not-null constraint")
```

## Root Cause
There was an inconsistency between two migrations:
1. Migration `2025-10-15-083717` added `receiver_id` column with `ON DELETE SET NULL`
2. Migration `2025-10-22-170948` later made `receiver_id` NOT NULL

When test cleanup deleted receivers, PostgreSQL tried to SET NULL on `receiver_id` (per the foreign key constraint), which violated the NOT NULL constraint.

## Solution
Changed the foreign key constraint to `ON DELETE CASCADE`. Since `receiver_id` is a required field (NOT NULL), APRS messages should be automatically deleted when their associated receiver is deleted.

## Testing
- All 5 APRS messages repository tests now pass ✓
- Pre-commit hooks pass (formatting, clippy, etc.)
- Migration tested on `soar_dev` database

## Migration Details
The migration:
1. Drops the old `aprs_messages_receiver_id_fkey` constraint
2. Adds a new constraint with `ON DELETE CASCADE`

This is a safe change as it maintains referential integrity while fixing the constraint violation issue.