### PR TITLE
feat: Add device title display and backend aircraft type filtering

### DIFF
--- a/web/src/lib/components/DeviceTile.svelte
+++ b/web/src/lib/components/DeviceTile.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
 	import { Radio, Plane, Antenna, Check, X, Activity } from '@lucide/svelte';
 	import { resolve } from '$app/paths';
-	import { getAircraftTypeOgnDescription, getAircraftTypeColor } from '$lib/formatters';
+	import {
+		getAircraftTypeOgnDescription,
+		getAircraftTypeColor,
+		getDeviceTitle
+	} from '$lib/formatters';
 	import type { Device } from '$lib/types';
 
 	let { device }: { device: Device } = $props();
@@ -13,6 +17,7 @@
 		<div class="mb-4 flex items-start justify-between">
 			<div class="flex items-center gap-2">
 				<Radio class="h-5 w-5 text-primary-500" />
+				<h3 class="text-lg font-semibold">{getDeviceTitle(device)}</h3>
 			</div>
 		</div>
 

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -184,3 +184,46 @@ export function formatTransponderCode(transponderCode: number | null | undefined
 	// Convert to hex and pad to 6 digits
 	return transponderCode.toString(16).toUpperCase().padStart(6, '0');
 }
+
+/**
+ * Get the title/display name for a device card
+ * Priority:
+ * 1. If both registration and aircraft_model: "Model - Registration" (e.g., "Piper Pawnee - N4606Y")
+ * 2. If only registration: registration
+ * 3. If only aircraft_model: aircraft_model
+ * 4. If no registration but has competition_number: competition_number
+ * 5. Otherwise: device_address (e.g., "FLARM-A0B380")
+ */
+export function getDeviceTitle(device: {
+	registration?: string | null;
+	aircraft_model?: string | null;
+	competition_number?: string | null;
+	device_address: string;
+}): string {
+	const hasRegistration = device.registration && device.registration.trim() !== '';
+	const hasModel = device.aircraft_model && device.aircraft_model.trim() !== '';
+	const hasCompetition = device.competition_number && device.competition_number.trim() !== '';
+
+	// If both registration and model are available
+	if (hasRegistration && hasModel) {
+		return `${device.aircraft_model} - ${device.registration}`;
+	}
+
+	// If only registration
+	if (hasRegistration) {
+		return device.registration!;
+	}
+
+	// If only model
+	if (hasModel) {
+		return device.aircraft_model!;
+	}
+
+	// If no registration but has competition number
+	if (hasCompetition) {
+		return device.competition_number!;
+	}
+
+	// Default to device address
+	return device.device_address;
+}


### PR DESCRIPTION
## Summary
This PR adds device title display to device cards and implements backend aircraft type filtering for the recently active devices view.

## Changes

### Frontend
- **Device Title Display**: Added `getDeviceTitle()` formatter function that intelligently displays device names with the following priority:
  1. Model + Registration (e.g., "Piper Pawnee - N4606Y")
  2. Registration only
  3. Aircraft model only
  4. Competition number (if no registration)
  5. Device address (e.g., "FLARM-A0B380")
- **DeviceTile Component**: Updated to display titles in card headers
- **Devices Page**: Removed incorrect static device count text
- **Aircraft Type Filter**: Added filter UI with clickable badges for all OGN aircraft types:
  - Glider, Tow/Tug, Reciprocating Engine, Jet/Turboprop, Helicopter/Gyro
  - Paraglider, Hang Glider, Skydiver/Parachute, Drop Plane
  - Balloon, Airship, UAV, Static Obstacle
- **Svelte 5 Updates**: Migrated to Svelte 5 runes (`$state`, `$derived`) and `SvelteSet` for reactive state

### Backend
- **API Endpoint**: Added `aircraft-types` query parameter to `/devices` endpoint (accepts comma-separated list)
- **Device Repository**: Updated `get_recent_devices()` to accept optional aircraft type filters
- **Efficient Filtering**: Implemented SQL-level filtering using Diesel's `eq_any()` method for performance

## Test Plan
- [x] Frontend builds successfully
- [x] Backend compiles and passes clippy
- [x] All pre-commit hooks pass
- [x] Linting passes
- [ ] Manual testing: Verify device titles display correctly for various device types
- [ ] Manual testing: Verify aircraft type filter works and queries backend correctly
- [ ] Manual testing: Verify filter combinations work as expected