### PR TITLE
fix: increase backup timeout from 6 to 12 hours

### DIFF
--- a/soar-backup-base.service
+++ b/soar-backup-base.service
@@ -25,8 +25,8 @@ ReadWritePaths=-/var/log/soar
 # Process limits
 LimitNOFILE=65536
 
-# Timeout (allow up to 6 hours for large database backup and upload)
-TimeoutStartSec=21600
+# Timeout (allow up to 12 hours for large database backup and upload)
+TimeoutStartSec=43200
 
 # Restart on failure after 10 minutes
 Restart=on-failure


### PR DESCRIPTION
## Summary
- Increased timeout in `soar-backup-base.service` from 6 hours to 12 hours (43200 seconds)

## Reason
The backups were timing out because they're taking longer than 6 hours to complete. This extends the timeout to 12 hours to allow sufficient time for large database backup and upload operations.

## Changes
- Updated `TimeoutStartSec` from 21600 to 43200 seconds in `soar-backup-base.service`