### PR TITLE
Fix: Restore raw APRS message display in device fixes

### DIFF
--- a/src/actions/devices.rs
+++ b/src/actions/devices.rs
@@ -40,7 +40,7 @@ pub struct FlightsQuery {
 
 #[derive(Debug, Serialize)]
 pub struct PaginatedFixesResponse {
-    pub fixes: Vec<Fix>,
+    pub fixes: Vec<crate::fixes::FixWithRawPacket>,
     pub page: i64,
     pub total_pages: i64,
 }

--- a/web/src/routes/devices/[id]/+page.svelte
+++ b/web/src/routes/devices/[id]/+page.svelte
@@ -666,7 +666,7 @@
 			<div class="space-y-4 card p-6">
 				<h2 class="flex items-center gap-2 h2">
 					<Activity class="h-6 w-6" />
-					Recent Position Fixes (Last 24 Hours)
+					Recent Position Fixes
 				</h2>
 
 				<FixesList


### PR DESCRIPTION
## Summary

- Fixed the "Show RAW" button on the device detail page that was not displaying raw APRS messages
- Updated repository methods to use INNER JOIN with aprs_messages table (more correct than LEFT JOIN)
- Changed from `Option<String>` to `String` for raw_message since both `aprs_message_id` and `raw_message` are NOT NULL
- Removed "(Last 24 Hours)" from the "Recent Position Fixes" heading as it was inaccurate with pagination

## Technical Details

The "Show RAW" checkbox on the device detail page wasn't working because the backend repository method `get_fixes_by_device_paginated()` only returned `Fix` objects without the `raw_packet` field.

### Database Schema Facts
- `fixes.aprs_message_id` is NOT NULL (migration #318)
- `aprs_messages.raw_message` is NOT NULL
- Foreign key constraint exists from fixes to aprs_messages
- Every fix must have a corresponding aprs_message

### Changes Made
1. **Updated `get_fixes_by_device_paginated()`**:
   - Changed from LEFT JOIN to INNER JOIN (more accurate since FK is NOT NULL)
   - Changed return type from `Vec<Fix>` to `Vec<FixWithRawPacket>`
   - Select both Fix fields and `aprs_messages.raw_message`
   - Changed from `(Fix, Option<String>)` to `(Fix, String)` since raw_message is NOT NULL

2. **Updated `get_fixes_for_aircraft_with_time_range()`**:
   - Applied same improvements for consistency

3. **Updated API response type**:
   - Changed `PaginatedFixesResponse` to use `Vec<FixWithRawPacket>`

## Test Plan

- [ ] Navigate to a device detail page (e.g., `/devices/{id}`)
- [ ] Verify the heading shows "Recent Position Fixes" (without "Last 24 Hours")
- [ ] Check the "Show raw" checkbox in the Recent Position Fixes section
- [ ] Verify that raw APRS messages are displayed below each position fix
- [ ] Uncheck the "Show raw" checkbox and verify raw messages are hidden
- [ ] Test pagination to ensure it still works correctly
- [ ] Verify performance is same or better (INNER JOIN is typically faster than LEFT JOIN)