### PR TITLE
feat: add index on fixes.device_id

### DIFF
--- a/migrations/2025-11-15-035805-0000_add_fixes_device_id_index/down.sql
+++ b/migrations/2025-11-15-035805-0000_add_fixes_device_id_index/down.sql
@@ -1,0 +1,2 @@
+-- Remove the fixes_device_id_idx index
+DROP INDEX IF EXISTS fixes_device_id_idx;

--- a/migrations/2025-11-15-035805-0000_add_fixes_device_id_index/up.sql
+++ b/migrations/2025-11-15-035805-0000_add_fixes_device_id_index/up.sql
@@ -1,0 +1,3 @@
+-- Create index on fixes.device_id for faster device-related queries
+-- This improves performance when looking up all fixes for a specific device
+CREATE INDEX IF NOT EXISTS fixes_device_id_idx ON fixes (device_id);


### PR DESCRIPTION
## Summary
- Adds standalone index on `fixes.device_id` to improve query performance for device-related lookups
- While composite indexes exist (`idx_fixes_device_id_timestamp`, `idx_fixes_device_received_at`), a dedicated single-column index provides better optimization for queries filtering only on device_id

## Test plan
- [x] Migration created and tested on `soar_dev` database
- [x] Index successfully created as partitioned index
- [ ] Deploy to production and monitor query performance