### PR TITLE
fix: update ON CONFLICT to use composite unique constraint and drop redundant fixes index

### DIFF
--- a/migrations/2025-11-16-035017-0000_drop_redundant_fixes_device_id_index/down.sql
+++ b/migrations/2025-11-16-035017-0000_drop_redundant_fixes_device_id_index/down.sql
@@ -1,0 +1,5 @@
+-- Recreate the single-column device_id index on fixes table
+-- Note: This is a rollback migration. The index is redundant with idx_fixes_device_received_at,
+-- but we recreate it here for migration reversibility
+
+CREATE INDEX fixes_device_id_idx ON fixes (device_id);

--- a/migrations/2025-11-16-035017-0000_drop_redundant_fixes_device_id_index/up.sql
+++ b/migrations/2025-11-16-035017-0000_drop_redundant_fixes_device_id_index/up.sql
@@ -1,0 +1,5 @@
+-- Drop the redundant single-column device_id index on fixes table
+-- The composite index idx_fixes_device_received_at (device_id, received_at DESC)
+-- can serve all queries that fixes_device_id_idx can, making it redundant
+
+DROP INDEX IF EXISTS fixes_device_id_idx;

--- a/src/device_repo.rs
+++ b/src/device_repo.rs
@@ -54,7 +54,7 @@ impl DeviceRepository {
         for new_device in new_devices {
             let result = diesel::insert_into(devices::table)
                 .values(&new_device)
-                .on_conflict(devices::address)
+                .on_conflict((devices::address_type, devices::address))
                 .do_update()
                 .set((
                     // Update fields from DDB, but preserve existing values if DDB value is empty
@@ -181,7 +181,7 @@ impl DeviceRepository {
         // The DO UPDATE with a no-op ensures RETURNING gives us the existing row on conflict
         let device_model = diesel::insert_into(devices::table)
             .values(&new_device)
-            .on_conflict(devices::address)
+            .on_conflict((devices::address_type, devices::address))
             .do_update()
             .set(devices::address.eq(excluded(devices::address))) // No-op update to trigger RETURNING
             .get_result::<DeviceModel>(&mut conn)?;
@@ -249,7 +249,7 @@ impl DeviceRepository {
             // This eliminates the need for separate async update tasks
             let device_model = diesel::insert_into(devices::table)
                 .values(&new_device)
-                .on_conflict(devices::address)
+                .on_conflict((devices::address_type, devices::address))
                 .do_update()
                 .set((
                     devices::last_fix_at.eq(fix_timestamp),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -136,6 +136,18 @@ diesel::table! {
 }
 
 diesel::table! {
+    airport_analytics_daily (airport_id, date) {
+        airport_id -> Int4,
+        date -> Date,
+        airport_ident -> Nullable<Varchar>,
+        airport_name -> Nullable<Varchar>,
+        departure_count -> Int4,
+        arrival_count -> Int4,
+        updated_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
     use diesel::sql_types::*;
     use super::sql_types::Geography;
 
@@ -288,6 +300,19 @@ diesel::table! {
 }
 
 diesel::table! {
+    club_analytics_daily (club_id, date) {
+        club_id -> Uuid,
+        date -> Date,
+        club_name -> Nullable<Varchar>,
+        flight_count -> Int4,
+        active_devices -> Int4,
+        total_airtime_seconds -> Int8,
+        tow_count -> Int4,
+        updated_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
     clubs (id) {
         id -> Uuid,
         #[max_length = 255]
@@ -305,6 +330,36 @@ diesel::table! {
         #[max_length = 2]
         code -> Bpchar,
         name -> Text,
+    }
+}
+
+diesel::table! {
+    data_quality_metrics_daily (metric_date) {
+        metric_date -> Date,
+        total_fixes -> Int8,
+        fixes_with_gaps_60s -> Int4,
+        fixes_with_gaps_300s -> Int4,
+        unparsed_aprs_messages -> Int4,
+        flights_timed_out -> Int4,
+        avg_fixes_per_flight -> Numeric,
+        quality_score -> Numeric,
+        updated_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    device_analytics (device_id) {
+        device_id -> Uuid,
+        registration -> Nullable<Varchar>,
+        aircraft_model -> Nullable<Varchar>,
+        flight_count_total -> Int4,
+        flight_count_30d -> Int4,
+        flight_count_7d -> Int4,
+        last_flight_at -> Nullable<Timestamptz>,
+        avg_flight_duration_seconds -> Int4,
+        total_distance_meters -> Int8,
+        z_score_30d -> Nullable<Numeric>,
+        updated_at -> Timestamptz,
     }
 }
 
@@ -771,6 +826,41 @@ diesel::table! {
 }
 
 diesel::table! {
+    flight_analytics_daily (date) {
+        date -> Date,
+        flight_count -> Int4,
+        total_duration_seconds -> Int8,
+        avg_duration_seconds -> Int4,
+        total_distance_meters -> Int8,
+        tow_flight_count -> Int4,
+        cross_country_count -> Int4,
+        updated_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    flight_analytics_hourly (hour) {
+        hour -> Timestamptz,
+        flight_count -> Int4,
+        active_devices -> Int4,
+        active_clubs -> Int4,
+        updated_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    flight_duration_buckets (bucket_name) {
+        #[max_length = 20]
+        bucket_name -> Varchar,
+        bucket_order -> Int4,
+        min_minutes -> Int4,
+        max_minutes -> Nullable<Int4>,
+        flight_count -> Int4,
+        updated_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
     flight_pilots (id) {
         id -> Uuid,
         flight_id -> Uuid,
@@ -1141,6 +1231,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     aircraft_models,
     aircraft_other_names,
     aircraft_registrations,
+    airport_analytics_daily,
     airports,
     aprs_messages,
     aprs_messages_default,
@@ -1152,8 +1243,11 @@ diesel::allow_tables_to_appear_in_same_query!(
     aprs_messages_p20251114,
     aprs_messages_p20251115,
     aprs_messages_p20251116,
+    club_analytics_daily,
     clubs,
     countries,
+    data_quality_metrics_daily,
+    device_analytics,
     devices,
     fixes,
     fixes_default,
@@ -1165,6 +1259,9 @@ diesel::allow_tables_to_appear_in_same_query!(
     fixes_p20251114,
     fixes_p20251115,
     fixes_p20251116,
+    flight_analytics_daily,
+    flight_analytics_hourly,
+    flight_duration_buckets,
     flight_pilots,
     flights,
     locations,


### PR DESCRIPTION
## Summary

This PR fixes a critical bug that caused APRS fix processing to fail with the error:
```
there is no unique or exclusion constraint matching the ON CONFLICT specification
```

The issue was introduced when the `idx_devices_address_unique` index was removed (migration `2025-11-16-032805-0000`). The Rust code in `device_repo.rs` was still using `ON CONFLICT (address)`, but only the composite unique constraint `(address_type, address)` exists in the database.

## Changes

### Code Fixes (src/device_repo.rs)
- Updated all three `ON CONFLICT` clauses to use `(address_type, address)` instead of just `address`:
  1. `upsert_devices()` method (line 57)
  2. `get_or_insert_device()` method (line 184)
  3. `device_for_fix()` method (line 252)

### Migration (2025-11-16-035017-0000)
- Drop redundant `fixes_device_id_idx` index on the `fixes` table
- The composite index `idx_fixes_device_received_at (device_id, received_at DESC)` can serve all queries that the single-column index can, making it redundant
- Reduces index maintenance overhead and saves disk space

## Testing

- [x] Tested migration on `soar_dev` database
- [x] Verified index removal
- [x] Verified rollback works correctly
- [x] Code passes `cargo clippy` and `cargo fmt`

## Impact

This fix resolves the production error that was preventing APRS fix processing and will reduce index overhead on the heavily-used `fixes` table.