### PR TITLE
fix: convert binary hash to hex for CSV archival of APRS messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,6 +4637,7 @@ dependencies = [
  "flydent",
  "futures-util",
  "google_maps",
+ "hex",
  "http-body 1.0.1",
  "http-body-util",
  "include_dir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ lru = "0.16"
 moka = { version = "0.12", features = ["future", "sync"] }
 sha2 = "0.10.9"
 kml = "0.12"
+hex = "0.4.3"
 
 # Optimized development profile with light optimization
 # Use with: cargo build --profile dev-fast

--- a/src/commands/archive/aprs_messages.rs
+++ b/src/commands/archive/aprs_messages.rs
@@ -1,15 +1,56 @@
 use anyhow::Result;
-use chrono::{NaiveDate, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use diesel::prelude::*;
+use hex;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 use tracing::info;
+use uuid::Uuid;
 
 use soar::aprs_messages_repo::AprsMessage;
 use soar::schema::aprs_messages;
 
 use super::archiver::{Archivable, PgPool, write_records_to_file};
 
-impl Archivable for AprsMessage {
+/// CSV-serializable version of AprsMessage with hex-encoded hash
+/// This is used for archival to avoid CSV serialization issues with Vec<u8>
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AprsMessageCsv {
+    id: Uuid,
+    raw_message: String,
+    received_at: DateTime<Utc>,
+    receiver_id: Uuid,
+    unparsed: Option<String>,
+    raw_message_hash: String, // Hex-encoded instead of Vec<u8>
+}
+
+impl From<AprsMessage> for AprsMessageCsv {
+    fn from(msg: AprsMessage) -> Self {
+        Self {
+            id: msg.id,
+            raw_message: msg.raw_message,
+            received_at: msg.received_at,
+            receiver_id: msg.receiver_id,
+            unparsed: msg.unparsed,
+            raw_message_hash: hex::encode(msg.raw_message_hash),
+        }
+    }
+}
+
+impl From<AprsMessageCsv> for AprsMessage {
+    fn from(csv: AprsMessageCsv) -> Self {
+        Self {
+            id: csv.id,
+            raw_message: csv.raw_message,
+            received_at: csv.received_at,
+            receiver_id: csv.receiver_id,
+            unparsed: csv.unparsed,
+            raw_message_hash: hex::decode(csv.raw_message_hash).unwrap_or_default(),
+        }
+    }
+}
+
+impl Archivable for AprsMessageCsv {
     fn table_name() -> &'static str {
         "aprs_messages"
     }
@@ -59,6 +100,7 @@ impl Archivable for AprsMessage {
         let file_path = file_path.to_path_buf();
         tokio::task::spawn_blocking(move || {
             let mut conn = pool.get()?;
+            // Query database for AprsMessage records
             let messages_iter = aprs_messages::table
                 .filter(aprs_messages::received_at.ge(day_start))
                 .filter(aprs_messages::received_at.lt(day_end))
@@ -66,7 +108,10 @@ impl Archivable for AprsMessage {
                 .select(AprsMessage::as_select())
                 .load_iter::<AprsMessage, diesel::pg::PgRowByRowLoadingMode>(&mut conn)?;
 
-            write_records_to_file(messages_iter, &file_path, Self::table_name())
+            // Convert AprsMessage to AprsMessageCsv for CSV serialization
+            let csv_messages_iter = messages_iter.map(|result| result.map(AprsMessageCsv::from));
+
+            write_records_to_file(csv_messages_iter, &file_path, Self::table_name())
         })
         .await?
     }
@@ -99,9 +144,11 @@ impl Archivable for AprsMessage {
 
     fn insert_batch(conn: &mut PgConnection, batch: &[Self]) -> Result<()> {
         conn.transaction::<_, anyhow::Error, _>(|conn| {
-            for message in batch {
+            for csv_message in batch {
+                // Convert CSV format back to database format
+                let db_message: AprsMessage = csv_message.clone().into();
                 diesel::insert_into(aprs_messages::table)
-                    .values(message)
+                    .values(&db_message)
                     .on_conflict_do_nothing()
                     .execute(conn)?;
             }


### PR DESCRIPTION
## Summary
Fixes the CSV serialization error during APRS message archival by converting binary hash data to hex-encoded strings.

## Problem
The archival process was failing with the error:
```
CSV write error: cannot serialize sequence container inside struct when writing headers from structs
```

This occurred because the `raw_message_hash` field in `AprsMessage` is a `Vec<u8>` (binary data), which the CSV serializer cannot directly handle.

## Solution
- Created a CSV-compatible wrapper type `AprsMessageCsv` that converts binary hash to hex string
- Implemented bidirectional conversions between `AprsMessage` and `AprsMessageCsv`
- Updated archival operations to use the wrapper type for CSV serialization/deserialization
- Added `hex` crate dependency for encoding/decoding

## Testing
- ✅ Builds successfully
- ✅ Passes all pre-commit hooks (clippy, fmt, tests)
- ✅ CSV archival now works correctly with hex-encoded hash field
- ✅ Resurrection (restore) process handles conversion back to binary

## Changes
- `Cargo.toml`: Added hex crate dependency
- `src/commands/archive/aprs_messages.rs`: Created `AprsMessageCsv` wrapper with conversions
- `src/commands/archive/mod.rs`: Updated to use `AprsMessageCsv` for archival operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)