### PR TITLE
Migrate database backups from Wasabi to local SSH server

### DIFF
--- a/backup-env.example
+++ b/backup-env.example
@@ -6,11 +6,13 @@
 # Installation:
 #   sudo mkdir -p /etc/soar
 #   sudo cp backup-env.example /etc/soar/backup-env
-#   sudo cp rclone.conf.example /etc/soar/rclone.conf
 #   sudo nano /etc/soar/backup-env  # Edit with your values
-#   sudo nano /etc/soar/rclone.conf  # Edit with your rclone remote config
-#   sudo chown postgres:postgres /etc/soar/backup-env /etc/soar/rclone.conf
-#   sudo chmod 600 /etc/soar/backup-env /etc/soar/rclone.conf
+#   sudo chown postgres:postgres /etc/soar/backup-env
+#   sudo chmod 600 /etc/soar/backup-env
+#
+#   # Ensure SSH key exists and has correct permissions
+#   sudo chown postgres:postgres /var/soar/keys/backup_key
+#   sudo chmod 600 /var/soar/keys/backup_key
 #
 # IMPORTANT: This file contains sensitive credentials. Protect it carefully!
 #   - Set permissions to 600 (read/write for owner only)
@@ -18,24 +20,27 @@
 #   - Never commit this file to version control
 
 #------------------------------------------------------------------------------
-# CLOUD STORAGE CONFIGURATION (using rclone)
+# SSH BACKUP STORAGE CONFIGURATION
 #------------------------------------------------------------------------------
 
-# Rclone remote and bucket (in rclone remote:bucket format)
-# The remote name must match a [remote] section in /etc/soar/rclone.conf
-#
-# For Wasabi example:
-export BACKUP_REMOTE="soar-db:soar-backup-prod"
-#
-# Where:
-#   soar-db = rclone remote name (defined in /etc/soar/rclone.conf)
-#   soar-backup-prod = bucket name
-#
-# See rclone.conf.example for configuration examples
+# SSH server hostname or IP address
+export BACKUP_SSH_HOST="cryptobot"
 
-# Path to rclone configuration file
-# Default: /etc/soar/rclone.conf
-export RCLONE_CONFIG="/etc/soar/rclone.conf"
+# SSH user (default: root)
+export BACKUP_SSH_USER="root"
+
+# Remote path on SSH server where backups will be stored
+export BACKUP_SSH_PATH="/srv/soar-backups"
+
+# Path to SSH private key for authentication
+# Default: /var/soar/keys/backup_key
+export BACKUP_SSH_KEY="/var/soar/keys/backup_key"
+
+# Note: The SSH public key must be added to the authorized_keys file
+# on the remote server:
+#   ssh-copy-id -i /var/soar/keys/backup_key.pub root@cryptobot
+# Or manually add the contents of /var/soar/keys/backup_key.pub to
+# ~/.ssh/authorized_keys on the remote server
 
 #------------------------------------------------------------------------------
 # BACKUP RETENTION CONFIGURATION
@@ -129,15 +134,14 @@ export METRICS_PUSHGATEWAY=""
 # Example: export METRICS_PUSHGATEWAY="http://localhost:9091"
 
 #------------------------------------------------------------------------------
-# RCLONE CONFIGURATION
+# SSH CONNECTION CONFIGURATION
 #------------------------------------------------------------------------------
 
-# Rclone configuration file location (default: /etc/soar/rclone.conf)
-# Only change if you need to use a different config file
-# export RCLONE_CONFIG="/etc/soar/rclone.conf"
-
-# Rclone additional options (optional)
-# export RCLONE_OPTS="--stats=1s"
+# Additional SSH options can be configured by modifying the backup scripts
+# Default SSH options used:
+#   -i $SSH_KEY                      # Use specified private key
+#   -o StrictHostKeyChecking=accept-new  # Accept new host keys automatically
+#   -o BatchMode=yes                 # Non-interactive mode
 
 #------------------------------------------------------------------------------
 # ADVANCED CONFIGURATION
@@ -162,9 +166,9 @@ export METRICS_PUSHGATEWAY=""
 
 # After editing this file, verify the configuration:
 #
-# 1. Test cloud storage access:
+# 1. Test SSH access to backup server:
 #    source /etc/soar/backup-env
-#    rclone lsd ${BACKUP_REMOTE} --config /etc/soar/rclone.conf
+#    ssh -i ${BACKUP_SSH_KEY} ${BACKUP_SSH_USER}@${BACKUP_SSH_HOST} "ls -la ${BACKUP_SSH_PATH}"
 #
 # 2. Test WAL archiving (as postgres user):
 #    sudo -u postgres /usr/local/bin/soar-wal-archive \
@@ -175,5 +179,6 @@ export METRICS_PUSHGATEWAY=""
 #    sudo systemctl start soar-backup-base.service
 #    sudo journalctl -u soar-backup-base.service -f
 #
-# 4. Verify backup in cloud:
-#    rclone lsd ${BACKUP_REMOTE}/base/ --config /etc/soar/rclone.conf
+# 4. Verify backup on remote server:
+#    ssh -i ${BACKUP_SSH_KEY} ${BACKUP_SSH_USER}@${BACKUP_SSH_HOST} \
+#      "find ${BACKUP_SSH_PATH}/base -type d"

--- a/scripts/backup/base-backup
+++ b/scripts/backup/base-backup
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# base-backup - Create full PostgreSQL base backup and upload to cloud storage
+# base-backup - Create full PostgreSQL base backup and upload to remote SSH server
 #
 # This script creates a physical backup of the PostgreSQL database using
-# pg_basebackup, compresses it, uploads to cloud storage, and manages retention.
+# pg_basebackup, compresses it, uploads to remote SSH server, and manages retention.
 #
 # Usage:
 #   base-backup [--no-cleanup]
@@ -46,16 +46,20 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# SSH configuration
+SSH_KEY="${BACKUP_SSH_KEY:-/var/soar/keys/backup_key}"
+SSH_HOST="${BACKUP_SSH_HOST:-cryptobot}"
+SSH_PATH="${BACKUP_SSH_PATH:-/srv/soar-backups}"
+SSH_USER="${BACKUP_SSH_USER:-root}"
+
 # Validate configuration
-if [[ -z "${BACKUP_REMOTE:-}" ]]; then
-    echo "ERROR: BACKUP_REMOTE not set in /etc/soar/backup-env" >&2
+if [[ -z "${BACKUP_SSH_HOST:-}" ]]; then
+    echo "ERROR: BACKUP_SSH_HOST not set in /etc/soar/backup-env" >&2
     exit 1
 fi
 
-# Rclone configuration
-RCLONE_CONFIG="${RCLONE_CONFIG:-/etc/soar/rclone.conf}"
-if [[ ! -f "$RCLONE_CONFIG" ]]; then
-    echo "ERROR: Rclone config not found: $RCLONE_CONFIG" >&2
+if [[ ! -f "$SSH_KEY" ]]; then
+    echo "ERROR: SSH key not found: $SSH_KEY" >&2
     exit 1
 fi
 
@@ -80,7 +84,10 @@ BACKUP_DATE=$(date -u +"%Y-%m-%d")
 BACKUP_TIMESTAMP=$(date -u +"%Y-%m-%d_%H-%M-%S")
 BACKUP_NAME="backup-${BACKUP_TIMESTAMP}"
 BACKUP_LOCAL_DIR="$TEMP_DIR/$BACKUP_NAME"
-BACKUP_CLOUD_PREFIX="${BACKUP_REMOTE}/base/${BACKUP_DATE}"
+BACKUP_REMOTE_PATH="${SSH_PATH}/base/${BACKUP_DATE}"
+
+# SSH options for rsync
+SSH_OPTS="-i $SSH_KEY -o StrictHostKeyChecking=accept-new -o BatchMode=yes"
 
 # Metrics and notifications
 NOTIFY_EMAIL="${BACKUP_NOTIFY_EMAIL:-}"
@@ -139,7 +146,7 @@ main() {
     log INFO "Starting base backup: $BACKUP_NAME"
     log INFO "=========================================="
     log INFO "Database: ${PGUSER}@${PGHOST}:${PGPORT}/${PGDATABASE}"
-    log INFO "Destination: $BACKUP_CLOUD_PREFIX"
+    log INFO "Destination: ${SSH_USER}@${SSH_HOST}:${BACKUP_REMOTE_PATH}"
     log INFO "Compression: $COMPRESSION"
     log INFO "Parallel jobs: $PARALLEL_JOBS"
 
@@ -185,14 +192,24 @@ main() {
     local backup_size=$(du -sb "$BACKUP_LOCAL_DIR" | cut -f1)
     log INFO "Backup size: $(numfmt --to=iec-i --suffix=B "$backup_size")"
 
-    # Upload to cloud storage
-    log INFO "Uploading backup to cloud storage..."
-
-    if ! rclone sync "$BACKUP_LOCAL_DIR" "$BACKUP_CLOUD_PREFIX/" \
-        --config "$RCLONE_CONFIG" \
-        --progress \
+    # Create remote directory if it doesn't exist
+    log INFO "Creating remote directory..."
+    if ! ssh $SSH_OPTS "${SSH_USER}@${SSH_HOST}" \
+        "mkdir -p ${BACKUP_REMOTE_PATH}" \
         >> "$LOG_DIR/backup.log" 2>&1; then
-        log ERROR "Failed to upload backup to cloud storage"
+        log ERROR "Failed to create remote directory"
+        exit 1
+    fi
+
+    # Upload to remote server
+    log INFO "Uploading backup to remote server..."
+
+    if ! rsync -avz --progress \
+        -e "ssh $SSH_OPTS" \
+        "$BACKUP_LOCAL_DIR/" \
+        "${SSH_USER}@${SSH_HOST}:${BACKUP_REMOTE_PATH}/" \
+        >> "$LOG_DIR/backup.log" 2>&1; then
+        log ERROR "Failed to upload backup to remote server"
         exit 1
     fi
 
@@ -200,16 +217,15 @@ main() {
 
     # Verify uploaded files
     log INFO "Verifying uploaded files..."
-    local uploaded_count=$(rclone lsf "$BACKUP_CLOUD_PREFIX/" \
-        --config "$RCLONE_CONFIG" \
-        | wc -l)
+    local uploaded_count=$(ssh $SSH_OPTS "${SSH_USER}@${SSH_HOST}" \
+        "find ${BACKUP_REMOTE_PATH} -type f | wc -l" 2>> "$LOG_DIR/backup.log")
 
     if [[ $uploaded_count -eq 0 ]]; then
-        log ERROR "Verification failed: no files found in cloud storage"
+        log ERROR "Verification failed: no files found on remote server"
         exit 1
     fi
 
-    log INFO "Verification passed: found $uploaded_count files in cloud storage"
+    log INFO "Verification passed: found $uploaded_count files on remote server"
 
     # Create metadata file
     log INFO "Creating backup metadata..."
@@ -228,8 +244,10 @@ main() {
 }
 EOF
 
-    rclone copyto "$TEMP_DIR/backup-metadata.json" "$BACKUP_CLOUD_PREFIX/backup-metadata.json" \
-        --config "$RCLONE_CONFIG" \
+    rsync -az \
+        -e "ssh $SSH_OPTS" \
+        "$TEMP_DIR/backup-metadata.json" \
+        "${SSH_USER}@${SSH_HOST}:${BACKUP_REMOTE_PATH}/backup-metadata.json" \
         >> "$LOG_DIR/backup.log" 2>&1
 
     # Cleanup old backups if enabled
@@ -237,9 +255,9 @@ EOF
         log INFO "Cleaning up old backups (retention: $RETENTION_DAYS days, minimum: ${BASE_BACKUP_MIN_COUNT:-2})..."
 
         # List all base backups (sorted newest first)
-        local all_backups=$(rclone lsd "${BACKUP_REMOTE}/base/" \
-            --config "$RCLONE_CONFIG" \
-            2>/dev/null | awk '{print $5}' | sort -r || echo "")
+        local all_backups=$(ssh $SSH_OPTS "${SSH_USER}@${SSH_HOST}" \
+            "find ${SSH_PATH}/base -maxdepth 1 -type d -name '20*' -printf '%f\n' | sort -r" \
+            2>/dev/null || echo "")
 
         if [[ -z "$all_backups" ]]; then
             log WARN "No backups found for cleanup"
@@ -278,8 +296,8 @@ EOF
                     if [[ "$backup_date" < "$cutoff_date" ]]; then
                         log INFO "Deleting old backup: $backup_date (older than $cutoff_date)"
 
-                        if rclone purge "${BACKUP_REMOTE}/base/${backup_date}/" \
-                            --config "$RCLONE_CONFIG" \
+                        if ssh $SSH_OPTS "${SSH_USER}@${SSH_HOST}" \
+                            "rm -rf ${SSH_PATH}/base/${backup_date}" \
                             >> "$LOG_DIR/backup.log" 2>&1; then
                             ((deleted_count++))
                             log INFO "Successfully deleted backup: $backup_date"
@@ -302,7 +320,7 @@ EOF
     log INFO "=========================================="
     log INFO "Backup completed successfully!"
     log INFO "Duration: $duration_formatted"
-    log INFO "Backup location: $BACKUP_CLOUD_PREFIX"
+    log INFO "Backup location: ${SSH_USER}@${SSH_HOST}:${BACKUP_REMOTE_PATH}"
     log INFO "=========================================="
 
     # Send success notification
@@ -311,7 +329,7 @@ Backup: $BACKUP_NAME
 Duration: $duration_formatted
 Database size: $(numfmt --to=iec-i --suffix=B "$db_size")
 Backup size: $(numfmt --to=iec-i --suffix=B "$backup_size")
-Location: $BACKUP_CLOUD_PREFIX"
+Location: ${SSH_USER}@${SSH_HOST}:${BACKUP_REMOTE_PATH}"
 
     # Update metrics (if metrics endpoint is available)
     if [[ -n "${METRICS_PUSHGATEWAY:-}" ]] && command -v curl >/dev/null 2>&1; then

--- a/scripts/backup/wal-archive
+++ b/scripts/backup/wal-archive
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# wal-archive - Archive PostgreSQL WAL segments to cloud storage
+# wal-archive - Archive PostgreSQL WAL segments to remote SSH server
 #
 # This script is called by PostgreSQL via archive_command for each completed
-# WAL segment (typically 16MB files). It uploads the WAL file to cloud storage
-# using rclone and verifies the upload succeeded.
+# WAL segment (typically 16MB files). It uploads the WAL file to a remote
+# SSH server using rsync and verifies the upload succeeded.
 #
 # Usage (called by PostgreSQL):
 #   wal-archive <wal_path> <wal_filename>
@@ -18,8 +18,8 @@
 #   1 - Failure (PostgreSQL will retry)
 #
 # Configuration:
-#   Source credentials from /etc/soar/backup-env
-#   Rclone config at /etc/soar/rclone.conf
+#   Source configuration from /etc/soar/backup-env
+#   SSH key at /var/soar/keys/backup_key (default)
 #
 # Example archive_command in postgresql.conf:
 #   archive_command = '/usr/local/bin/soar-wal-archive %p %f'
@@ -34,8 +34,11 @@ fi
 
 source /etc/soar/backup-env
 
-# Rclone configuration
-RCLONE_CONFIG="${RCLONE_CONFIG:-/etc/soar/rclone.conf}"
+# SSH configuration
+SSH_KEY="${BACKUP_SSH_KEY:-/var/soar/keys/backup_key}"
+SSH_HOST="${BACKUP_SSH_HOST:-cryptobot}"
+SSH_PATH="${BACKUP_SSH_PATH:-/srv/soar-backups}"
+SSH_USER="${BACKUP_SSH_USER:-root}"
 
 # Arguments
 WAL_PATH="$1"
@@ -48,13 +51,13 @@ if [[ ! -f "$WAL_PATH" ]]; then
 fi
 
 # Validate configuration
-if [[ -z "${BACKUP_REMOTE:-}" ]]; then
-    echo "ERROR: BACKUP_REMOTE not set in /etc/soar/backup-env" >&2
+if [[ -z "${BACKUP_SSH_HOST:-}" ]]; then
+    echo "ERROR: BACKUP_SSH_HOST not set in /etc/soar/backup-env" >&2
     exit 1
 fi
 
-if [[ ! -f "$RCLONE_CONFIG" ]]; then
-    echo "ERROR: Rclone config not found: $RCLONE_CONFIG" >&2
+if [[ ! -f "$SSH_KEY" ]]; then
+    echo "ERROR: SSH key not found: $SSH_KEY" >&2
     exit 1
 fi
 
@@ -67,23 +70,24 @@ log() {
     echo "[$(date -u +"%Y-%m-%d %H:%M:%S UTC")] WAL Archive: $*" >> "$LOG_DIR/backup.log"
 }
 
-# Destination in cloud storage (rclone remote:bucket/path format)
-DEST="${BACKUP_REMOTE}/wal/${WAL_FILE}"
+# Destination on remote server
+REMOTE_DEST="${SSH_USER}@${SSH_HOST}:${SSH_PATH}/wal/"
 
-# Upload WAL file to cloud storage using rclone
+# SSH options for rsync
+SSH_OPTS="-i $SSH_KEY -o StrictHostKeyChecking=accept-new -o BatchMode=yes"
+
+# Upload WAL file to remote server using rsync over SSH
 log "Archiving WAL segment: $WAL_FILE ($(du -h "$WAL_PATH" | cut -f1))"
 
-if rclone copyto \
-    --config "$RCLONE_CONFIG" \
-    --quiet \
+if rsync -az \
+    -e "ssh $SSH_OPTS" \
     "$WAL_PATH" \
-    "$DEST" \
+    "${REMOTE_DEST}${WAL_FILE}" \
     >> "$LOG_DIR/backup.log" 2>&1; then
 
-    # Verify upload by checking if file exists in cloud
-    if rclone lsf \
-        --config "$RCLONE_CONFIG" \
-        "$DEST" \
+    # Verify upload by checking if file exists on remote server
+    if ssh $SSH_OPTS "${SSH_USER}@${SSH_HOST}" \
+        "test -f ${SSH_PATH}/wal/${WAL_FILE}" \
         >> "$LOG_DIR/backup.log" 2>&1; then
         log "Successfully archived WAL segment: $WAL_FILE"
         exit 0


### PR DESCRIPTION
## Summary

This PR migrates the production database backup system from cloud storage (Wasabi via rclone) to a local SSH server on the same network (`cryptobot:/srv/soar-backups`). This change reduces monthly backup costs and keeps backups on-premises for better control and faster access.

### Changes Made

**Backup Scripts:**
- `scripts/backup/wal-archive`: Replaced rclone with rsync over SSH for WAL segment archiving
- `scripts/backup/base-backup`: Replaced all rclone operations with rsync/SSH for base backups and cleanup

**Configuration:**
- `backup-env.example`: Updated with SSH configuration variables instead of rclone config
  - Added `BACKUP_SSH_HOST`, `BACKUP_SSH_USER`, `BACKUP_SSH_PATH`, `BACKUP_SSH_KEY`
  - Removed references to `BACKUP_REMOTE` and `RCLONE_CONFIG`
  - Updated verification instructions for SSH-based setup

**SSH Authentication:**
- Uses ECDSA 521-bit keypair at `/var/soar/keys/backup_key`
- SSH options: `StrictHostKeyChecking=accept-new`, `BatchMode=yes`

### Deployment Plan

**Prerequisites:**
1. Generate SSH keypair on production server:
   ```bash
   sudo mkdir -p /var/soar/keys
   sudo chown postgres:postgres /var/soar/keys
   sudo chmod 700 /var/soar/keys
   sudo -u postgres ssh-keygen -t ecdsa -b 521 -f /var/soar/keys/backup_key -N ""
   ```

2. Add public key to cryptobot:
   ```bash
   # On cryptobot
   cat /var/soar/keys/backup_key.pub | ssh root@cryptobot 'cat >> ~/.ssh/authorized_keys'
   ```

3. Create backup directories on cryptobot:
   ```bash
   ssh root@cryptobot 'mkdir -p /srv/soar-backups/{base,wal}'
   ```

4. Update production config:
   ```bash
   sudo cp backup-env.example /etc/soar/backup-env
   sudo nano /etc/soar/backup-env  # Verify SSH settings
   sudo chown postgres:postgres /etc/soar/backup-env
   sudo chmod 600 /etc/soar/backup-env
   ```

## Test plan

- [ ] Verify SSH connectivity from production to cryptobot as postgres user
- [ ] Test WAL archiving manually with a test WAL file
- [ ] Run manual base backup: `sudo systemctl start soar-backup-base.service`
- [ ] Verify files appear on cryptobot in `/srv/soar-backups/{base,wal}`
- [ ] Monitor logs: `sudo journalctl -u soar-backup-base.service -f`
- [ ] Verify backup cleanup logic works (after retention period)
- [ ] Test restore procedure from new SSH-based backups

## Cost Savings

- **Before:** ~$5.40/month (Wasabi for ~900GB)
- **After:** $0 (local storage on cryptobot)
- **Annual savings:** ~$65/year

## Notes

- Backup location: `root@cryptobot:/srv/soar-backups`
- WAL segments: `/srv/soar-backups/wal/`
- Base backups: `/srv/soar-backups/base/YYYY-MM-DD/`
- No changes to backup schedule (still bi-weekly base backups + continuous WAL)
- No changes to systemd timers or service files