### PR TITLE
Refactor: Replace tokio mpsc with flume and improve elevation queue reliability

### DIFF
--- a/src/fix_processor.rs
+++ b/src/fix_processor.rs
@@ -363,21 +363,14 @@ impl FixProcessor {
                 fix: updated_fix.clone(),
             };
 
-            // Send to elevation queue with non-blocking try_send
-            // If queue is full, drop the elevation task rather than blocking fix processing
-            // Large queue (50K) makes drops rare, but prevents multi-second spikes
-            match elevation_tx.try_send(task) {
+            // Send to elevation queue with blocking send_async
+            // Never drops elevation tasks - applies backpressure if queue fills
+            // Large queue (100K) prevents backpressure under normal conditions
+            match elevation_tx.send_async(task).await {
                 Ok(_) => {
                     metrics::counter!("aprs.elevation.queued").increment(1);
                 }
-                Err(flume::TrySendError::Full(_)) => {
-                    warn!(
-                        "Elevation queue full - dropping elevation task for fix {}",
-                        updated_fix.id
-                    );
-                    metrics::counter!("aprs.elevation.dropped_full").increment(1);
-                }
-                Err(flume::TrySendError::Disconnected(_)) => {
+                Err(_) => {
                     error!("Elevation processing channel is closed");
                     metrics::counter!("aprs.elevation.channel_closed").increment(1);
                 }

--- a/src/queue_config.rs
+++ b/src/queue_config.rs
@@ -73,10 +73,10 @@ pub const RECEIVER_POSITION_QUEUE_SIZE: usize = 100;
 pub const SERVER_STATUS_QUEUE_SIZE: usize = 100;
 
 /// Elevation lookup queue for Google Maps API requests
-/// Very large queue (50,000 tasks) to prevent blocking fix processing
-/// Changed from 1K to 50K to eliminate backpressure spikes in fix processing
-/// Uses non-blocking send - drops elevation tasks if queue is full rather than blocking
-pub const ELEVATION_QUEUE_SIZE: usize = 50_000;
+/// Very large queue (100,000 tasks) to prevent blocking fix processing
+/// Changed from 50K to 100K and switched to blocking send to never drop elevation tasks
+/// Uses blocking send - applies backpressure if queue fills but never drops messages
+pub const ELEVATION_QUEUE_SIZE: usize = 100_000;
 
 /// AGL database lookup queue for batch writes to database
 /// Small queue (100 tasks) - minimizes message loss during crashes


### PR DESCRIPTION
## Summary

This PR makes two key improvements to channel usage:

1. **Standardize on flume channels**: Replaces `tokio::sync::mpsc` with `flume` in the WebSocket handler (`fixes.rs`), consolidating channel implementations across the codebase
2. **Improve elevation queue reliability**: Increases elevation queue size to 100K and switches from non-blocking `try_send()` to blocking `send_async()`, ensuring elevation data is never dropped

## Changes

### WebSocket Handler (src/actions/fixes.rs)
- Replaced `tokio::sync::mpsc::unbounded_channel` with `flume::unbounded`
- Updated all send/receive calls to use flume's API (`send_async()`, `recv_async()`)
- Maintains same functionality with consistent channel implementation

### Elevation Queue (src/fix_processor.rs)
- Changed from `try_send()` to `send_async().await`
- Now applies backpressure when queue fills instead of dropping tasks
- Removed `aprs.elevation.dropped_full` metric (no longer needed)
- Kept `aprs.elevation.channel_closed` metric for genuine errors

### Queue Configuration (src/queue_config.rs)
- Increased `ELEVATION_QUEUE_SIZE` from 50,000 to 100,000
- Updated documentation to reflect new behavior

## Motivation

### Channel Consolidation
The codebase was using two different channel implementations:
- `flume` (10 bounded channels, used throughout)
- `tokio::sync::mpsc` (2 unbounded channels, only in WebSocket handler)

Consolidating on flume provides consistency and simplifies the codebase.

### Elevation Data Reliability
Previously, elevation tasks were dropped when the queue filled, resulting in missing AGL (Above Ground Level) data for some fixes. With the larger queue (100K) and blocking sends, all elevation data is now guaranteed to be processed. The backpressure mechanism naturally slows down fix processing if elevation lookups become a bottleneck, preventing data loss.

## Impact

- **No message drops**: All elevation tasks are now processed (previously could drop under high load)
- **Better observability**: Removed confusing `dropped_full` metric that indicated data loss
- **Channel consolidation**: Single channel implementation across the codebase

## Test Plan

- [x] Code compiles cleanly with no clippy warnings
- [x] All pre-commit hooks pass (cargo fmt, clippy, tests)
- [x] 106 unit tests pass
- [ ] Deploy to staging and monitor queue depths
- [ ] Verify no elevation tasks are lost under load
- [ ] Check that `aprs.elevation.queued` counter increments without drops