### PR TITLE
fix: replace is_some()/unwrap() with if let Some pattern

### DIFF
--- a/src/flight_tracker/altitude.rs
+++ b/src/flight_tracker/altitude.rs
@@ -90,11 +90,10 @@ pub async fn calculate_and_update_agl_async(
             "Failed to update altitude_agl_feet for fix {}: {}",
             fix_id, e
         );
-    } else if agl.is_some() {
+    } else if let Some(agl_value) = agl {
         trace!(
             "Updated altitude_agl_feet for fix {} to {} ft",
-            fix_id,
-            agl.unwrap()
+            fix_id, agl_value
         );
     } else {
         trace!(

--- a/src/flight_tracker/runway.rs
+++ b/src/flight_tracker/runway.rs
@@ -227,14 +227,11 @@ pub(crate) async fn determine_runway_identifier(
         // If we found a match and we're searching at a specific airport (airport_ref provided),
         // always use the best match from the database since we know runway data exists
         if let Some((ident, diff)) = best_match {
-            if airport_ref.is_some() {
+            if let Some(airport_id) = airport_ref {
                 // Airport-specific search: always use the closest runway from database
                 debug!(
                     "Matched runway {} from database for device {} at airport {} (heading diff: {:.1}°)",
-                    ident,
-                    device_id,
-                    airport_ref.unwrap(),
-                    diff
+                    ident, device_id, airport_id, diff
                 );
                 return Some((ident, false)); // false = from database, not inferred
             } else if diff < 30.0 {


### PR DESCRIPTION
## Summary
- Fixed clippy warnings about unnecessary unwraps in two files
- Replaced `is_some()`/`unwrap()` pattern with idiomatic `if let Some(...)` pattern matching

## Changes
- **src/flight_tracker/runway.rs**: Changed `airport_ref.is_some()` check and `airport_ref.unwrap()` to `if let Some(airport_id) = airport_ref`
- **src/flight_tracker/altitude.rs**: Changed `agl.is_some()` check and `agl.unwrap()` to `if let Some(agl_value) = agl`

## Test plan
- [x] Cargo clippy passes with no warnings
- [x] Pre-commit hooks pass
- [x] No functional changes - behavior remains identical