### PR TITLE
Improve receiver marker styling and fix effect depth error

### DIFF
--- a/web/src/routes/flights/[id]/+page.svelte
+++ b/web/src/routes/flights/[id]/+page.svelte
@@ -1849,7 +1849,7 @@
 	}
 
 	:global(.receiver-icon) {
-		background: white;
+		background: transparent;
 		border: 2px solid #374151;
 		border-radius: 50%;
 		width: 24px;
@@ -1857,21 +1857,28 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		color: #10b981;
+		color: #fb923c;
 		box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
 		transition: all 0.2s ease-in-out;
 	}
 
 	@media (prefers-color-scheme: dark) {
 		:global(.receiver-icon) {
-			background: #1f2937;
+			background: transparent;
 			border-color: #6b7280;
 		}
 	}
 
 	:global(.receiver-marker:hover .receiver-icon) {
-		border-color: #10b981;
-		box-shadow: 0 3px 8px rgba(16, 185, 129, 0.4);
+		background: white;
+		border-color: #fb923c;
+		box-shadow: 0 3px 8px rgba(251, 146, 60, 0.4);
+	}
+
+	@media (prefers-color-scheme: dark) {
+		:global(.receiver-marker:hover .receiver-icon) {
+			background: #1f2937;
+		}
 	}
 
 	:global(.receiver-label) {
@@ -1888,6 +1895,11 @@
 		text-rendering: optimizeLegibility;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
+		opacity: 0;
+		visibility: hidden;
+		transition:
+			opacity 0.2s ease-in-out,
+			visibility 0.2s ease-in-out;
 	}
 
 	@media (prefers-color-scheme: dark) {
@@ -1896,5 +1908,10 @@
 			border-color: #4b5563;
 			color: #e5e7eb;
 		}
+	}
+
+	:global(.receiver-marker:hover .receiver-label) {
+		opacity: 1;
+		visibility: visible;
 	}
 </style>

--- a/web/src/routes/flights/[id]/map/+page.svelte
+++ b/web/src/routes/flights/[id]/map/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	/// <reference types="@types/google.maps" />
-	import { onMount, onDestroy } from 'svelte';
+	import { onMount, onDestroy, untrack } from 'svelte';
 	import { SvelteSet } from 'svelte/reactivity';
 	import { setOptions, importLibrary } from '@googlemaps/js-api-loader';
 	import { goto } from '$app/navigation';
@@ -583,10 +583,15 @@
 
 	// Update map when color scheme changes
 	$effect(() => {
-		// Reactively update map when color scheme changes
-		if (colorScheme && map && flightPathSegments.length > 0) {
-			updateMap();
-		}
+		// Track colorScheme changes
+		void colorScheme;
+
+		// Untrack the rest to avoid infinite loop when updateMap modifies state
+		untrack(() => {
+			if (map && flightPathSegments.length > 0) {
+				updateMap();
+			}
+		});
 	});
 
 	// Recreate chart when panel transitions from collapsed to expanded

--- a/web/src/routes/operations/+page.svelte
+++ b/web/src/routes/operations/+page.svelte
@@ -2154,7 +2154,7 @@
 	}
 
 	:global(.receiver-icon) {
-		background: white;
+		background: transparent;
 		border: 2px solid #374151;
 		border-radius: 50%;
 		width: 24px;
@@ -2162,21 +2162,28 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		color: #10b981;
+		color: #fb923c;
 		box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
 		transition: all 0.2s ease-in-out;
 	}
 
 	@media (prefers-color-scheme: dark) {
 		:global(.receiver-icon) {
-			background: #1f2937;
+			background: transparent;
 			border-color: #6b7280;
 		}
 	}
 
 	:global(.receiver-marker:hover .receiver-icon) {
-		border-color: #10b981;
-		box-shadow: 0 3px 8px rgba(16, 185, 129, 0.4);
+		background: white;
+		border-color: #fb923c;
+		box-shadow: 0 3px 8px rgba(251, 146, 60, 0.4);
+	}
+
+	@media (prefers-color-scheme: dark) {
+		:global(.receiver-marker:hover .receiver-icon) {
+			background: #1f2937;
+		}
 	}
 
 	:global(.receiver-label) {
@@ -2193,6 +2200,11 @@
 		text-rendering: optimizeLegibility;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
+		opacity: 0;
+		visibility: hidden;
+		transition:
+			opacity 0.2s ease-in-out,
+			visibility 0.2s ease-in-out;
 	}
 
 	@media (prefers-color-scheme: dark) {
@@ -2201,5 +2213,10 @@
 			border-color: #4b5563;
 			color: #e5e7eb;
 		}
+	}
+
+	:global(.receiver-marker:hover .receiver-label) {
+		opacity: 1;
+		visibility: visible;
 	}
 </style>


### PR DESCRIPTION
## Summary
- Changed receiver icon color from green to orange (#fb923c) to match airport icons
- Made receiver icon backgrounds transparent by default, solid white/dark on hover
- Hidden receiver labels by default, show on hover with smooth fade-in transition
- Fixed effect depth exceeded error on flight map page by using untrack() to prevent infinite loops

## Changes Made

### Receiver Marker Styling
**Icon Color:**
- Changed from green (`#10b981`) to orange (`#fb923c`) to match airport icons on operations page

**Icon Background:**
- Default: transparent (both light and dark mode)
- On hover: solid white (light mode) or dark gray (dark mode)
- Border color changes to orange on hover with matching glow effect

**Labels:**
- Hidden by default with `opacity: 0` and `visibility: hidden`
- Fade in smoothly on hover with transition effect
- Label background remains solid/opaque when visible

### Bug Fix
**Effect Depth Error:**
- Fixed infinite loop in flight map page (`/flights/[id]/map`)
- Used `untrack()` to prevent `updateMap()` from triggering the effect recursively
- Matches the same fix previously applied to flight details page

## Pages Updated
- Flight details (`/flights/[id]`)
- Flight map (`/flights/[id]/map`)
- Operations page (`/operations`)

## Test Plan
- [x] Verify receiver icons display with transparent backgrounds
- [x] Verify icons change to orange color
- [x] Verify labels are hidden by default
- [x] Verify hover shows label and solid icon background
- [x] Verify no effect depth errors on flight map page
- [x] Verify dark mode styling works correctly