### PR TITLE
fix: set flight created_at to fix timestamp instead of current time

### DIFF
--- a/src/flights.rs
+++ b/src/flights.rs
@@ -267,7 +267,7 @@ impl Flight {
             timed_out_at: None,
             last_fix_at: fix.timestamp,
             callsign: None,
-            created_at: now,
+            created_at: fix.timestamp,
             updated_at: now,
         }
     }
@@ -321,7 +321,7 @@ impl Flight {
             timed_out_at: None,
             last_fix_at: fix.timestamp,
             callsign: None,
-            created_at: now,
+            created_at: fix.timestamp,
             updated_at: now,
         }
     }


### PR DESCRIPTION
## Summary
- Fixes check constraint violation `check_last_fix_after_created` when processing historical/backfilled APRS data
- Changes `created_at` field in flight creation to use `fix.timestamp` instead of `Utc::now()`

## Problem
All flight insertions were failing with:
```
Failed to create flight: new row for relation "flights" violates check constraint "check_last_fix_after_created"
```

The constraint requires `last_fix_at >= created_at`, but when processing historical data:
- `created_at` was set to `Utc::now()` (current time)
- `last_fix_at` was set to `fix.timestamp` (historical timestamp)
- Since `fix.timestamp < Utc::now()`, the constraint failed

## Solution
Set `created_at` to `fix.timestamp` in both:
- `Flight::new_airborne_from_fix_with_id`
- `Flight::new_with_takeoff_from_fix_with_id`

This makes semantic sense: the flight was created (started) at the time of the first fix, not at the current wall-clock time.

## Test plan
- [x] `cargo clippy` passes
- [x] `cargo test` passes
- [x] Pre-commit hooks pass