### PR TITLE
Show 10 most recently active devices on page load

### DIFF
--- a/src/device_repo.rs
+++ b/src/device_repo.rs
@@ -204,11 +204,12 @@ impl DeviceRepository {
             .collect())
     }
 
-    /// Get recent devices with a limit
+    /// Get recent devices with a limit, ordered by last_fix_at (most recently heard from)
     pub async fn get_recent_devices(&self, limit: i64) -> Result<Vec<Device>> {
         let mut conn = self.get_connection()?;
         let device_models = devices::table
-            .order(devices::updated_at.desc().nulls_last())
+            .filter(devices::last_fix_at.is_not_null())
+            .order(devices::last_fix_at.desc())
             .limit(limit)
             .load::<DeviceModel>(&mut conn)?;
 


### PR DESCRIPTION
## Summary
Improves the devices page user experience by showing the 10 most recently heard from devices when the page loads, instead of requiring a search.

## Backend Changes
- Modified `DeviceRepository::get_recent_devices()` to:
  - Order by `last_fix_at` DESC instead of `updated_at` DESC
  - Filter out devices where `last_fix_at` is NULL
  - Returns only devices we've actually heard from
- Added `get_recent_devices_response()` handler function
- Modified `search_devices()` API endpoint to return recent devices when no search criteria provided

## Frontend Changes
- Added `loadRecentDevices()` function to fetch without query parameters
- Call `loadRecentDevices()` in `onMount` to load data on page mount
- Updated UI to show different headers based on context:
  - "Recently Active Devices" with Activity icon when showing recent devices
  - "Search Results" when showing search results
- Changed count text from "X devices found" to "X devices heard from recently" for recent view

## Benefits
- Better initial user experience - see active devices immediately
- Useful default view shows recently active aircraft
- No breaking changes - all search functionality remains the same
- Leverages existing `last_fix_at` column and index

## Testing
- ✅ Page loads with 10 most recent devices
- ✅ Search functionality still works as expected
- ✅ All pre-commit hooks pass (Rust format, clippy, frontend lint, type check)