### PR TITLE
feat: Add APRS type suppression to reduce database load

### DIFF
--- a/soar-run.service
+++ b/soar-run.service
@@ -10,7 +10,7 @@ Type=simple
 User=soar
 Group=soar
 WorkingDirectory=/var/soar
-ExecStart=/usr/local/bin/soar run --archive
+ExecStart=/usr/local/bin/soar run --archive --suppress-aprs-type OGADSB
 ExecReload=/bin/kill -s HUP $MAINPID
 
 # Environment variables

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,6 +130,11 @@ enum Commands {
         /// NATS server URL for JetStream consumer and pub/sub
         #[arg(long, default_value = "nats://localhost:4222")]
         nats_url: String,
+
+        /// APRS type(s) to suppress from processing (e.g., OGADSB, OGFLR)
+        /// Can be specified multiple times to suppress multiple types
+        #[arg(long)]
+        suppress_aprs_type: Vec<String>,
     },
     /// Start the web server
     Web {
@@ -717,6 +722,7 @@ async fn main() -> Result<()> {
             archive_dir,
             archive,
             nats_url,
+            suppress_aprs_type,
         } => {
             // Determine archive directory if --archive flag is used
             let final_archive_dir = if archive {
@@ -725,7 +731,13 @@ async fn main() -> Result<()> {
                 archive_dir
             };
 
-            handle_run(final_archive_dir, nats_url, diesel_pool).await
+            handle_run(
+                final_archive_dir,
+                nats_url,
+                &suppress_aprs_type,
+                diesel_pool,
+            )
+            .await
         }
         Commands::Web { interface, port } => {
             // Check SOAR_ENV and override port if not production


### PR DESCRIPTION
## Summary
Adds `--suppress-aprs-type` command-line flag to filter out specific APRS types from being processed, addressing performance issues from high-volume ADS-B data.

## Problem
OGADSB (ADS-B) fixes are causing significant performance problems due to their high volume. Many of these are from aircraft that aren't relevant to soaring operations but still get processed, creating unnecessary database load.

## Solution
Add early filtering based on APRS packet type (the `to` field, e.g., "OGADSB", "OGFLR") before any database operations occur.

## Changes

### Core Changes
1. **CLI Parameter**: Added `--suppress-aprs-type` to `Run` command (can be specified multiple times)
2. **Fix Processor**: 
   - Added `suppressed_aprs_types: Vec<String>` field
   - Added `with_suppressed_aprs_types()` builder method
   - Early return in `process_aprs_packet()` if type is suppressed
3. **Metric**: Added `aprs.fixes.suppressed` counter for monitoring
4. **Systemd Service**: Updated `soar-run.service` to suppress OGADSB by default

### Benefits
- **No database operations** for suppressed types (device lookup, fix creation, flight tracking all skipped)
- **Immediate performance improvement** for high-volume ADS-B data
- **Flexible**: Can suppress multiple types if needed
- **Observable**: Logs suppressed types at startup + metric for monitoring

## Usage

```bash
# Suppress single type
soar run --suppress-aprs-type OGADSB

# Suppress multiple types
soar run --suppress-aprs-type OGADSB --suppress-aprs-type OGFLR

# Production (via systemd)
ExecStart=/usr/local/bin/soar run --archive --suppress-aprs-type OGADSB
```

## Testing

- ✅ Compiles successfully
- ✅ Clippy passes
- ✅ Pre-commit hooks pass
- ⚠️ Manual testing needed: Verify OGADSB fixes are suppressed in production

## Deployment Notes

After merging:
1. Deploy new binary to production
2. Reload systemd service: `sudo systemctl daemon-reload && sudo systemctl restart soar-run`
3. Monitor `aprs.fixes.suppressed` metric to confirm filtering is working
4. Watch for reduced database load and improved performance

## Future Enhancements

Could add configuration file support for suppressed types instead of CLI flags, but this provides immediate relief for the current issue.