### PR TITLE
refactor: Extract device tile into reusable component

### DIFF
--- a/web/src/lib/components/DeviceTile.svelte
+++ b/web/src/lib/components/DeviceTile.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import { Radio, Plane, Antenna, Check, X, Activity } from '@lucide/svelte';
+	import { resolve } from '$app/paths';
+	import { getAircraftTypeOgnDescription, getAircraftTypeColor } from '$lib/formatters';
+	import type { Device } from '$lib/types';
+
+	let { device }: { device: Device } = $props();
+</script>
+
+<div class="card preset-tonal-primary p-4">
+	<a href={resolve(`/devices/${device.id}`)} class="group block transition-all hover:scale-[1.02]">
+		<!-- Header Section -->
+		<div class="mb-4 flex items-start justify-between">
+			<div class="flex items-center gap-2">
+				<Radio class="h-5 w-5 text-primary-500" />
+			</div>
+		</div>
+
+		<!-- Registration and Model -->
+		<div class="mb-4 space-y-2">
+			<div class="flex items-center gap-2">
+				<Plane class="h-4 w-4 text-surface-500" />
+				<div>
+					<p class="text-surface-600-300-token text-xs">Registration</p>
+					<p class="text-sm font-semibold">
+						{device.registration || 'Unknown'}
+					</p>
+				</div>
+			</div>
+			<div class="flex items-center gap-2">
+				<Antenna class="h-4 w-4 text-surface-500" />
+				<div>
+					<p class="text-surface-600-300-token text-xs">Aircraft Model</p>
+					<p class="text-sm">{device.aircraft_model || 'Unknown'}</p>
+				</div>
+			</div>
+			{#if device.competition_number}
+				<div class="flex items-center gap-2">
+					<Activity class="h-4 w-4 text-surface-500" />
+					<div>
+						<p class="text-surface-600-300-token text-xs">Competition Number</p>
+						<p class="font-mono text-sm">{device.competition_number}</p>
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		<!-- Status Badges -->
+		<div class="flex flex-wrap gap-2">
+			<span
+				class="badge text-xs {device.tracked
+					? 'preset-filled-success-500'
+					: 'preset-filled-surface-500'}"
+			>
+				{#if device.tracked}
+					<Check class="mr-1 h-3 w-3" />
+				{:else}
+					<X class="mr-1 h-3 w-3" />
+				{/if}
+				{device.tracked ? 'Tracked' : 'Not Tracked'}
+			</span>
+			<span
+				class="badge text-xs {device.identified
+					? 'preset-filled-primary-500'
+					: 'preset-filled-surface-500'}"
+			>
+				{#if device.identified}
+					<Check class="mr-1 h-3 w-3" />
+				{:else}
+					<X class="mr-1 h-3 w-3" />
+				{/if}
+				{device.identified ? 'Identified' : 'Unidentified'}
+			</span>
+			{#if device.from_ddb}
+				<span class="badge preset-filled-success-500 text-xs">
+					<Check class="mr-1 h-3 w-3" />
+					OGN DB
+				</span>
+			{/if}
+			{#if device.aircraft_type_ogn}
+				<span class="badge {getAircraftTypeColor(device.aircraft_type_ogn)} text-xs">
+					{getAircraftTypeOgnDescription(device.aircraft_type_ogn)}
+				</span>
+			{/if}
+		</div>
+	</a>
+</div>

--- a/web/src/routes/devices/+page.svelte
+++ b/web/src/routes/devices/+page.svelte
@@ -1,31 +1,11 @@
 <script lang="ts">
-	import { Search, Radio, Plane, Antenna, Building2, Check, X, Activity } from '@lucide/svelte';
+	import { Search, Radio, Plane, Antenna, Building2, Activity } from '@lucide/svelte';
 	import { SegmentedControl } from '@skeletonlabs/skeleton-svelte';
-	import { resolve } from '$app/paths';
 	import { serverCall } from '$lib/api/server';
 	import ClubSelector from '$lib/components/ClubSelector.svelte';
+	import DeviceTile from '$lib/components/DeviceTile.svelte';
 	import { onMount } from 'svelte';
-	import {
-		formatDeviceAddress,
-		getAircraftTypeOgnDescription,
-		getAircraftTypeColor
-	} from '$lib/formatters';
-
-	interface Device {
-		id?: string;
-		device_address: string;
-		address_type: string;
-		address: string;
-		aircraft_model: string;
-		registration: string;
-		competition_number: string;
-		tracked: boolean;
-		identified: boolean;
-		from_ddb?: boolean;
-		aircraft_type_ogn?: string;
-		created_at?: string;
-		updated_at?: string;
-	}
+	import type { Device } from '$lib/types';
 
 	let devices: Device[] = [];
 	let loading = false;
@@ -481,93 +461,7 @@
 			<!-- Device Cards Grid -->
 			<div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
 				{#each paginatedDevices as device (device.id || device.address)}
-					<a
-						href={resolve(`/devices/${device.id}`)}
-						class="group card p-5 card-hover transition-all hover:scale-[1.02]"
-					>
-						<!-- Header Section -->
-						<div class="mb-4 flex items-start justify-between">
-							<div class="flex items-center gap-2">
-								<Radio class="h-5 w-5 text-primary-500" />
-								<div>
-									<h3 class="font-mono text-lg font-bold group-hover:text-primary-500">
-										{device.device_address}
-									</h3>
-									<p class="text-surface-600-300-token text-xs">
-										{formatDeviceAddress(device.address_type, device.address)}
-									</p>
-								</div>
-							</div>
-						</div>
-
-						<!-- Registration and Model -->
-						<div class="mb-4 space-y-2">
-							<div class="flex items-center gap-2">
-								<Plane class="h-4 w-4 text-surface-500" />
-								<div>
-									<p class="text-surface-600-300-token text-xs">Registration</p>
-									<p class="text-sm font-semibold">
-										{device.registration || 'Unknown'}
-									</p>
-								</div>
-							</div>
-							<div class="flex items-center gap-2">
-								<Antenna class="h-4 w-4 text-surface-500" />
-								<div>
-									<p class="text-surface-600-300-token text-xs">Aircraft Model</p>
-									<p class="text-sm">{device.aircraft_model || 'Unknown'}</p>
-								</div>
-							</div>
-							{#if device.competition_number}
-								<div class="flex items-center gap-2">
-									<Activity class="h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token text-xs">Competition Number</p>
-										<p class="font-mono text-sm">{device.competition_number}</p>
-									</div>
-								</div>
-							{/if}
-						</div>
-
-						<!-- Status Badges -->
-						<div class="flex flex-wrap gap-2">
-							<span
-								class="badge text-xs {device.tracked
-									? 'preset-filled-success-500'
-									: 'preset-filled-surface-500'}"
-							>
-								{#if device.tracked}
-									<Check class="mr-1 h-3 w-3" />
-								{:else}
-									<X class="mr-1 h-3 w-3" />
-								{/if}
-								{device.tracked ? 'Tracked' : 'Not Tracked'}
-							</span>
-							<span
-								class="badge text-xs {device.identified
-									? 'preset-filled-primary-500'
-									: 'preset-filled-surface-500'}"
-							>
-								{#if device.identified}
-									<Check class="mr-1 h-3 w-3" />
-								{:else}
-									<X class="mr-1 h-3 w-3" />
-								{/if}
-								{device.identified ? 'Identified' : 'Unidentified'}
-							</span>
-							{#if device.from_ddb}
-								<span class="badge preset-filled-success-500 text-xs">
-									<Check class="mr-1 h-3 w-3" />
-									OGN DB
-								</span>
-							{/if}
-							{#if device.aircraft_type_ogn}
-								<span class="badge {getAircraftTypeColor(device.aircraft_type_ogn)} text-xs">
-									{getAircraftTypeOgnDescription(device.aircraft_type_ogn)}
-								</span>
-							{/if}
-						</div>
-					</a>
+					<DeviceTile {device} />
 				{/each}
 			</div>
 


### PR DESCRIPTION
## Summary
- Created `DeviceTile` component with card styling (`preset-tonal-primary`)
- Removed redundant device address title from tile header (ICAO-XXXXXX display)
- Imported `Device` type from shared `$lib/types` instead of duplicating interface
- Updated devices page to use the new reusable component

## Changes
- **New file**: `web/src/lib/components/DeviceTile.svelte` - Reusable device tile component
- **Modified**: `web/src/routes/devices/+page.svelte` - Now uses DeviceTile component

## Benefits
- Reduced code duplication by 110 lines
- Improved maintainability with centralized Device type definition
- Cleaner UI with card styling and no redundant title