### PR TITLE
Fix: Extract US registrations from ICAO addresses for dynamically created devices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -548,3 +548,4 @@ git checkout main
 ```
 - Any time that you have enter a filename in the shell, use quotes. We are using zsh, and shell expansion treats our Svelte pages incorrectly if you do not because "[]" has a special meaning.
 - Whenever you commit, you should also push with -u to set the upstream branch.
+- When opening a PR, do not set it to squash commits. Set it to create a merge commit.


### PR DESCRIPTION
## Summary

When devices are created dynamically from APRS fixes (not from the OGN DDB), US aircraft were not getting their N-numbers populated even though the ICAO hex address contained this information (e.g., N841X with ICAO hex AB859D).

This PR fixes three issues:
- Empty registration strings in APRS packets were blocking fallback extraction logic
- Updated `extract_tail_number_from_icao` to use `flydent::registration::icao_to_registration` function
- Added country_code to device conflict updates so existing devices get their country set

## Changes

**src/device_repo.rs**:
- Fixed empty string handling in registration extraction (`.filter(|r| !r.is_empty())`)
- Uses flydent's `extract_tail_number_from_icao` function which calls `flydent::registration::icao_to_registration`
- Added country_code to the ON CONFLICT UPDATE clause

**src/devices.rs**:
- Updated `extract_tail_number_from_icao` to use `flydent::registration::icao_to_registration(icao_bytes)`
- Converts u32 address to [u8; 3] byte array for flydent function
- Added comprehensive tests verifying N841X (AB859D) and N1 (A00001) extraction

**CLAUDE.md**:
- Added note about PR merge commit preference

## How It Works

For US ICAO addresses:
1. Converts u32 address to [u8; 3] byte array: `[(address >> 16) as u8, (address >> 8) as u8, address as u8]`
2. Calls `flydent::registration::icao_to_registration(icao_bytes)` which implements the FAA algorithm
3. Returns the N-number if successful (e.g., "N841X" for 0xAB859D)
4. Sets country_code field on both insert and update

## Test Plan

- [x] Code compiles without warnings
- [x] All device-related tests pass including new test for N841X (AB859D) → "N841X"
- [x] Passes cargo clippy checks
- [x] Code formatted with cargo fmt
- [x] Test verifies: N841X (0xAB859D) → "N841X" ✅
- [x] Test verifies: N1 (0xA00001) → "N1" ✅
- [x] Test verifies: German ICAO (0x3C0001) → None ✅
- [ ] Verify in production that N841X (AB859D) device gets populated with registration
- [ ] Monitor logs for US ICAO devices to confirm registration extraction is working

🤖 Generated with [Claude Code](https://claude.com/claude-code)