### PR TITLE
fix: loop partition_data_time until all data is migrated

### DIFF
--- a/migrations/2025-11-12-191049-0000_convert_fixes_to_partitioned_table/README.md
+++ b/migrations/2025-11-12-191049-0000_convert_fixes_to_partitioned_table/README.md
@@ -24,14 +24,17 @@ This migration converts the `fixes` and `aprs_messages` tables from monolithic t
    - Rename fixes → fixes_old (~1s)
    - Create partitioned table structure (~1s)
    - Create partitions for existing data (~30s)
-   - Migrate 225M rows to partitions (**SLOW**: 30-60 mins)
+   - Migrate 225M rows to partitions in batches (**SLOW**: 30-60 mins)
+     - The migration loops automatically, processing 10 days of data per iteration
+     - Progress is logged with NOTICE messages showing rows moved per iteration
    - Recreate indexes on partitions (~2-3 mins)
    - Add constraints (~10s)
 3. Partition aprs_messages table:
    - Rename aprs_messages → aprs_messages_old (~1s)
    - Create partitioned table structure (~1s)
    - Create partitions (~30s)
-   - Migrate data (~5-10 mins)
+   - Migrate data in batches (~5-10 mins)
+     - The migration loops automatically until all data is migrated
    - Recreate indexes (~1 min)
    - Add constraints (~10s)
 4. Configure pg_partman with 30-day retention (~1s)


### PR DESCRIPTION
## Summary

Fixes the partition migration that was failing with row count mismatch. The original migration only called `partition_data_time()` once with `p_batch_count := 10`, which only processed 10 days of data. With production having 233M rows spanning 26+ days, this left ~190M rows unmigrated.

## Problem

When the migration ran:
1. `partition_data_time()` was called once with `p_batch_count := 10`
2. Only ~40M rows from the first 10 days were migrated
3. Verification check found mismatch: Old: 232943472, New: ~40M
4. Migration threw exception and rolled back completely

## Solution

- Wrap `partition_data_time()` calls in DO blocks with LOOP
- Continue looping until `rows_moved = 0` (indicating all data migrated)
- Add progress logging with RAISE NOTICE for each iteration
- Apply to both `fixes` and `aprs_messages` tables

## Expected Output During Migration

```
NOTICE: Iteration 1: Moved 40123456 rows (total: 40123456)
NOTICE: Iteration 2: Moved 50234567 rows (total: 90358023)
NOTICE: Iteration 3: Moved 42686947 rows (total: 133044970)
...
NOTICE: Fixes data migration complete: 233044970 total rows migrated in N iterations
```

## Testing

Verified on production database:
- Current data spans: Oct 18 - Nov 13 (26 days)
- Total rows: 233M in fixes table
- Tables are currently regular (not partitioned) due to rollback

## Changes

- `migrations/.../up.sql`: Added loops for both fixes and aprs_messages
- `migrations/.../README.md`: Documented automatic looping behavior