### PR TITLE
chore: Release v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4891,7 +4891,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "soar"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soar"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 resolver = "2"
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "web",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "web",
-			"version": "0.1.2",
+			"version": "0.1.3",
 			"dependencies": {
 				"@googlemaps/js-api-loader": "^2.0.2",
 				"@lucide/svelte": "^0.552.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "web",
 	"private": true,
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"type": "module",
 	"engines": {
 		"node": ">=24.0.0",


### PR DESCRIPTION
## Release v0.1.3

This PR bumps the version to **v0.1.3** in preparation for release.

### Changes
- Updated version in `Cargo.toml`
- Updated version in `web/package.json`
- Updated `Cargo.lock`

### Automated Release Process
This PR is configured to auto-merge when all checks pass. After merge, the release script will automatically create and push the git tag.