### PR TITLE
feat: extend archive retention by 2 weeks

### DIFF
--- a/src/commands/archive/mod.rs
+++ b/src/commands/archive/mod.rs
@@ -17,9 +17,9 @@ use tracing::info;
 
 /// Handle the archive command
 /// Archives data in the correct order to respect foreign key constraints:
-/// 1. Flights (8+ days old)
-/// 2. Fixes and ReceiverStatuses (9+ days old)
-/// 3. AprsMessages (10+ days old)
+/// 1. Flights (22+ days old)
+/// 2. Fixes and ReceiverStatuses (23+ days old)
+/// 3. AprsMessages (24+ days old)
 pub async fn handle_archive(pool: PgPool, before: String, archive_path: String) -> Result<()> {
     // Parse the before date
     let before_date = NaiveDate::parse_from_str(&before, "%Y-%m-%d").context(format!(
@@ -49,20 +49,20 @@ pub async fn handle_archive(pool: PgPool, before: String, archive_path: String) 
     info!("Archive directory: {}", archive_path);
 
     // Archive in order to respect foreign key constraints
-    // Flights first (8+ days old)
-    info!("=== Archiving flights (8+ days old) ===");
-    let flights_before = before_date - chrono::Duration::days(8);
+    // Flights first (22+ days old)
+    info!("=== Archiving flights (22+ days old) ===");
+    let flights_before = before_date - chrono::Duration::days(22);
     archive::<FlightModel>(&pool, flights_before, archive_dir).await?;
 
-    // Fixes and ReceiverStatuses next (9+ days old)
-    info!("=== Archiving fixes and receiver_statuses (9+ days old) ===");
-    let fixes_before = before_date - chrono::Duration::days(9);
+    // Fixes and ReceiverStatuses next (23+ days old)
+    info!("=== Archiving fixes and receiver_statuses (23+ days old) ===");
+    let fixes_before = before_date - chrono::Duration::days(23);
     archive::<Fix>(&pool, fixes_before, archive_dir).await?;
     archive::<ReceiverStatus>(&pool, fixes_before, archive_dir).await?;
 
-    // AprsMessages last (10+ days old)
-    info!("=== Archiving aprs_messages (10+ days old) ===");
-    let messages_before = before_date - chrono::Duration::days(10);
+    // AprsMessages last (24+ days old)
+    info!("=== Archiving aprs_messages (24+ days old) ===");
+    let messages_before = before_date - chrono::Duration::days(24);
     archive::<AprsMessage>(&pool, messages_before, archive_dir).await?;
 
     info!("Archive process completed successfully");


### PR DESCRIPTION
## Summary

Extends the data retention period for all archived tables by 14 days (2 weeks), keeping more historical data in the active database before archiving to compressed CSV files.

## Changes

Updated retention periods in `src/commands/archive/mod.rs`:

| Table | Previous Retention | New Retention | Change |
|-------|-------------------|---------------|---------|
| Flights | 8 days | 22 days | +14 days |
| Fixes | 9 days | 23 days | +14 days |
| ReceiverStatuses | 9 days | 23 days | +14 days |
| AprsMessages | 10 days | 24 days | +14 days |

## Impact

- **Database Size**: The active database will retain approximately 2 additional weeks of data, increasing storage requirements
- **Archive Frequency**: Same archive schedule, but older data threshold
- **Query Performance**: More historical data available for recent queries without needing to restore from archives
- **Backward Compatible**: No changes to archive file format or resurrection process

## Test Plan

- [x] Code passes `cargo fmt`
- [x] Code passes `cargo clippy` with no warnings
- [ ] Verify archive command runs successfully with new retention periods
- [ ] Monitor database size after deployment

## Additional Notes

The staggered retention periods (22/23/24 days) are maintained to respect foreign key constraints during the archival process. Flights are archived first, followed by fixes/receiver_statuses, and finally aprs_messages.