### PR TITLE
feat: add detailed router processing metrics to Grafana dashboard

### DIFF
--- a/infrastructure/grafana-dashboard-run.json
+++ b/infrastructure/grafana-dashboard-run.json
@@ -2005,12 +2005,288 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "fe4qj1bybjncwc"
+      },
+      "description": "Monitors router internal queue depth and disconnection events",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Disconnected.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 71
+      },
+      "id": 956,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fe4qj1bybjncwc"
+          },
+          "editorMode": "code",
+          "expr": "aprs_router_internal_queue_depth{component=\"run\"}",
+          "legendFormat": "Internal Queue Depth",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fe4qj1bybjncwc"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_router_internal_queue_disconnected{component=\"run\"}[5m])",
+          "legendFormat": "Queue Disconnected/sec",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Router Internal Queue Health",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "fe4qj1bybjncwc"
+      },
+      "description": "Detailed router processing metrics and aircraft position routing",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*No Queue.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 71
+      },
+      "id": 957,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fe4qj1bybjncwc"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_router_process_packet_called{component=\"run\"}[5m])",
+          "legendFormat": "Process Packet Called/sec",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fe4qj1bybjncwc"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_router_process_packet_internal_called{component=\"run\"}[5m])",
+          "legendFormat": "Internal Processing/sec",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fe4qj1bybjncwc"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_router_position_source_aircraft{component=\"run\"}[5m])",
+          "legendFormat": "Aircraft Position Source/sec",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fe4qj1bybjncwc"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_router_no_queue_aircraft{component=\"run\"}[5m])",
+          "legendFormat": "No Queue Available/sec",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Router Processing Details",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 71
+        "y": 79
       },
       "id": 290,
       "panels": [],
@@ -2079,7 +2355,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 55
       },
       "id": 291,
       "options": {
@@ -2255,7 +2531,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 55
       },
       "id": 292,
       "options": {
@@ -2375,7 +2651,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 55
       },
       "id": 300,
       "panels": [],
@@ -2490,7 +2766,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 39
+        "y": 47
       },
       "id": 301,
       "options": {
@@ -2622,7 +2898,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 39
+        "y": 47
       },
       "id": 302,
       "options": {
@@ -2720,7 +2996,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 55
       },
       "id": 400,
       "panels": [],
@@ -2789,7 +3065,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 48
+        "y": 56
       },
       "id": 401,
       "options": {
@@ -2875,7 +3151,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 48
+        "y": 56
       },
       "id": 402,
       "options": {
@@ -2946,7 +3222,7 @@
         "h": 4,
         "w": 12,
         "x": 0,
-        "y": 56
+        "y": 64
       },
       "id": 403,
       "options": {
@@ -3045,7 +3321,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 56
+        "y": 64
       },
       "id": 404,
       "options": {
@@ -3131,7 +3407,7 @@
         "h": 4,
         "w": 12,
         "x": 0,
-        "y": 64
+        "y": 72
       },
       "id": 406,
       "options": {
@@ -3204,7 +3480,7 @@
         "h": 4,
         "w": 12,
         "x": 12,
-        "y": 64
+        "y": 72
       },
       "id": 405,
       "options": {
@@ -3279,7 +3555,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 76
       },
       "id": 407,
       "options": {
@@ -3376,7 +3652,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 68
+        "y": 76
       },
       "id": 408,
       "options": {
@@ -3486,7 +3762,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 76
+        "y": 84
       },
       "id": 406,
       "options": {
@@ -3551,7 +3827,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 84
+        "y": 92
       },
       "id": 500,
       "panels": [],
@@ -3636,7 +3912,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 85
+        "y": 93
       },
       "id": 501,
       "options": {
@@ -3720,7 +3996,7 @@
         "h": 4,
         "w": 12,
         "x": 12,
-        "y": 85
+        "y": 93
       },
       "id": 502,
       "options": {
@@ -3763,7 +4039,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 93
+        "y": 101
       },
       "id": 600,
       "panels": [],
@@ -3806,7 +4082,7 @@
         "h": 4,
         "w": 12,
         "x": 0,
-        "y": 94
+        "y": 102
       },
       "id": 601,
       "options": {
@@ -3905,7 +4181,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 94
+        "y": 102
       },
       "id": 603,
       "options": {
@@ -3948,7 +4224,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 102
+        "y": 110
       },
       "id": 700,
       "panels": [],
@@ -4017,7 +4293,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 103
+        "y": 111
       },
       "id": 701,
       "options": {
@@ -4060,7 +4336,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 111
+        "y": 119
       },
       "id": 900,
       "panels": [],
@@ -4129,7 +4405,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 112
+        "y": 120
       },
       "id": 901,
       "options": {
@@ -4254,7 +4530,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 112
+        "y": 120
       },
       "id": 902,
       "options": {


### PR DESCRIPTION
## Summary
Adds deeper observability into the APRS router processing pipeline by adding detailed metrics visualization to the run dashboard.

## New Panels

### 1. Router Internal Queue Health
Monitors the router's internal queue health and connection status:
- **Internal Queue Depth** (gauge) - Current queue depth
- **Queue Disconnected/sec** (counter) - Disconnection events indicating channel failures

**Use cases:**
- Detect queue backpressure issues
- Monitor channel disconnection problems  
- Track router pipeline health

### 2. Router Processing Details
Provides detailed insights into router processing flow:
- **Process Packet Called/sec** - Entry point for packet processing
- **Internal Processing/sec** - Internal handler invocations
- **Aircraft Position Source/sec** - Aircraft-specific packets detected
- **No Queue Available/sec** - Routing failures when queue is unavailable

**Use cases:**
- Understand router throughput patterns
- Track aircraft-specific routing activity
- Identify queue availability issues
- Debug processing pipeline bottlenecks

## Metrics Visualized (+6 metrics)

- `aprs.router.internal_queue_depth`
- `aprs.router.internal_queue_disconnected`
- `aprs.router.process_packet.called`
- `aprs.router.process_packet_internal.called`
- `aprs.router.position_source.aircraft`
- `aprs.router.no_queue.aircraft`

## Visual Design

- **Error indicators**: Red color for disconnection events
- **Warning indicators**: Yellow color for "No Queue Available" events
- **Layout**: 2-column layout (12w x 8h panels)
- **Positioning**: Added to existing "APRS Router & Parser" section

## Impact

Provides operators with visibility into router internal operations for:
- Debugging message routing issues
- Identifying processing bottlenecks
- Monitoring queue health
- Understanding traffic patterns

## Testing

- [x] JSON syntax validated
- [x] Panel IDs unique (956, 957)
- [x] Metric names match codebase
- [x] Pre-commit hooks passed

## Related

Complements PR #363 by adding deeper router metrics beyond the high-priority basics.