### PR TITLE
perf: increase aircraft workers from 20 to 80

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -452,8 +452,10 @@ pub async fn handle_run(
     }
 
     // Spawn dedicated worker pools for each processor type
-    // Aircraft position workers (20 workers - heaviest processing due to FixProcessor + flight tracking)
-    let num_aircraft_workers = 20;
+    // Aircraft position workers (80 workers - heaviest processing due to FixProcessor + flight tracking)
+    // Increased from 20 to 80 because aircraft queue was constantly full at 1,000 capacity
+    // Most APRS messages (~80-90%) are aircraft positions, so this queue needs the most workers
+    let num_aircraft_workers = 80;
     info!(
         "Spawning {} aircraft position workers",
         num_aircraft_workers


### PR DESCRIPTION
## Problem

The aircraft processing queue was **constantly full at 1,000 capacity** while other processor queues (receiver status, receiver position) were always empty.

## Root Cause Analysis

With the new intake queue architecture from PR #285:
- 10 intake workers can sustain ~1000 msg/s with immediate ACKs
- **80-90% of APRS messages are aircraft positions**
- That means ~800-900 aircraft messages/second entering the aircraft queue
- 20 aircraft workers couldn't keep up with this volume
- Result: Aircraft queue perpetually saturated at 1,000 messages

## Solution

**Increase aircraft workers from 20 to 80** (4x increase)

This provides:
- ~8 aircraft workers per intake worker (good ratio for heavy processing)
- Enough parallelism to handle ~800-900 aircraft msg/s
- Headroom for burst traffic without saturation

## Why 80 Workers?

Aircraft processing is the most CPU and database intensive:
- Device lookup (database)
- Fix creation and validation
- Flight tracking (in-memory state + database)
- Elevation calculations (may queue to elevation workers)
- NATS publishing (network I/O)

With this workload complexity, we need high parallelism to match the intake rate.

## Expected Impact

**Before:**
- Aircraft queue: Always full at 1,000/1,000
- Bottleneck limiting overall throughput
- Messages backing up despite intake queue improvements

**After:**
- Aircraft queue should stabilize at healthy levels (200-600 range)
- Full throughput capability of ~1000 msg/s
- No artificial bottleneck from worker count

## Testing

- ✅ Code compiles successfully
- ✅ Pre-commit hooks pass
