### PR TITLE
Fix packet router queue overflow issue

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -60,7 +60,9 @@ async fn process_aprs_message(
     // Server messages don't create PacketContext
     if actual_message.starts_with('#') {
         info!("Server message: {}", actual_message);
-        packet_router.process_server_message(actual_message, received_at);
+        packet_router
+            .process_server_message(actual_message, received_at)
+            .await;
         return;
     }
 
@@ -68,7 +70,9 @@ async fn process_aprs_message(
     match ogn_parser::parse(actual_message) {
         Ok(parsed) => {
             // Call PacketRouter to archive, process, and route to queues
-            packet_router.process_packet(parsed, actual_message, received_at);
+            packet_router
+                .process_packet(parsed, actual_message, received_at)
+                .await;
         }
         Err(e) => {
             // For OGNFNT sources with invalid lat/lon, log as trace instead of error


### PR DESCRIPTION
Changed PacketRouter.process_packet() and process_server_message() to use blocking send_async() instead of try_send(), ensuring packets are never dropped when the internal queue is full. The methods now wait for space to become available rather than dropping messages.

This change prevents data loss during high traffic periods when the internal queue fills up. The queue will now apply backpressure to the message intake rather than silently dropping packets.

Changes:
- Made process_packet() and process_server_message() async
- Replaced try_send() with send_async().await
- Updated call sites to await the async methods
- Changed metric from internal_queue_full to internal_queue_disconnected