### PR TITLE
fix: prevent flight-fix association corruption in archive process

### DIFF
--- a/migrations/2025-12-10-224301-0000_add_flight_timestamp_check_constraints/down.sql
+++ b/migrations/2025-12-10-224301-0000_add_flight_timestamp_check_constraints/down.sql
@@ -1,0 +1,9 @@
+-- Remove check constraints for timestamp relationships in flights table
+
+ALTER TABLE flights DROP CONSTRAINT IF EXISTS check_timeout_reasonable;
+ALTER TABLE flights DROP CONSTRAINT IF EXISTS check_landing_near_last_fix;
+ALTER TABLE flights DROP CONSTRAINT IF EXISTS check_timeout_after_last_fix;
+ALTER TABLE flights DROP CONSTRAINT IF EXISTS check_last_fix_after_created;
+ALTER TABLE flights DROP CONSTRAINT IF EXISTS check_tow_release_before_landing;
+ALTER TABLE flights DROP CONSTRAINT IF EXISTS check_takeoff_before_tow_release;
+ALTER TABLE flights DROP CONSTRAINT IF EXISTS check_takeoff_before_landing;

--- a/migrations/2025-12-10-224301-0000_add_flight_timestamp_check_constraints/up.sql
+++ b/migrations/2025-12-10-224301-0000_add_flight_timestamp_check_constraints/up.sql
@@ -1,0 +1,74 @@
+-- Add check constraints for timestamp relationships in flights table
+--
+-- The key insight: created_at is when the DATABASE RECORD was created,
+-- but takeoff_time, landing_time, tow_release_time are ACTUAL EVENT TIMES.
+-- timed_out_at is set to last_fix_at (not current time) when a flight times out.
+--
+-- For retroactive imports, created_at can be AFTER the actual flight events,
+-- but there are still logical constraints on the actual event times themselves.
+
+-- First, fix existing data inconsistencies where flights were created after their fixes
+-- This happened when orphaned fixes were retroactively associated with flights
+UPDATE flights
+SET created_at = last_fix_at
+WHERE created_at > last_fix_at;
+
+-- 1. Takeoff must come before landing
+ALTER TABLE flights
+  ADD CONSTRAINT check_takeoff_before_landing
+  CHECK (
+    takeoff_time IS NULL OR
+    landing_time IS NULL OR
+    takeoff_time < landing_time
+  );
+
+-- 2. Takeoff must come before tow release
+ALTER TABLE flights
+  ADD CONSTRAINT check_takeoff_before_tow_release
+  CHECK (
+    takeoff_time IS NULL OR
+    tow_release_time IS NULL OR
+    takeoff_time < tow_release_time
+  );
+
+-- 3. Tow release must come before landing
+ALTER TABLE flights
+  ADD CONSTRAINT check_tow_release_before_landing
+  CHECK (
+    tow_release_time IS NULL OR
+    landing_time IS NULL OR
+    tow_release_time < landing_time
+  );
+
+-- 4. Last fix must be at or after the flight was created
+--    This catches cases where a flight record was created but has no fixes
+ALTER TABLE flights
+  ADD CONSTRAINT check_last_fix_after_created
+  CHECK (last_fix_at >= created_at);
+
+-- 5. If flight timed out, the timeout must be at or after last fix
+--    (timed_out_at is SET TO last_fix_at by the code, so this should always be true)
+ALTER TABLE flights
+  ADD CONSTRAINT check_timeout_after_last_fix
+  CHECK (
+    timed_out_at IS NULL OR
+    timed_out_at >= last_fix_at
+  );
+
+-- 6. If flight landed, landing must be at or before last fix
+--    (the last fix should be close to the landing time)
+ALTER TABLE flights
+  ADD CONSTRAINT check_landing_near_last_fix
+  CHECK (
+    landing_time IS NULL OR
+    last_fix_at >= landing_time - INTERVAL '10 minutes'
+  );
+
+-- 7. If flight timed out, last_fix should be reasonably close to timeout
+--    (allowing some processing delay, but not months)
+ALTER TABLE flights
+  ADD CONSTRAINT check_timeout_reasonable
+  CHECK (
+    timed_out_at IS NULL OR
+    timed_out_at <= last_fix_at + INTERVAL '24 hours'
+  );

--- a/migrations/2025-12-11-001035-0000_change_fixes_flight_fk_to_restrict/down.sql
+++ b/migrations/2025-12-11-001035-0000_change_fixes_flight_fk_to_restrict/down.sql
@@ -1,0 +1,26 @@
+-- Revert fixes.flight_id FK back to ON DELETE SET NULL
+
+-- Drop the RESTRICT FK constraint
+ALTER TABLE fixes DROP CONSTRAINT IF EXISTS fixes_flight_id_fkey;
+
+-- For each partition, drop the FK constraint
+DO $$
+DECLARE
+    partition_name TEXT;
+BEGIN
+    FOR partition_name IN
+        SELECT tablename
+        FROM pg_tables
+        WHERE schemaname = 'public'
+          AND tablename LIKE 'fixes_p%'
+    LOOP
+        EXECUTE format('ALTER TABLE %I DROP CONSTRAINT IF EXISTS fixes_flight_id_fkey', partition_name);
+    END LOOP;
+END $$;
+
+-- Restore old FK constraint with ON DELETE SET NULL
+ALTER TABLE fixes
+    ADD CONSTRAINT fixes_flight_id_fkey
+    FOREIGN KEY (flight_id)
+    REFERENCES flights(id)
+    ON DELETE SET NULL;

--- a/migrations/2025-12-11-001035-0000_change_fixes_flight_fk_to_restrict/up.sql
+++ b/migrations/2025-12-11-001035-0000_change_fixes_flight_fk_to_restrict/up.sql
@@ -1,0 +1,29 @@
+-- Change fixes.flight_id FK from ON DELETE SET NULL to ON DELETE RESTRICT
+-- This prevents accidental orphaning of fixes when flights are deleted
+
+-- Drop the old FK constraint
+ALTER TABLE fixes DROP CONSTRAINT IF EXISTS fixes_flight_id_fkey;
+
+-- For each partition, drop the old FK constraint
+DO $$
+DECLARE
+    partition_name TEXT;
+BEGIN
+    FOR partition_name IN
+        SELECT tablename
+        FROM pg_tables
+        WHERE schemaname = 'public'
+          AND tablename LIKE 'fixes_p%'
+    LOOP
+        EXECUTE format('ALTER TABLE %I DROP CONSTRAINT IF EXISTS fixes_flight_id_fkey', partition_name);
+    END LOOP;
+END $$;
+
+-- Add new FK constraint with ON DELETE RESTRICT
+ALTER TABLE fixes
+    ADD CONSTRAINT fixes_flight_id_fkey
+    FOREIGN KEY (flight_id)
+    REFERENCES flights(id)
+    ON DELETE RESTRICT;
+
+-- Partitions will inherit the constraint from the parent table


### PR DESCRIPTION
## Problem

Flight records in production had impossible timestamp relationships:
- Flight `019b075b-f2d2-7373-897b-66dd3ac6cc49` showed `timed_out_at` (Nov 18) BEFORE `created_at` (Dec 10)
- 6,155 total flights with `created_at > last_fix_at`
- Flights showing "no position data available" despite having fixes

## Root Cause

The `soar-archive.timer` service runs daily at 02:00 to archive old data. The archive process had critical flaws:

1. **Wrong deletion order**: Deleted flights BEFORE fixes (should be children before parents)
2. **Wrong FK behavior**: `fixes.flight_id` had `ON DELETE SET NULL`, which orphaned fixes when flights were deleted
3. **Staggered dates**: Different tables used different cutoff dates, increasing complexity

When flights were archived, their fixes were orphaned (flight_id set to NULL). These orphaned fixes could then be re-processed to create new flights with incorrect timestamps.

## Solution

### 1. Check Constraints (Migration: 2025-12-10-224301)
Prevents future bad data by enforcing timestamp relationships:
- `takeoff_time < landing_time`
- `created_at <= last_fix_at`
- `timed_out_at >= last_fix_at`
- `timed_out_at` within 24 hours of `last_fix_at`

Also fixes existing bad data where `created_at > last_fix_at`.

### 2. FK Constraint Change (Migration: 2025-12-11-001035)
Changes `fixes.flight_id` FK from `ON DELETE SET NULL` to `ON DELETE RESTRICT`:
- Prevents accidental orphaning of fixes
- Requires explicit deletion of fixes before their parent flights
- Handles both parent table and all partitions (`fixes_p%`)

### 3. Archive Logic Rewrite
Rewrites archive process in `src/commands/archive/mod.rs`:
- **Simplified**: All tables archive from same `before_date` (no staggered dates)
- **Sequential execution** in correct dependency order:
  1. Fixes (children first)
  2. ReceiverStatuses (children)
  3. Clear `towed_by_flight_id` self-references
  4. Flights (parents)
  5. AprsMessages (root parents)

This ensures FK constraints are respected and prevents data corruption.

## Testing

- [x] Code compiles successfully
- [x] Pre-commit hooks pass (formatting, clippy, tests)
- [ ] Migrations tested on `soar_dev` database
- [ ] Archive process tested end-to-end

## Deployment Notes

1. Run migration `2025-12-10-224301` first (check constraints)
2. Run migration `2025-12-11-001035` second (FK constraint change)
3. Deploy new binary with updated archive logic
4. Monitor next archive run (02:00 daily) for any issues

## Metrics Impact

No new metrics added. Archive process timing may change slightly due to sequential vs parallel execution.