### PR TITLE
perf: parallelize APRS message processing with PacketRouter worker pool

### DIFF
--- a/src/packet_processors/generic.rs
+++ b/src/packet_processors/generic.rs
@@ -18,9 +18,6 @@ pub struct PacketContext {
     /// Timestamp when the message was received from APRS-IS
     /// This is captured at ingestion time to prevent clock skew from queue processing delays
     pub received_at: chrono::DateTime<chrono::Utc>,
-    /// JetStream message handle for ACKing after processing
-    /// This is None for non-JetStream sources (e.g., archive replay)
-    pub jetstream_msg: Option<Arc<async_nats::jetstream::Message>>,
 }
 
 /// Generic processor that handles archiving, receiver identification, and APRS message insertion
@@ -68,7 +65,6 @@ impl GenericProcessor {
         packet: &AprsPacket,
         raw_message: &str,
         received_at: chrono::DateTime<chrono::Utc>,
-        jetstream_msg: Option<Arc<async_nats::jetstream::Message>>,
     ) -> Option<PacketContext> {
         // Step 1: Archive the raw message if archiving is enabled
         if let Some(archive) = &self.archive_service {
@@ -135,7 +131,6 @@ impl GenericProcessor {
                     aprs_message_id: id,
                     receiver_id,
                     received_at: received_at_timestamp,
-                    jetstream_msg,
                 })
             }
             Err(e) => {


### PR DESCRIPTION
## Problem

The single intake worker was the bottleneck in message processing. It could only process messages sequentially, blocking on database inserts (receiver lookup/insert + APRS message insert) for every message.

**Observed symptoms:**
- JetStream intake queue constantly full (1000/1000 messages)
- 12.6 hours of processing lag
- Only ~1 thread utilizing database connections while 75 aircraft workers sat idle

## Solution

Added internal worker pool (10 workers) to PacketRouter with a 1000-message internal queue.

### New Architecture:

```
Before:
JetStream → intake_queue (1K) → [1 worker] → PacketRouter (blocking DB ops) → downstream queues

After:
JetStream → intake_queue (1K) → PacketRouter internal queue (1K) → [10 workers] → downstream queues
                                                                          ↓
                                                                  Parallel DB operations
```

### Changes:

1. **PacketRouter internal worker pool**:
   - Created `MessageTask` enum for queuing packet/server message processing
   - Added internal bounded queue (1000 capacity)
   - Spawned 10 workers on initialization
   - Workers pull tasks and call `process_packet_internal()` / `process_server_message_internal()`
   - Added `aprs.router.internal_queue_depth` and `aprs.router.internal_queue_full` metrics

2. **API simplification**:
   - `process_packet()` and `process_server_message()` are now non-async (just enqueue)
   - Removed `jetstream_msg` parameter from PacketRouter and GenericProcessor (no longer needed)
   - Boxed `AprsPacket` in `MessageTask` enum to reduce size (596B → manageable)

3. **Archive service**:
   - Already has internal queue - no changes needed (confirmed at src/aprs_client.rs:713)

## Performance Impact

**Expected improvements:**
- **10x parallelization** of database operations
- Intake queue can drain faster (no longer blocked on sequential DB inserts)
- Better database connection pool utilization
- Reduced JetStream lag

**Memory impact:**
- Internal queue: 1000 messages × ~36-50 bytes per task ≈ 36-50 KB
- Minimal overhead compared to throughput gains

## Testing

- ✅ Compiles with `cargo build --release`
- ✅ All clippy lints pass
- ✅ Pre-commit hooks pass

## Deployment

After merging, production `soar-run` service should see:
1. Intake queue depth decrease from 1000
2. JetStream lag decrease
3. Higher database connection utilization
4. New metric: `aprs_router_internal_queue_depth`

Monitor for:
- Any increase in `aprs_router_internal_queue_full` (indicates workers can't keep up)
- Database connection pool saturation (may need to increase pool size)