### PR TITLE
chore: improve logging levels and detail

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -20,7 +20,7 @@ use soar::receiver_status_repo::ReceiverStatusRepository;
 use soar::server_messages_repo::ServerMessagesRepository;
 use std::env;
 use tracing::Instrument;
-use tracing::{info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 /// Process a received APRS message by parsing and routing through PacketRouter
 /// The message format is: "YYYY-MM-DDTHH:MM:SS.SSSZ <original_message>"
@@ -62,7 +62,7 @@ async fn process_aprs_message(
     // Route server messages (starting with #) differently
     // Server messages don't create PacketContext
     if actual_message.starts_with('#') {
-        info!("Server message: {}", actual_message);
+        debug!("Server message: {}", actual_message);
         packet_router
             .process_server_message(actual_message, received_at)
             .await;

--- a/src/flight_tracker/state_transitions.rs
+++ b/src/flight_tracker/state_transitions.rs
@@ -419,9 +419,10 @@ pub(crate) async fn process_state_transition(
             match agl {
                 Some(altitude_agl) if altitude_agl >= 250 => {
                     // Case 3b2: Still airborne (>= 250 ft AGL) - slow moving aircraft
+                    let speed_knots = fix.ground_speed_knots.unwrap_or(0.0);
                     info!(
-                        "Device {} slow but still airborne at {} ft AGL - continuing flight {}",
-                        fix.device_id, altitude_agl, flight_id
+                        "Device {} slow but still airborne at {} ft AGL ({:.1} knots) - continuing flight {}",
+                        fix.device_id, altitude_agl, speed_knots, flight_id
                     );
 
                     // Keep the flight active, assign flight_id to fix


### PR DESCRIPTION
## Summary

- Downgrade APRS server messages from INFO to DEBUG level - these keepalive/status messages are too verbose for INFO
- Add ground speed to slow airborne aircraft log messages to help diagnose edge cases

## Changes

1. **src/commands/run.rs**: Changed APRS server message logging from `info!` to `debug!`
2. **src/flight_tracker/state_transitions.rs**: Added ground speed to the "slow but still airborne" log message

## Testing

- ✅ Code compiles cleanly
- ✅ Passes clippy checks
- ✅ All existing tests pass (105/110, 5 pre-existing DB failures)
- ✅ Pre-commit hooks pass