### PR TITLE
fix: ACK unparseable messages and increase max_ack_pending

### DIFF
--- a/src/aprs_jetstream_consumer.rs
+++ b/src/aprs_jetstream_consumer.rs
@@ -51,6 +51,7 @@ impl JetStreamConsumer {
             ack_policy: AckPolicy::Explicit, // Require explicit ack after processing
             deliver_policy: DeliverPolicy::All, // Start from beginning for new consumers
             filter_subject: subject,
+            max_ack_pending: 50_000, // Allow 50K unACKed messages (default 1000 is too low for slow workers)
             ..Default::default()
         };
 


### PR DESCRIPTION
## Summary

Fixes critical performance regression from ~1000 msg/s to ~25 msg/s in soar-run.

**Root cause**: Messages that failed to parse were never ACKed, causing JetStream to stop delivering after 1000 unACKed messages accumulated.

## Changes

1. **ACK unparseable messages** (src/commands/run.rs:98-105)
   - When `ogn-parser::parse()` fails, now ACK the message immediately
   - Prevents unparseable messages from blocking the queue
   - Adds `aprs.jetstream.acked_unparseable` metric

2. **Increase max_ack_pending** (src/aprs_jetstream_consumer.rs:54)
   - Raised from 1000 (default) to 50,000
   - Allows JetStream to deliver more messages while workers catch up
   - Prevents flow control issues when workers are temporarily slow

## Problem Analysis

Before the ACK refactor (commit 377883a0), messages were ACKed immediately after routing. After the refactor, ACKs happen after worker processing. This exposed the bug:

- Unparseable messages (like OGNFNT with bad coordinates) were logged but never ACKed
- JetStream's `max_ack_pending` limit (default: 1000) was reached
- JetStream stopped delivering new messages once limit was hit
- System appeared to stall at ~25 msg/s (only processing very old backlog)

## Test Plan

- [x] Cargo fmt, clippy pass
- [x] Pre-commit hooks pass
- [ ] Deploy and verify throughput returns to ~1000 msg/s
- [ ] Monitor `aprs.jetstream.acked_unparseable` metric
- [ ] Check that queue depth returns to normal

## Monitoring

After deployment, watch for:
- `aprs.jetstream.consumed` should increase rapidly
- `aprs.jetstream.acked_after_processing` should match consumed count
- `aprs.jetstream.acked_unparseable` should show unparseable message count
- Processing rate should return to ~1000 msg/s