### PR TITLE
feat: add environment-specific Grafana links on info page

### DIFF
--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -1,7 +1,19 @@
 // Central configuration file for client-side environment variables
+import { browser } from '$app/environment';
 
 // Google Maps API Key
 // Set via VITE_GOOGLE_MAPS_API_KEY environment variable
 // Falls back to hardcoded key if not set in .env
 export const GOOGLE_MAPS_API_KEY =
 	import.meta.env.VITE_GOOGLE_MAPS_API_KEY || 'AIzaSyBaK8UU0l4z-k6b-UPlLzw3wv_Ti71XNy8';
+
+// Environment detection
+export function isStaging(): boolean {
+	if (!browser) return false;
+	return window.location.hostname === 'staging.glider.flights';
+}
+
+// Get the appropriate Grafana base URL for the current environment
+export function getGrafanaUrl(): string {
+	return isStaging() ? 'https://grafana.staging.glider.flights' : 'https://grafana.glider.flights';
+}

--- a/web/src/routes/info/+page.svelte
+++ b/web/src/routes/info/+page.svelte
@@ -1,32 +1,35 @@
 <script lang="ts">
 	import { BarChart3, Activity, Radio, Inbox } from '@lucide/svelte';
+	import { getGrafanaUrl } from '$lib/config';
 
-	const metrics = [
+	// Generate metrics with environment-specific Grafana URLs
+	const grafanaBase = $derived(getGrafanaUrl());
+	const metrics = $derived([
 		{
 			title: 'Web Performance',
-			url: 'https://grafana.glider.flights/public-dashboards/9c476a10e31f48bf9a9e0edd13f4285c',
+			url: `${grafanaBase}/public-dashboards/9c476a10e31f48bf9a9e0edd13f4285c`,
 			icon: BarChart3,
 			description: 'HTTP request metrics, WebSocket connections, and endpoint performance'
 		},
 		{
 			title: 'APRS Queue Performance',
-			url: 'https://grafana.glider.flights/public-dashboards/30a74b108e014a00831374a302711e58',
+			url: `${grafanaBase}/public-dashboards/30a74b108e014a00831374a302711e58`,
 			icon: Inbox,
 			description: 'NATS JetStream queue depths, consumer lag, and message flow rates'
 		},
 		{
 			title: 'Processor Performance',
-			url: 'https://grafana.glider.flights/public-dashboards/15160e9b72244eab82a2031e16d17a97',
+			url: `${grafanaBase}/public-dashboards/15160e9b72244eab82a2031e16d17a97`,
 			icon: Activity,
 			description: 'APRS message processing, elevation lookups, and flight tracking metrics'
 		},
 		{
 			title: 'APRS Ingest Performance',
-			url: 'https://grafana.glider.flights/public-dashboards/6ad16fc10c5941b5b09a0ff086309bd8',
+			url: `${grafanaBase}/public-dashboards/6ad16fc10c5941b5b09a0ff086309bd8`,
 			icon: Radio,
 			description: 'OGN APRS-IS connection status and message publishing metrics'
 		}
-	];
+	]);
 </script>
 
 <svelte:head>


### PR DESCRIPTION
## Summary
- Added environment detection to dynamically use staging or production Grafana URLs
- Info page now shows `grafana.staging.glider.flights` when accessed from `staging.glider.flights`
- Info page shows `grafana.glider.flights` when accessed from production

## Changes
- Added `isStaging()` and `getGrafanaUrl()` functions to `web/src/lib/config.ts`
- Updated `web/src/routes/info/+page.svelte` to use environment-specific Grafana base URLs
- Used Svelte 5's `$derived` rune for reactive URL generation

## Test Plan
- [x] Code passes pre-commit hooks (ESLint, Prettier, TypeScript)
- [x] Production build successful
- [ ] Verify staging environment links to `grafana.staging.glider.flights`
- [ ] Verify production environment links to `grafana.glider.flights`

🤖 Generated with [Claude Code](https://claude.com/claude-code)