### PR TITLE
perf: reduce log verbosity and add flight lifecycle metrics

### DIFF
--- a/infrastructure/grafana-dashboard-run.json
+++ b/infrastructure/grafana-dashboard-run.json
@@ -4295,12 +4295,232 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "fe4qj1bybjncwc"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 110
+      },
+      "id": 604,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fe4qj1bybjncwc"
+          },
+          "editorMode": "code",
+          "expr": "rate(flight_tracker_flight_created_takeoff[5m])",
+          "legendFormat": "Takeoff",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fe4qj1bybjncwc"
+          },
+          "editorMode": "code",
+          "expr": "rate(flight_tracker_flight_created_airborne[5m])",
+          "legendFormat": "Airborne",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Flight Creation",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "fe4qj1bybjncwc"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 110
+      },
+      "id": 605,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fe4qj1bybjncwc"
+          },
+          "editorMode": "code",
+          "expr": "rate(flight_tracker_flight_ended_landed[5m])",
+          "legendFormat": "Landed",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "fe4qj1bybjncwc"
+          },
+          "editorMode": "code",
+          "expr": "rate(flight_tracker_flight_ended_timed_out[5m])",
+          "legendFormat": "Timed Out",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Flight Ends",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 110
+        "y": 118
       },
       "id": 700,
       "panels": [],
@@ -4369,7 +4589,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 111
+        "y": 119
       },
       "id": 701,
       "options": {
@@ -4412,7 +4632,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 119
+        "y": 127
       },
       "id": 900,
       "panels": [],
@@ -4481,7 +4701,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 120
+        "y": 128
       },
       "id": 901,
       "options": {
@@ -4606,7 +4826,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 120
+        "y": 128
       },
       "id": 902,
       "options": {

--- a/src/aprs_jetstream_consumer.rs
+++ b/src/aprs_jetstream_consumer.rs
@@ -171,8 +171,8 @@ impl JetStreamConsumer {
                                 processed_count += 1;
                                 metrics::counter!("aprs.jetstream.consumed").increment(1);
 
-                                // Log progress every 1000 messages
-                                if processed_count.is_multiple_of(1000) {
+                                // Log progress every 10000 messages
+                                if processed_count.is_multiple_of(10000) {
                                     let elapsed_since_start = start_time.elapsed().as_secs_f64();
                                     let rate_since_start =
                                         processed_count as f64 / elapsed_since_start;

--- a/src/flight_tracker/flight_lifecycle.rs
+++ b/src/flight_tracker/flight_lifecycle.rs
@@ -135,6 +135,8 @@ pub(crate) async fn timeout_flight(
             let mut flights = active_flights.write().await;
             flights.remove(&device_id);
 
+            metrics::counter!("flight_tracker.flight_ended.timed_out").increment(1);
+
             Ok(())
         }
         Ok(false) => {
@@ -382,6 +384,8 @@ pub(crate) async fn complete_flight(
         "Completed flight {} with landing at {:.6}, {:.6}",
         flight_id, fix.latitude, fix.longitude
     );
+
+    metrics::counter!("flight_tracker.flight_ended.landed").increment(1);
 
     Ok(true) // Return true to indicate flight was completed normally
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -264,6 +264,19 @@ pub fn initialize_run_metrics() {
     metrics::counter!("flight_tracker_timeouts_detected").absolute(0);
     metrics::gauge!("flight_tracker_active_devices").set(0.0);
 
+    // Flight coalescing metrics
+    metrics::counter!("flight_tracker.coalesce.resumed").absolute(0);
+    metrics::counter!("flight_tracker.coalesce.callsign_mismatch").absolute(0);
+    metrics::counter!("flight_tracker.coalesce.no_timeout_flight").absolute(0);
+
+    // Flight creation metrics
+    metrics::counter!("flight_tracker.flight_created.takeoff").absolute(0);
+    metrics::counter!("flight_tracker.flight_created.airborne").absolute(0);
+
+    // Flight end metrics
+    metrics::counter!("flight_tracker.flight_ended.landed").absolute(0);
+    metrics::counter!("flight_tracker.flight_ended.timed_out").absolute(0);
+
     // Receiver status metrics
     metrics::counter!("receiver_status_updates_total").absolute(0);
 


### PR DESCRIPTION
## Summary
This PR reduces log verbosity for high-frequency messages and adds comprehensive flight lifecycle metrics for better operational visibility.

## Changes

### Log Verbosity Reduction
- **APRS message processing**: Reduced log frequency from every 1,000 messages to every 10,000 messages (10x reduction)
- **Changed INFO to DEBUG** for verbose flight tracking logs:
  - Device appearing in-flight (airborne flight creation)
  - Device callsign mismatch during flight coalescing

### New Metrics

**Flight Creation:**
- `flight_tracker.flight_created.takeoff` - Flights created via takeoff detection (with airport lookup)
- `flight_tracker.flight_created.airborne` - Flights created when device appears mid-flight (without airport lookup)

**Flight Endings:**
- `flight_tracker.flight_ended.landed` - Flights that ended with a detected landing
- `flight_tracker.flight_ended.timed_out` - Flights that ended due to timeout (no position updates)

**Flight Coalescing:**
- `flight_tracker.coalesce.resumed` - Timed-out flights successfully resumed
- `flight_tracker.coalesce.callsign_mismatch` - Coalescing rejected due to callsign mismatch
- `flight_tracker.coalesce.no_timeout_flight` - New flights created (no timed-out flight to resume)

### Grafana Dashboard
Added two new panels to the Flight Tracker section:
- **Flight Creation** - Shows rate of takeoff vs airborne flight creation
- **Flight Ends** - Shows rate of landed vs timed out flights

## Benefits
- Reduced log volume in production (10x reduction for high-frequency messages)
- Better visibility into flight lifecycle patterns
- Easier debugging of flight tracking issues
- Metrics for monitoring flight coalescing behavior

## Test Plan
- [x] All pre-commit hooks passed
- [ ] Deploy to staging and verify metrics are populating
- [ ] Verify Grafana panels display correctly
- [ ] Confirm log verbosity reduction works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)