### PR TITLE
Fix backup script deployment and add multi-threaded zstd compression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,7 @@ jobs:
 
           # Copy backup scripts directory
           if [ -d scripts/backup ]; then
+            mkdir -p deploy-pkg/scripts
             cp -r scripts/backup deploy-pkg/scripts/
             echo "Backup scripts included in deployment package"
           fi

--- a/scripts/backup/base-backup
+++ b/scripts/backup/base-backup
@@ -193,7 +193,7 @@ main() {
     log INFO "=========================================="
     log INFO "Database: ${PGUSER}@${PGHOST}:${PGPORT}/${PGDATABASE}"
     log INFO "Destination: ${SSH_USER}@${SSH_HOST}:${BACKUP_REMOTE_PATH}"
-    log INFO "Compression: $COMPRESSION"
+    log INFO "Compression: zstd (multi-threaded)"
     log INFO "Parallel jobs: $PARALLEL_JOBS"
 
     # Check database connectivity
@@ -216,16 +216,20 @@ main() {
     log INFO "Creating base backup with pg_basebackup..."
     mkdir -p "$BACKUP_LOCAL_DIR"
 
+    # Detect number of CPU cores for parallel compression
+    local num_cores=$(nproc)
+    log INFO "Using zstd compression with $num_cores threads"
+
     if ! pg_basebackup \
         -h "$PGHOST" \
         -p "$PGPORT" \
         -U "$PGUSER" \
         -D "$BACKUP_LOCAL_DIR" \
         -Ft \
-        -z \
         -P \
         -v \
         --wal-method=fetch \
+        --compress=zstd:${num_cores} \
         --label="$BACKUP_NAME" \
         >> "$LOG_DIR/backup.log" 2>&1; then
         log ERROR "pg_basebackup failed"
@@ -283,7 +287,8 @@ main() {
   "database": "$PGDATABASE",
   "database_size_bytes": $db_size,
   "backup_size_bytes": $backup_size,
-  "compression": "$COMPRESSION",
+  "compression": "zstd",
+  "compression_threads": $(nproc),
   "hostname": "$(hostname)",
   "postgresql_version": "$(psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -t -c "SHOW server_version" | tr -d ' ')",
   "completed_at": "$(date -u +"%Y-%m-%d %H:%M:%S UTC")"


### PR DESCRIPTION
## Summary
- Fix CI/CD deployment bug preventing backup scripts from being deployed
- Upgrade backup compression from single-threaded gzip to multi-threaded zstd

## Problem 1: Backup Scripts Not Deployed

The GitHub Actions deployment workflow was failing to deploy backup scripts to `/usr/local/bin/soar-backup-*`. 

**Root cause**: The workflow tried to copy `scripts/backup` to `deploy-pkg/scripts/` without first creating the parent directory, causing the copy operation to fail silently.

**Evidence from deployment logs**:
```
[WARN] scripts/backup directory not found in deployment, skipping backup script installation
```

**Fix**: Added `mkdir -p deploy-pkg/scripts` before the copy operation in `.github/workflows/ci.yml`

## Problem 2: Compression CPU Bottleneck

The base backup script was using `pg_basebackup -z` (single-threaded gzip compression), which saturated one CPU core and bottlenecked the backup process.

**Fix**: Replaced with `--compress=zstd:N` where N = number of CPU cores (detected via `nproc`)

**Benefits**:
- Utilizes all available CPU cores for compression
- Faster backup completion time
- Better compression ratio than gzip at similar speeds
- Metadata now tracks compression type and thread count

## Changes

### `.github/workflows/ci.yml`
- Added directory creation before copying backup scripts

### `scripts/backup/base-backup`
- Replaced `-z` flag with `--compress=zstd:${num_cores}`
- Auto-detect CPU cores using `nproc`
- Updated logging to show compression type and thread count
- Updated metadata JSON to include compression type and thread count

## Testing
- [ ] Verify backup scripts are deployed to `/usr/local/bin/` in next deployment
- [ ] Monitor backup performance with multi-threaded compression
- [ ] Confirm all CPU cores are utilized during backup

🤖 Generated with [Claude Code](https://claude.com/claude-code)