### PR TITLE
Fix missing home_base_airport_ident in club query

### DIFF
--- a/src/clubs_repo.rs
+++ b/src/clubs_repo.rs
@@ -491,7 +491,7 @@ impl ClubsRepository {
             let mut conn = pool.get()?;
 
             let sql = r#"
-                SELECT c.id, c.name, c.is_soaring, c.home_base_airport_id, c.location_id,
+                SELECT c.id, c.name, c.is_soaring, c.home_base_airport_id, a.ident as home_base_airport_ident, c.location_id,
                        l.street1, l.street2, l.city, l.state, l.zip_code, l.region_code,
                        l.country_mail_code,
                        (l.geolocation)[0]::numeric as longitude,
@@ -499,6 +499,7 @@ impl ClubsRepository {
                        c.created_at, c.updated_at
                 FROM clubs c
                 LEFT JOIN locations l ON c.location_id = l.id
+                LEFT JOIN airports a ON c.home_base_airport_id = a.id
                 WHERE c.is_soaring = true
                 AND c.home_base_airport_id IS NULL
                 AND l.geolocation IS NOT NULL


### PR DESCRIPTION
## Summary

Fixes the `pull-data` command which was failing at the "club airport linking" step with error:
```
Error: Column `home_base_airport_ident` was not present in query
```

The `get_soaring_clubs_without_home_base()` SQL query was missing:
- The `home_base_airport_ident` column in the SELECT clause
- The LEFT JOIN to the `airports` table

This caused Diesel to fail when deserializing query results into the `ClubWithLocation` struct.

## Changes

- Added `LEFT JOIN airports a ON c.home_base_airport_id = a.id`
- Added `a.ident as home_base_airport_ident` to SELECT clause in `clubs_repo.rs:494`

This matches the pattern used in all other club queries throughout the file (e.g., `find_by_name`, `get_by_id`, `get_all`, `fuzzy_search`, etc.).

## Test Plan

- [x] Code compiles with `cargo check`
- [x] Pre-commit hooks pass
- [ ] Run `pull-data` command and verify it completes the "club airport linking" step without errors
- [ ] Verify clubs with geocoded locations but no home base airport get linked to nearby airports