### PR TITLE
fix: loading bar now covers full AppBar height

### DIFF
--- a/web/src/lib/components/LoadingBar.svelte
+++ b/web/src/lib/components/LoadingBar.svelte
@@ -13,7 +13,12 @@
 <style>
 	.loading-bar-overlay {
 		position: absolute;
-		inset: 0;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		width: 100%;
+		height: 100%;
 		pointer-events: none;
 		z-index: 1;
 		animation: slide 2.5s ease-in-out infinite;


### PR DESCRIPTION
## Problem
The loading gradient animation at the top of the AppBar was only covering approximately half of the AppBar's height.

## Solution
Added explicit `width: 100%` and `height: 100%` properties to the loading bar overlay to ensure it fills the entire AppBar container.

## Changes
- Changed from just `inset: 0` to also include explicit width/height properties
- This ensures the gradient fills the full AppBar vertically

## Test Plan
- [x] Trigger loading state (navigate between pages)
- [x] Verify gradient animation covers full AppBar height
- [x] Pre-commit hooks pass