### PR TITLE
fix: ensure timers always start after deployment and remove duplicate schedule

### DIFF
--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -309,21 +309,15 @@ done
 # Timer-invoked services are installed but not enabled or started
 log_info "Timer-invoked services (${TIMER_SERVICES[*]}) will only be invoked by their timers"
 
-# Enable timers (but don't start them - they will activate on next boot or scheduled time)
-log_info "Enabling SOAR timers..."
+# Enable and start timers to ensure they are properly scheduled
+log_info "Enabling and starting SOAR timers..."
 for timer in "${TIMERS[@]}"; do
     if [ -f "/etc/systemd/system/$timer" ]; then
         log_info "Enabling $timer..."
         systemctl enable "$timer" || log_warn "Failed to enable $timer"
 
-        # Check if timer was already running before deployment
-        # If so, restart it to pick up any config changes
-        if systemctl is-active --quiet "$timer"; then
-            log_info "Restarting $timer (was already active)..."
-            systemctl restart "$timer" || log_warn "Failed to restart $timer"
-        else
-            log_info "$timer enabled (will activate on next boot or scheduled time)"
-        fi
+        log_info "Starting $timer..."
+        systemctl restart "$timer" || log_warn "Failed to restart $timer"
     fi
 done
 

--- a/soar-pull-data.timer
+++ b/soar-pull-data.timer
@@ -26,8 +26,6 @@ Requires=soar-pull-data.service
 
 [Timer]
 # Run daily at 3:00 AM local time
-OnCalendar=daily
-# Offset to 3:00 AM
 OnCalendar=*-*-* 03:00:00
 
 # If the system was down when the timer should have triggered, run it as soon as possible


### PR DESCRIPTION
## Summary

- Fixed `soar-deploy` to always start timers after enabling them during deployment
- Removed duplicate `OnCalendar` directive from `soar-pull-data.timer` that was causing double-scheduling
- Prevents timers from getting stuck in "enabled but not started" state after deployments

## Problem

The `soar-pull-data.timer` was showing as "inactive (dead)" with "Trigger: n/a" despite being enabled. This was caused by two issues:

1. **Deployment script bug**: `soar-deploy` only restarted timers that were already running. If a timer was stopped for any reason (like manual stop, system issue, etc.), subsequent deployments would enable it but not start it, leaving it waiting for the next boot.

2. **Duplicate schedule**: `soar-pull-data.timer` had two `OnCalendar` directives:
   - `OnCalendar=daily` (midnight)
   - `OnCalendar=*-*-* 03:00:00` (3:00 AM)
   
   This caused the timer to schedule runs at both midnight and 3:00 AM, which was not intended.

## Solution

**infrastructure/soar-deploy:312-322**
- Changed timer handling to always `systemctl restart` timers after enabling
- Removed conditional logic that only restarted already-active timers
- Ensures timers are properly scheduled after every deployment

**soar-pull-data.timer:27-29**
- Removed `OnCalendar=daily` directive
- Kept only `OnCalendar=*-*-* 03:00:00` for single daily run at 3:00 AM

## Test Plan

- [x] Verified fix manually on production: timer now shows proper "NEXT" schedule
- [ ] Next deployment will verify timers auto-start correctly
- [ ] Monitor timer status after deployment with `systemctl list-timers`

## Impact

- Low risk: Only affects deployment process and timer scheduling
- Fixes existing bug where timers could be left inactive
- No changes to runtime behavior or data processing logic