### PR TITLE
feat: add time_gap_seconds to track connectivity gaps

### DIFF
--- a/migrations/2025-11-11-045309-0000_add_time_gap_to_fixes/down.sql
+++ b/migrations/2025-11-11-045309-0000_add_time_gap_to_fixes/down.sql
@@ -1,0 +1,4 @@
+-- Reverse the time_gap_seconds column addition
+
+DROP INDEX IF EXISTS idx_fixes_time_gap_seconds;
+ALTER TABLE fixes DROP COLUMN time_gap_seconds;

--- a/migrations/2025-11-11-045309-0000_add_time_gap_to_fixes/up.sql
+++ b/migrations/2025-11-11-045309-0000_add_time_gap_to_fixes/up.sql
@@ -1,0 +1,9 @@
+-- Add time_gap_seconds column to fixes table
+-- This column stores the number of seconds elapsed since the previous fix within the same flight
+-- NULL for the first fix in a flight or for fixes without a flight_id
+
+ALTER TABLE fixes ADD COLUMN time_gap_seconds INTEGER;
+
+-- Create index for efficient queries on time gaps
+-- Useful for finding significant gaps or analyzing coverage patterns
+CREATE INDEX idx_fixes_time_gap_seconds ON fixes (time_gap_seconds) WHERE time_gap_seconds IS NOT NULL;

--- a/src/fixes.rs
+++ b/src/fixes.rs
@@ -101,6 +101,10 @@ pub struct Fix {
 
     /// Whether altitude_agl_feet has been looked up (true even if NULL due to no data)
     pub altitude_agl_valid: bool,
+
+    /// Number of seconds elapsed since the previous fix within the same flight
+    /// NULL for the first fix in a flight or for fixes without a flight_id
+    pub time_gap_seconds: Option<i32>,
 }
 
 /// Extended Fix struct that includes raw packet data from aprs_messages table
@@ -269,6 +273,7 @@ impl Fix {
                     receiver_id,
                     aprs_message_id,
                     altitude_agl_valid: false, // Will be set to true when elevation is looked up
+                    time_gap_seconds: None,    // Will be set by flight tracker if part of a flight
                 }))
             }
             _ => {

--- a/src/fixes_repo.rs
+++ b/src/fixes_repo.rs
@@ -131,6 +131,7 @@ struct FixDslRow {
     gnss_vertical_resolution: Option<i16>,
     aprs_message_id: Uuid,
     altitude_agl_valid: bool,
+    time_gap_seconds: Option<i32>,
 }
 
 impl From<FixDslRow> for Fix {
@@ -163,6 +164,7 @@ impl From<FixDslRow> for Fix {
             receiver_id: row.receiver_id,
             aprs_message_id: row.aprs_message_id,
             altitude_agl_valid: row.altitude_agl_valid,
+            time_gap_seconds: row.time_gap_seconds,
         }
     }
 }
@@ -807,6 +809,8 @@ impl FixesRepository {
                 aprs_message_id: uuid::Uuid,
                 #[diesel(sql_type = diesel::sql_types::Bool)]
                 altitude_agl_valid: bool,
+                #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Int4>)]
+                time_gap_seconds: Option<i32>,
             }
 
             let fix_rows: Vec<FixRow> = diesel::sql_query(fixes_sql)
@@ -850,6 +854,7 @@ impl FixesRepository {
                     receiver_id: fix_row.receiver_id,
                     aprs_message_id: fix_row.aprs_message_id,
                     altitude_agl_valid: fix_row.altitude_agl_valid,
+                    time_gap_seconds: fix_row.time_gap_seconds,
                 };
                 fixes_by_device
                     .entry(device_id)

--- a/src/flight_tracker/aircraft_tracker.rs
+++ b/src/flight_tracker/aircraft_tracker.rs
@@ -115,6 +115,7 @@ mod tests {
             receiver_id: uuid::Uuid::now_v7(),
             aprs_message_id: uuid::Uuid::now_v7(),
             altitude_agl_valid: false,
+            time_gap_seconds: None,
         };
 
         assert!(should_be_active(&fix));

--- a/src/flight_tracker/state_transitions.rs
+++ b/src/flight_tracker/state_transitions.rs
@@ -167,6 +167,11 @@ pub(crate) async fn process_state_transition(
                 // Assign existing flight_id to this fix
                 fix.flight_id = Some(state.flight_id);
 
+                // Calculate time gap from last fix in the same flight
+                let time_gap_seconds =
+                    (fix.timestamp - state.last_fix_timestamp).num_seconds() as i32;
+                fix.time_gap_seconds = Some(time_gap_seconds);
+
                 // Update last_fix_at in database
                 update_flight_timestamp(ctx.flights_repo, state.flight_id, fix.timestamp).await;
 
@@ -289,6 +294,12 @@ pub(crate) async fn process_state_transition(
 
                     // Assign fix to the resumed flight
                     fix.flight_id = Some(flight_id);
+
+                    // Calculate time gap from the last fix in the resumed flight
+                    // This will capture the gap during the timeout period
+                    let time_gap_seconds =
+                        (fix.timestamp - timed_out_flight.last_fix_at).num_seconds() as i32;
+                    fix.time_gap_seconds = Some(time_gap_seconds);
 
                     // Return the fix with the resumed flight_id
                     return Ok(fix);
@@ -434,6 +445,11 @@ pub(crate) async fn process_state_transition(
                     // Keep the flight active, assign flight_id to fix
                     fix.flight_id = Some(flight_id);
 
+                    // Calculate time gap from last fix in the same flight
+                    let time_gap_seconds =
+                        (fix.timestamp - state.last_fix_timestamp).num_seconds() as i32;
+                    fix.time_gap_seconds = Some(time_gap_seconds);
+
                     // Update last_fix_at in database
                     update_flight_timestamp(ctx.flights_repo, flight_id, fix.timestamp).await;
 
@@ -460,6 +476,11 @@ pub(crate) async fn process_state_transition(
 
                         // Assign flight_id to this landing fix
                         fix.flight_id = Some(flight_id);
+
+                        // Calculate time gap from last fix in the same flight
+                        let time_gap_seconds =
+                            (fix.timestamp - state.last_fix_timestamp).num_seconds() as i32;
+                        fix.time_gap_seconds = Some(time_gap_seconds);
 
                         // Update altitude_agl_feet if we have it
                         if let Some(altitude_agl) = agl {
@@ -522,6 +543,11 @@ pub(crate) async fn process_state_transition(
 
                         // Assign flight_id to this fix
                         fix.flight_id = Some(flight_id);
+
+                        // Calculate time gap from last fix in the same flight
+                        let time_gap_seconds =
+                            (fix.timestamp - state.last_fix_timestamp).num_seconds() as i32;
+                        fix.time_gap_seconds = Some(time_gap_seconds);
 
                         // Update last_fix_at in database
                         update_flight_timestamp(ctx.flights_repo, flight_id, fix.timestamp).await;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -280,6 +280,7 @@ diesel::table! {
         aprs_message_id -> Uuid,
         altitude_agl_valid -> Bool,
         location_geom -> Nullable<Geometry>,
+        time_gap_seconds -> Nullable<Int4>,
     }
 }
 


### PR DESCRIPTION
## Summary
Add `time_gap_seconds` column to the `fixes` table to cache the time elapsed since the previous fix within the same flight. This enables easy identification of receiver connectivity gaps and temporal coverage issues.

## Changes
- **Database**: Add `time_gap_seconds INTEGER` column to fixes table (nullable)
- **Migration**: Create migration with indexed column for efficient queries
- **Schema**: Regenerate Diesel schema with new column
- **FlightTracker**: Calculate gaps in real-time during fix processing
  - Calculates gap from last fix timestamp when continuing flights
  - Captures gaps during slow flight, landing, and timeout resumption
  - NULL for first fix in flight or pre-flight fixes
- **Models**: Update Fix struct and repository queries

## Implementation Details
Gap calculation: `(current_fix.timestamp - last_fix_timestamp).num_seconds()`

Calculated at these points:
- When continuing an active flight
- When aircraft is slow but still airborne
- When landing (5 consecutive inactive fixes)
- When resuming a timed-out flight (captures large gaps)

## Benefits
- **Simple queries**: Find gaps with `WHERE time_gap_seconds > 60`
- **No performance impact**: Calculated once during processing, cached forever
- **Easy visualization**: Frontend can display gaps in flight timelines
- **Metrics ready**: Aggregate gap statistics per flight/device/receiver
- **Identifies issues**: Reveals receiver coverage problems and connectivity loss

## Usage Examples
```sql
-- Find all gaps over 60 seconds
SELECT * FROM fixes 
WHERE time_gap_seconds > 60 
ORDER BY time_gap_seconds DESC;

-- Average gap per flight
SELECT flight_id, AVG(time_gap_seconds) as avg_gap 
FROM fixes 
WHERE time_gap_seconds IS NOT NULL 
GROUP BY flight_id;

-- Gaps by receiver (identify coverage issues)
SELECT receiver_id, COUNT(*) as gap_count 
FROM fixes 
WHERE time_gap_seconds > 120 
GROUP BY receiver_id;
```

## Test Results
- ✅ Cargo clippy: Passed
- ✅ Flight tracker tests: 2/2 passed
- ✅ Overall: 106/111 tests passed (5 pre-existing failures in aprs_messages_repo)