### PR TITLE
fix: remove gap between AppBar and operations map

### DIFF
--- a/web/src/routes/operations/+page.svelte
+++ b/web/src/routes/operations/+page.svelte
@@ -1528,7 +1528,7 @@
 	<title>Operations - Glider Flights</title>
 </svelte:head>
 
-<div class="fixed inset-x-0 top-14 bottom-0 w-full">
+<div class="fixed inset-x-0 top-[42px] bottom-0 w-full">
 	<!-- Google Maps Container -->
 	<div bind:this={mapContainer} class="h-full w-full"></div>
 


### PR DESCRIPTION
## Problem
There was an unwanted gap between the AppBar and the operations map on the operations page. The map was positioned with `top-14` (56px) but the AppBar's actual height is only 42px.

## Solution
Changed from `top-14` to `top-[42px]` to match the exact AppBar height.

## Changes
- Updated operations page map container positioning
- Changed from Tailwind class `top-14` to arbitrary value `top-[42px]`

## Test Plan
- [x] Operations page loads correctly
- [x] No gap between AppBar and map
- [x] Map positioning is flush with AppBar
- [x] Pre-commit hooks pass