### PR TITLE
chore: remove log file redirection from backup scripts

### DIFF
--- a/scripts/backup/backup-verify
+++ b/scripts/backup/backup-verify
@@ -48,9 +48,7 @@ if [[ ! -f "$RCLONE_CONFIG" ]]; then
     exit 1
 fi
 
-# Directories
-LOG_DIR="${BACKUP_LOG_DIR:-/var/log/soar}"
-mkdir -p "$LOG_DIR"
+# No log directory needed - output goes to systemd journal
 
 # Retention configuration
 RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-30}"
@@ -74,7 +72,7 @@ WARNINGS=0
 log() {
     local level="$1"
     shift
-    echo "[$(date -u +"%Y-%m-%d %H:%M:%S UTC")] [$level] Backup Verify: $*" | tee -a "$LOG_DIR/backup.log"
+    echo "[$(date -u +"%Y-%m-%d %H:%M:%S UTC")] [$level] Backup Verify: $*"
 }
 
 # Function to increment check counters
@@ -432,14 +430,14 @@ Passed: $PASSED_CHECKS
 Failed: $FAILED_CHECKS
 Warnings: $WARNINGS
 
-Check logs at $LOG_DIR/backup.log for details."
+Check logs with: journalctl -u soar-backup-verify"
     elif [[ $WARNINGS -gt 0 ]]; then
         notify "WARNING" "Backup verification completed with warnings on $(hostname)
 Total checks: $TOTAL_CHECKS
 Passed: $PASSED_CHECKS
 Warnings: $WARNINGS
 
-Check logs at $LOG_DIR/backup.log for details."
+Check logs with: journalctl -u soar-backup-verify"
     else
         notify "SUCCESS" "Backup verification passed on $(hostname)
 Total checks: $TOTAL_CHECKS

--- a/scripts/backup/base-backup
+++ b/scripts/backup/base-backup
@@ -65,8 +65,7 @@ fi
 
 # Directories
 TEMP_DIR="${BACKUP_TEMP_DIR:-/var/lib/soar/backup-temp}"
-LOG_DIR="${BACKUP_LOG_DIR:-/var/log/soar}"
-mkdir -p "$TEMP_DIR" "$LOG_DIR"
+mkdir -p "$TEMP_DIR"
 
 # Database connection
 PGHOST="${PGHOST:-localhost}"
@@ -98,7 +97,7 @@ SENTRY_DSN="${SENTRY_DSN:-}"
 log() {
     local level="$1"
     shift
-    echo "[$(date -u +"%Y-%m-%d %H:%M:%S UTC")] [$level] Base Backup: $*" | tee -a "$LOG_DIR/backup.log"
+    echo "[$(date -u +"%Y-%m-%d %H:%M:%S UTC")] [$level] Base Backup: $*"
 }
 
 # Function to send notifications
@@ -172,7 +171,7 @@ cleanup() {
     local exit_code=$?
     if [[ $exit_code -ne 0 ]]; then
         log ERROR "Backup failed with exit code $exit_code"
-        notify "FAILED" "Base backup failed on $(hostname) at $(date). Check logs at $LOG_DIR/backup.log"
+        notify "FAILED" "Base backup failed on $(hostname) at $(date). Check logs with: journalctl -u soar-backup-base"
     fi
 
     # Remove temporary files
@@ -235,8 +234,7 @@ main() {
         -v \
         --wal-method=stream \
         --compress=zstd:${compression_level} \
-        --label="$BACKUP_NAME" \
-        >> "$LOG_DIR/backup.log" 2>&1; then
+        --label="$BACKUP_NAME"; then
         log ERROR "pg_basebackup failed"
         exit 1
     fi
@@ -250,8 +248,7 @@ main() {
     # Create remote directory if it doesn't exist
     log INFO "Creating remote directory..."
     if ! ssh $SSH_OPTS "${SSH_USER}@${SSH_HOST}" \
-        "mkdir -p ${BACKUP_REMOTE_PATH}" \
-        >> "$LOG_DIR/backup.log" 2>&1; then
+        "mkdir -p ${BACKUP_REMOTE_PATH}"; then
         log ERROR "Failed to create remote directory"
         exit 1
     fi
@@ -262,8 +259,7 @@ main() {
     if ! rsync -avz --progress \
         -e "ssh $SSH_OPTS" \
         "$BACKUP_LOCAL_DIR/" \
-        "${SSH_USER}@${SSH_HOST}:${BACKUP_REMOTE_PATH}/" \
-        >> "$LOG_DIR/backup.log" 2>&1; then
+        "${SSH_USER}@${SSH_HOST}:${BACKUP_REMOTE_PATH}/"; then
         log ERROR "Failed to upload backup to remote server"
         exit 1
     fi
@@ -273,7 +269,7 @@ main() {
     # Verify uploaded files
     log INFO "Verifying uploaded files..."
     local uploaded_count=$(ssh $SSH_OPTS "${SSH_USER}@${SSH_HOST}" \
-        "find ${BACKUP_REMOTE_PATH} -type f | wc -l" 2>> "$LOG_DIR/backup.log")
+        "find ${BACKUP_REMOTE_PATH} -type f | wc -l" 2>&1)
 
     if [[ $uploaded_count -eq 0 ]]; then
         log ERROR "Verification failed: no files found on remote server"
@@ -303,8 +299,7 @@ EOF
     rsync -az \
         -e "ssh $SSH_OPTS" \
         "$TEMP_DIR/backup-metadata.json" \
-        "${SSH_USER}@${SSH_HOST}:${BACKUP_REMOTE_PATH}/backup-metadata.json" \
-        >> "$LOG_DIR/backup.log" 2>&1
+        "${SSH_USER}@${SSH_HOST}:${BACKUP_REMOTE_PATH}/backup-metadata.json"
 
     # Cleanup old backups if enabled
     if [[ "$CLEANUP" == "true" ]]; then
@@ -353,8 +348,7 @@ EOF
                         log INFO "Deleting old backup: $backup_date (older than $cutoff_date)"
 
                         if ssh $SSH_OPTS "${SSH_USER}@${SSH_HOST}" \
-                            "rm -rf ${SSH_PATH}/base/${backup_date}" \
-                            >> "$LOG_DIR/backup.log" 2>&1; then
+                            "rm -rf ${SSH_PATH}/base/${backup_date}"; then
                             ((deleted_count++))
                             log INFO "Successfully deleted backup: $backup_date"
                         else

--- a/soar-backup-base.service
+++ b/soar-backup-base.service
@@ -20,7 +20,6 @@ EnvironmentFile=/etc/soar/backup-env
 # Security settings
 NoNewPrivileges=yes
 ReadWritePaths=-/var/lib/soar/backup-temp
-ReadWritePaths=-/var/log/soar
 
 # Process limits
 LimitNOFILE=65536

--- a/soar-backup-verify.service
+++ b/soar-backup-verify.service
@@ -18,7 +18,6 @@ EnvironmentFile=/etc/soar/backup-env
 
 # Security settings
 NoNewPrivileges=yes
-ReadWritePaths=-/var/log/soar
 
 # Process limits
 LimitNOFILE=65536


### PR DESCRIPTION
## Summary

The backup scripts were writing to `/var/log/soar/backup.log` in addition to stdout. Since these scripts run as systemd services, this is unnecessary - systemd automatically captures all stdout/stderr via journald.

## Changes

- ✅ Remove `LOG_DIR` variable and directory creation from both scripts
- ✅ Update `log()` function to write only to stdout (removed `tee`)
- ✅ Remove all output redirections to log files from commands
- ✅ Update error notifications to reference `journalctl` instead of log file path
- ✅ Remove `ReadWritePaths=-/var/log/soar` from systemd service files

## Benefits

- **Simpler code**: No need to manage separate log files
- **Better security**: Removed unnecessary filesystem write permissions
- **Standard practice**: Uses systemd's built-in logging (journald)
- **Easier access**: Users can view logs with standard journalctl commands

## Viewing Logs

After this change, logs can be viewed with:
```bash
journalctl -u soar-backup-base
journalctl -u soar-backup-verify
```

## Test Plan

- [x] Scripts pass bash syntax check (`bash -n`)
- [x] Pre-commit hooks pass
- [ ] Verify in production that logs appear in journald