### PR TITLE
Fix altitude profile dark mode toggle on flight detail page

### DIFF
--- a/web/src/routes/flights/[id]/+page.svelte
+++ b/web/src/routes/flights/[id]/+page.svelte
@@ -888,6 +888,7 @@
 				};
 
 				await Plotly.newPlot(altitudeChartContainer, traces, layout, config);
+				altitudeChartInitialized = true;
 
 				// Add hover event to highlight position on map
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary
- Fixed altitude profile chart not updating when toggling dark/light mode on flight detail page
- The altitudeChartInitialized flag was never set to true after initial chart creation
- This prevented the $effect() theme change handler from updating the chart
- Now correctly sets the flag after Plotly.newPlot() in onMount()

## Test plan
- [ ] Open a completed flight detail page (e.g., /flights/{id})
- [ ] Verify altitude profile chart is visible
- [ ] Toggle dark/light mode using the theme toggle in the header
- [ ] Verify altitude profile chart theme updates correctly (background colors, text colors, grid colors)
- [ ] Test with the full screen map page (/flights/{id}/map) to verify it still works
- [ ] Test with an active in-progress flight to ensure polling updates still work