### PR TITLE
Fix staging environment variable file naming inconsistency

### DIFF
--- a/scripts/provision
+++ b/scripts/provision
@@ -593,10 +593,10 @@ echo
 echo "   For production (/etc/soar/env):"
 echo "   DATABASE_URL=postgres://soar@localhost/soar"
 echo
-echo "   For staging (/etc/soar/env.staging):"
+echo "   For staging (/etc/soar/env-staging):"
 echo "   DATABASE_URL=postgres://soar@localhost/soar_staging"
 echo
-echo -e "${YELLOW}2. Set up additional environment variables in /etc/soar/env (or env.staging):${NC}"
+echo -e "${YELLOW}2. Set up additional environment variables in /etc/soar/env (or env-staging):${NC}"
 echo "   - NATS_URL (e.g., nats://localhost:4222)"
 echo "   - APRS_CALLSIGN (for APRS-IS connection)"
 echo "   - Any other application-specific configuration"


### PR DESCRIPTION
## Summary

- Fixed inconsistency in staging environment variable file naming
- The provision script was referencing `/etc/soar/env.staging` (with dot) while all other files use `/etc/soar/env-staging` (with dash)
- Updated provision script to consistently use `env-staging` to match systemd services, deployment script, and documentation

## Changes

- Updated `scripts/provision` line 596: `/etc/soar/env.staging` → `/etc/soar/env-staging`
- Updated `scripts/provision` line 599: `env.staging` → `env-staging`

## Context

During GitHub Actions deployment to staging, the system expects to read environment variables from `/etc/soar/env-staging` (as defined in all systemd service files and the deployment script). The provision script's documentation was the only place referencing the incorrect `env.staging` variant, which could cause confusion during server setup.

## Test plan

- [x] Verified all references to staging env file now use `env-staging` (with dash)
- [x] Pre-commit hooks passed
- [ ] Deploy to staging to confirm no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)