### PR TITLE
feat: add JetStream intake queue for graceful shutdown

### DIFF
--- a/src/queue_config.rs
+++ b/src/queue_config.rs
@@ -82,6 +82,12 @@ pub const ELEVATION_QUEUE_SIZE: usize = 1_000;
 /// Reduced from 10K since AGL is optional data (can be recalculated)
 pub const AGL_DATABASE_QUEUE_SIZE: usize = 100;
 
+/// JetStream intake queue for buffering raw APRS messages from JetStream
+/// Medium queue (1,000 messages) to buffer between JetStream consumer and processing
+/// Allows graceful shutdown by stopping JetStream reads and draining this queue
+/// At ~30 msg/s current rate, this provides ~33 seconds of buffering
+pub const JETSTREAM_INTAKE_QUEUE_SIZE: usize = 1_000;
+
 /// Calculate the warning threshold for queue depth monitoring
 ///
 /// Returns 80% of queue capacity as the warning threshold. When a queue


### PR DESCRIPTION
## Summary
- Add 1,000 message intake queue between JetStream consumer and processing pipeline
- Enable proper graceful shutdown by decoupling JetStream reads from message processing
- Add metrics for intake queue depth and processing rate

## Changes
- Add `JETSTREAM_INTAKE_QUEUE_SIZE` constant (1,000 messages)
- Create flume bounded channel for intake queue
- Spawn intake processor task to consume from queue
- Update JetStream consumer to send to intake queue instead of processing directly
- Update shutdown handler to monitor intake queue depth
- Add metrics: `aprs.intake.processed` counter and `aprs.intake_queue.depth` gauge

## Benefits
- **Graceful shutdown**: On Ctrl+C, JetStream stops reading and intake queue drains completely before exit
- **Better throughput**: Decouples JetStream consumption from processing, allowing better message flow
- **Improved visibility**: Intake queue metrics help monitor the pipeline health
- **Maintains backpressure**: Blocking sends ensure we don't overwhelm downstream processing

## Context
Currently reading ~30 msg/s with 10M+ messages to process. The intake queue provides:
- ~33 seconds of buffering at current rate
- Clean separation between consumption and processing
- Foundation for improved throughput once downstream bottlenecks are resolved

## Test Plan
- [x] All unit tests pass
- [x] Code compiles with no warnings
- [x] Pre-commit hooks pass