### PR TITLE
fix(a11y): add keyboard handlers to modal backdrops in profile page

### DIFF
--- a/web/src/routes/profile/+page.svelte
+++ b/web/src/routes/profile/+page.svelte
@@ -309,6 +309,8 @@
 	<div
 		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
 		onclick={closeChangeEmailModal}
+		onkeydown={(e) => e.key === 'Escape' && closeChangeEmailModal()}
+		role="presentation"
 	>
 		<div class="m-4 w-full max-w-md space-y-4 card p-6" onclick={(e) => e.stopPropagation()}>
 			<div class="flex items-center justify-between">
@@ -379,6 +381,8 @@
 	<div
 		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
 		onclick={closeDeleteAccountModal}
+		onkeydown={(e) => e.key === 'Escape' && closeDeleteAccountModal()}
+		role="presentation"
 	>
 		<div class="m-4 w-full max-w-md space-y-4 card p-6" onclick={(e) => e.stopPropagation()}>
 			<div class="flex items-center justify-between">


### PR DESCRIPTION
Added onkeydown handlers and role="presentation" to modal backdrop divs in the Change Email and Delete Account modals. This fixes accessibility warnings about non-interactive elements with click events needing keyboard event handlers.

- Added Escape key handler to close modals via keyboard
- Added role="presentation" for semantic clarity
- Follows pattern used in other modals across the codebase