### PR TITLE
fix: eliminate all queue drops across the system

### DIFF
--- a/src/fix_processor.rs
+++ b/src/fix_processor.rs
@@ -443,7 +443,9 @@ impl FixProcessor {
             };
 
             let fix_with_flight = crate::fixes::FixWithFlightInfo::new(updated_fix.clone(), flight);
-            nats_publisher.process_fix(fix_with_flight, raw_message);
+            nats_publisher
+                .process_fix(fix_with_flight, raw_message)
+                .await;
             metrics::histogram!("aprs.aircraft.nats_publish_ms")
                 .record(nats_publish_start.elapsed().as_micros() as f64 / 1000.0);
         }

--- a/src/packet_processors/generic.rs
+++ b/src/packet_processors/generic.rs
@@ -68,7 +68,7 @@ impl GenericProcessor {
     ) -> Option<PacketContext> {
         // Step 1: Archive the raw message if archiving is enabled
         if let Some(archive) = &self.archive_service {
-            archive.archive(raw_message);
+            archive.archive(raw_message).await;
         }
 
         // Step 2: Identify the receiver callsign
@@ -191,10 +191,10 @@ impl GenericProcessor {
     }
 
     /// Process a server message (lines starting with #) - archives only, no database insertion
-    pub fn process_server_message(&self, raw_message: &str) {
+    pub async fn process_server_message(&self, raw_message: &str) {
         // Archive the server message if archiving is enabled
         if let Some(archive) = &self.archive_service {
-            archive.archive(raw_message);
+            archive.archive(raw_message).await;
         }
         // Server messages are just archived, not processed further in GenericProcessor
         // They will be routed to ServerStatusProcessor for database insertion

--- a/src/packet_processors/router.rs
+++ b/src/packet_processors/router.rs
@@ -171,7 +171,9 @@ impl PacketRouter {
         received_at: chrono::DateTime<chrono::Utc>,
     ) {
         // Step 1: Archive via GenericProcessor
-        self.generic_processor.process_server_message(raw_message);
+        self.generic_processor
+            .process_server_message(raw_message)
+            .await;
 
         // Step 2: Route to server status queue if configured
         if let Some(tx) = &self.server_status_tx {


### PR DESCRIPTION
Extended the fix from the previous commit to all remaining queues that were dropping data. All queues now use blocking send_async() instead of try_send(), ensuring no data loss anywhere in the system.

Changes:
- APRS client raw message queue: Changed to blocking send
- Archive writer: Made archive() async with blocking send
- NATS fix publisher: Made process_fix() async with blocking send
- AGL database queue: Changed to blocking send
- Updated all call sites to await the now-async methods

All queues now apply backpressure when full rather than dropping data. This prevents any data loss during high traffic periods across:
- Message intake from APRS-IS
- Archive writing
- NATS publishing
- Elevation/AGL database updates