### PR TITLE
fix: update analytics triggers for aircraft_id rename and improve error logging

### DIFF
--- a/migrations/2025-12-12-231506-0000_fix_analytics_triggers_device_to_aircraft/down.sql
+++ b/migrations/2025-12-12-231506-0000_fix_analytics_triggers_device_to_aircraft/down.sql
@@ -1,0 +1,5 @@
+-- This migration fixes broken triggers and cannot be safely reverted.
+-- Rolling back would restore broken triggers that reference non-existent device_id columns.
+-- If you need to revert, you should restore the broken state manually, but this is not recommended.
+
+-- NO-OP: This migration cannot be safely reverted

--- a/migrations/2025-12-12-231506-0000_fix_analytics_triggers_device_to_aircraft/up.sql
+++ b/migrations/2025-12-12-231506-0000_fix_analytics_triggers_device_to_aircraft/up.sql
@@ -1,0 +1,333 @@
+-- Fix analytics trigger functions to use aircraft_id instead of device_id
+-- This migration updates all references from the old device_id column name
+-- to the new aircraft_id column name after the devices → aircraft rename
+
+-- Update device_analytics → aircraft_analytics trigger function
+CREATE OR REPLACE FUNCTION public.update_device_analytics()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    old_aircraft UUID;
+    new_aircraft UUID;
+    flight_duration INT;
+    old_duration INT;
+BEGIN
+    -- Handle INSERT
+    IF TG_OP = 'INSERT' THEN
+        -- Skip flights without takeoff_time
+        IF NEW.takeoff_time IS NULL THEN
+            RETURN NEW;
+        END IF;
+
+        new_aircraft := NEW.aircraft_id;
+        flight_duration := get_flight_duration_seconds(NEW.takeoff_time, NEW.landing_time);
+
+        INSERT INTO aircraft_analytics (aircraft_id, registration, aircraft_model, flight_count_total, last_flight_at, total_distance_meters)
+        SELECT
+            NEW.aircraft_id,
+            d.registration,
+            d.aircraft_model,
+            1,
+            NEW.takeoff_time,
+            COALESCE(NEW.total_distance_meters, 0)
+        FROM aircraft d
+        WHERE d.id = NEW.aircraft_id
+        ON CONFLICT (aircraft_id) DO UPDATE SET
+            flight_count_total = aircraft_analytics.flight_count_total + 1,
+            last_flight_at = GREATEST(aircraft_analytics.last_flight_at, NEW.takeoff_time),
+            total_distance_meters = aircraft_analytics.total_distance_meters + COALESCE(NEW.total_distance_meters, 0),
+            avg_flight_duration_seconds = CASE WHEN aircraft_analytics.flight_count_total + 1 > 0
+                THEN ((aircraft_analytics.avg_flight_duration_seconds * aircraft_analytics.flight_count_total) + flight_duration) / (aircraft_analytics.flight_count_total + 1)
+                ELSE 0 END,
+            updated_at = NOW();
+
+    -- Handle UPDATE
+    ELSIF TG_OP = 'UPDATE' THEN
+        -- Skip if both old and new takeoff_time are NULL
+        IF OLD.takeoff_time IS NULL AND NEW.takeoff_time IS NULL THEN
+            RETURN NEW;
+        END IF;
+
+        old_aircraft := OLD.aircraft_id;
+        new_aircraft := NEW.aircraft_id;
+        old_duration := get_flight_duration_seconds(OLD.takeoff_time, OLD.landing_time);
+        flight_duration := get_flight_duration_seconds(NEW.takeoff_time, NEW.landing_time);
+
+        -- If aircraft changed, update both
+        IF old_aircraft != new_aircraft THEN
+            -- Remove from old aircraft
+            UPDATE aircraft_analytics SET
+                flight_count_total = GREATEST(0, flight_count_total - 1),
+                total_distance_meters = GREATEST(0, total_distance_meters - COALESCE(OLD.total_distance_meters, 0)),
+                updated_at = NOW()
+            WHERE aircraft_id = old_aircraft;
+
+            -- Add to new aircraft
+            INSERT INTO aircraft_analytics (aircraft_id, registration, aircraft_model, flight_count_total, last_flight_at, total_distance_meters)
+            SELECT
+                NEW.aircraft_id,
+                d.registration,
+                d.aircraft_model,
+                1,
+                NEW.takeoff_time,
+                COALESCE(NEW.total_distance_meters, 0)
+            FROM aircraft d
+            WHERE d.id = NEW.aircraft_id
+            ON CONFLICT (aircraft_id) DO UPDATE SET
+                flight_count_total = aircraft_analytics.flight_count_total + 1,
+                last_flight_at = GREATEST(aircraft_analytics.last_flight_at, NEW.takeoff_time),
+                total_distance_meters = aircraft_analytics.total_distance_meters + COALESCE(NEW.total_distance_meters, 0),
+                updated_at = NOW();
+        ELSE
+            -- Same aircraft, just update the difference
+            UPDATE aircraft_analytics SET
+                total_distance_meters = total_distance_meters - COALESCE(OLD.total_distance_meters, 0) + COALESCE(NEW.total_distance_meters, 0),
+                last_flight_at = GREATEST(last_flight_at, NEW.takeoff_time),
+                updated_at = NOW()
+            WHERE aircraft_id = new_aircraft;
+        END IF;
+
+    -- Handle DELETE
+    ELSIF TG_OP = 'DELETE' THEN
+        -- Skip flights without takeoff_time
+        IF OLD.takeoff_time IS NULL THEN
+            RETURN OLD;
+        END IF;
+
+        old_aircraft := OLD.aircraft_id;
+        old_duration := get_flight_duration_seconds(OLD.takeoff_time, OLD.landing_time);
+
+        UPDATE aircraft_analytics SET
+            flight_count_total = GREATEST(0, flight_count_total - 1),
+            total_distance_meters = GREATEST(0, total_distance_meters - COALESCE(OLD.total_distance_meters, 0)),
+            avg_flight_duration_seconds = CASE WHEN flight_count_total - 1 > 0
+                THEN ((avg_flight_duration_seconds * flight_count_total) - old_duration) / (flight_count_total - 1)
+                ELSE 0 END,
+            updated_at = NOW()
+        WHERE aircraft_id = old_aircraft;
+    END IF;
+
+    RETURN NEW;
+END;
+$function$;
+
+-- Update club_analytics_daily trigger function to use towed_by_aircraft_id
+CREATE OR REPLACE FUNCTION public.update_club_analytics_daily()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    affected_club UUID;
+    affected_date DATE;
+    old_club UUID;
+    old_date DATE;
+    flight_duration INT;
+    old_duration INT;
+BEGIN
+    -- Handle INSERT
+    IF TG_OP = 'INSERT' AND NEW.club_id IS NOT NULL THEN
+        -- Skip flights without takeoff_time
+        IF NEW.takeoff_time IS NULL THEN
+            RETURN NEW;
+        END IF;
+
+        affected_club := NEW.club_id;
+        affected_date := DATE(NEW.takeoff_time);
+        flight_duration := get_flight_duration_seconds(NEW.takeoff_time, NEW.landing_time);
+
+        INSERT INTO club_analytics_daily (club_id, date, club_name, flight_count, total_airtime_seconds, tow_count)
+        SELECT
+            NEW.club_id,
+            affected_date,
+            c.name,
+            1,
+            flight_duration,
+            CASE WHEN NEW.towed_by_aircraft_id IS NOT NULL THEN 1 ELSE 0 END
+        FROM clubs c
+        WHERE c.id = NEW.club_id
+        ON CONFLICT (club_id, date) DO UPDATE SET
+            flight_count = club_analytics_daily.flight_count + 1,
+            total_airtime_seconds = club_analytics_daily.total_airtime_seconds + flight_duration,
+            tow_count = club_analytics_daily.tow_count + CASE WHEN NEW.towed_by_aircraft_id IS NOT NULL THEN 1 ELSE 0 END,
+            updated_at = NOW();
+
+    -- Handle UPDATE
+    ELSIF TG_OP = 'UPDATE' THEN
+        -- Skip if both old and new takeoff_time are NULL
+        IF OLD.takeoff_time IS NULL AND NEW.takeoff_time IS NULL THEN
+            RETURN NEW;
+        END IF;
+
+        old_club := OLD.club_id;
+        old_date := DATE(OLD.takeoff_time);
+        affected_club := NEW.club_id;
+        affected_date := DATE(NEW.takeoff_time);
+        old_duration := get_flight_duration_seconds(OLD.takeoff_time, OLD.landing_time);
+        flight_duration := get_flight_duration_seconds(NEW.takeoff_time, NEW.landing_time);
+
+        -- Remove from old club/date
+        IF old_club IS NOT NULL THEN
+            UPDATE club_analytics_daily SET
+                flight_count = GREATEST(0, flight_count - 1),
+                total_airtime_seconds = GREATEST(0, total_airtime_seconds - old_duration),
+                tow_count = GREATEST(0, tow_count - CASE WHEN OLD.towed_by_aircraft_id IS NOT NULL THEN 1 ELSE 0 END),
+                updated_at = NOW()
+            WHERE club_id = old_club AND date = old_date;
+        END IF;
+
+        -- Add to new club/date
+        IF affected_club IS NOT NULL THEN
+            INSERT INTO club_analytics_daily (club_id, date, club_name, flight_count, total_airtime_seconds, tow_count)
+            SELECT
+                NEW.club_id,
+                affected_date,
+                c.name,
+                1,
+                flight_duration,
+                CASE WHEN NEW.towed_by_aircraft_id IS NOT NULL THEN 1 ELSE 0 END
+            FROM clubs c
+            WHERE c.id = NEW.club_id
+            ON CONFLICT (club_id, date) DO UPDATE SET
+                flight_count = club_analytics_daily.flight_count + 1,
+                total_airtime_seconds = club_analytics_daily.total_airtime_seconds + flight_duration,
+                tow_count = club_analytics_daily.tow_count + CASE WHEN NEW.towed_by_aircraft_id IS NOT NULL THEN 1 ELSE 0 END,
+                updated_at = NOW();
+        END IF;
+
+    -- Handle DELETE
+    ELSIF TG_OP = 'DELETE' AND OLD.club_id IS NOT NULL THEN
+        -- Skip flights without takeoff_time
+        IF OLD.takeoff_time IS NULL THEN
+            RETURN OLD;
+        END IF;
+
+        old_club := OLD.club_id;
+        old_date := DATE(OLD.takeoff_time);
+        old_duration := get_flight_duration_seconds(OLD.takeoff_time, OLD.landing_time);
+
+        UPDATE club_analytics_daily SET
+            flight_count = GREATEST(0, flight_count - 1),
+            total_airtime_seconds = GREATEST(0, total_airtime_seconds - old_duration),
+            tow_count = GREATEST(0, tow_count - CASE WHEN OLD.towed_by_aircraft_id IS NOT NULL THEN 1 ELSE 0 END),
+            updated_at = NOW()
+        WHERE club_id = old_club AND date = old_date;
+    END IF;
+
+    RETURN NEW;
+END;
+$function$;
+
+-- Update flight_analytics_daily trigger function to use towed_by_aircraft_id
+CREATE OR REPLACE FUNCTION public.update_flight_analytics_daily()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+    affected_date DATE;
+    old_date DATE;
+    flight_duration INT;
+    old_duration INT;
+BEGIN
+    -- Handle INSERT
+    IF TG_OP = 'INSERT' THEN
+        -- Skip flights without takeoff_time
+        IF NEW.takeoff_time IS NULL THEN
+            RETURN NEW;
+        END IF;
+
+        affected_date := DATE(NEW.takeoff_time);
+        flight_duration := get_flight_duration_seconds(NEW.takeoff_time, NEW.landing_time);
+
+        INSERT INTO flight_analytics_daily (date, flight_count, total_duration_seconds, total_distance_meters, tow_flight_count, cross_country_count)
+        VALUES (
+            affected_date,
+            1,
+            flight_duration,
+            COALESCE(NEW.total_distance_meters, 0),
+            CASE WHEN NEW.towed_by_aircraft_id IS NOT NULL THEN 1 ELSE 0 END,
+            CASE WHEN NEW.departure_airport_id IS DISTINCT FROM NEW.arrival_airport_id THEN 1 ELSE 0 END
+        )
+        ON CONFLICT (date) DO UPDATE SET
+            flight_count = flight_analytics_daily.flight_count + 1,
+            total_duration_seconds = flight_analytics_daily.total_duration_seconds + flight_duration,
+            total_distance_meters = flight_analytics_daily.total_distance_meters + COALESCE(NEW.total_distance_meters, 0),
+            tow_flight_count = flight_analytics_daily.tow_flight_count + CASE WHEN NEW.towed_by_aircraft_id IS NOT NULL THEN 1 ELSE 0 END,
+            cross_country_count = flight_analytics_daily.cross_country_count + CASE WHEN NEW.departure_airport_id IS DISTINCT FROM NEW.arrival_airport_id THEN 1 ELSE 0 END,
+            avg_duration_seconds = CASE WHEN flight_analytics_daily.flight_count + 1 > 0
+                THEN (flight_analytics_daily.total_duration_seconds + flight_duration) / (flight_analytics_daily.flight_count + 1)
+                ELSE 0 END,
+            updated_at = NOW();
+
+    -- Handle UPDATE
+    ELSIF TG_OP = 'UPDATE' THEN
+        -- Skip if both old and new takeoff_time are NULL
+        IF OLD.takeoff_time IS NULL AND NEW.takeoff_time IS NULL THEN
+            RETURN NEW;
+        END IF;
+
+        old_date := DATE(OLD.takeoff_time);
+        affected_date := DATE(NEW.takeoff_time);
+        old_duration := get_flight_duration_seconds(OLD.takeoff_time, OLD.landing_time);
+        flight_duration := get_flight_duration_seconds(NEW.takeoff_time, NEW.landing_time);
+
+        -- Remove old values
+        UPDATE flight_analytics_daily SET
+            flight_count = GREATEST(0, flight_count - 1),
+            total_duration_seconds = GREATEST(0, total_duration_seconds - old_duration),
+            total_distance_meters = GREATEST(0, total_distance_meters - COALESCE(OLD.total_distance_meters, 0)),
+            tow_flight_count = GREATEST(0, tow_flight_count - CASE WHEN OLD.towed_by_aircraft_id IS NOT NULL THEN 1 ELSE 0 END),
+            cross_country_count = GREATEST(0, cross_country_count - CASE WHEN OLD.departure_airport_id IS DISTINCT FROM OLD.arrival_airport_id THEN 1 ELSE 0 END),
+            avg_duration_seconds = CASE WHEN flight_count - 1 > 0
+                THEN (total_duration_seconds - old_duration) / (flight_count - 1)
+                ELSE 0 END,
+            updated_at = NOW()
+        WHERE date = old_date;
+
+        -- Add new values
+        INSERT INTO flight_analytics_daily (date, flight_count, total_duration_seconds, total_distance_meters, tow_flight_count, cross_country_count)
+        VALUES (
+            affected_date,
+            1,
+            flight_duration,
+            COALESCE(NEW.total_distance_meters, 0),
+            CASE WHEN NEW.towed_by_aircraft_id IS NOT NULL THEN 1 ELSE 0 END,
+            CASE WHEN NEW.departure_airport_id IS DISTINCT FROM NEW.arrival_airport_id THEN 1 ELSE 0 END
+        )
+        ON CONFLICT (date) DO UPDATE SET
+            flight_count = flight_analytics_daily.flight_count + 1,
+            total_duration_seconds = flight_analytics_daily.total_duration_seconds + flight_duration,
+            total_distance_meters = flight_analytics_daily.total_distance_meters + COALESCE(NEW.total_distance_meters, 0),
+            tow_flight_count = flight_analytics_daily.tow_flight_count + CASE WHEN NEW.towed_by_aircraft_id IS NOT NULL THEN 1 ELSE 0 END,
+            cross_country_count = flight_analytics_daily.cross_country_count + CASE WHEN NEW.departure_airport_id IS DISTINCT FROM NEW.arrival_airport_id THEN 1 ELSE 0 END,
+            avg_duration_seconds = CASE WHEN flight_analytics_daily.flight_count + 1 > 0
+                THEN (flight_analytics_daily.total_duration_seconds + flight_duration) / (flight_analytics_daily.flight_count + 1)
+                ELSE 0 END,
+            updated_at = NOW();
+
+    -- Handle DELETE
+    ELSIF TG_OP = 'DELETE' THEN
+        -- Skip flights without takeoff_time
+        IF OLD.takeoff_time IS NULL THEN
+            RETURN OLD;
+        END IF;
+
+        affected_date := DATE(OLD.takeoff_time);
+        old_duration := get_flight_duration_seconds(OLD.takeoff_time, OLD.landing_time);
+
+        UPDATE flight_analytics_daily SET
+            flight_count = GREATEST(0, flight_count - 1),
+            total_duration_seconds = GREATEST(0, total_duration_seconds - old_duration),
+            total_distance_meters = GREATEST(0, total_distance_meters - COALESCE(OLD.total_distance_meters, 0)),
+            tow_flight_count = GREATEST(0, tow_flight_count - CASE WHEN OLD.towed_by_aircraft_id IS NOT NULL THEN 1 ELSE 0 END),
+            cross_country_count = GREATEST(0, cross_country_count - CASE WHEN OLD.departure_airport_id IS DISTINCT FROM OLD.arrival_airport_id THEN 1 ELSE 0 END),
+            avg_duration_seconds = CASE WHEN flight_count - 1 > 0
+                THEN (total_duration_seconds - old_duration) / (flight_count - 1)
+                ELSE 0 END,
+            updated_at = NOW()
+        WHERE date = affected_date;
+    END IF;
+
+    RETURN NEW;
+END;
+$function$;

--- a/src/flight_tracker/state_transitions.rs
+++ b/src/flight_tracker/state_transitions.rs
@@ -382,7 +382,10 @@ pub(crate) async fn process_state_transition(
                         }
                     }
                     Err(e) => {
-                        warn!("Failed to create flight: {}", e);
+                        error!(
+                            "Failed to create flight for aircraft {}: {}",
+                            fix.aircraft_id, e
+                        );
                         let mut flights = ctx.active_flights.write().await;
                         flights.remove(&fix.aircraft_id);
                     }
@@ -414,7 +417,10 @@ pub(crate) async fn process_state_transition(
                         // Note: last_fix_at is already set during flight creation
                     }
                     Err(e) => {
-                        warn!("Failed to create flight: {}", e);
+                        error!(
+                            "Failed to create flight for aircraft {}: {}",
+                            fix.aircraft_id, e
+                        );
                         let mut flights = ctx.active_flights.write().await;
                         flights.remove(&fix.aircraft_id);
                     }


### PR DESCRIPTION
## Summary

This PR fixes the `record "new" has no field "device_id"` error that was preventing flight insertion. The analytics triggers were not updated when the `devices` table was renamed to `aircraft` in migration `2025-12-11-165518`.

## Changes

### Database Migration
- **New migration**: `2025-12-12-231506-0000_fix_analytics_triggers_device_to_aircraft`
- Updated `update_device_analytics()` to use `aircraft_id` instead of `device_id`
- Updated `update_club_analytics_daily()` to use `towed_by_aircraft_id` instead of `towed_by_device_id`
- Updated `update_flight_analytics_daily()` to use `towed_by_aircraft_id` instead of `towed_by_device_id`

### Code Changes
- Changed flight creation error logging from `WARN` to `ERROR` level (this is a database issue, not a warning)
- Added `aircraft_id` to error logs for easier debugging (`state_transitions.rs:385`, `state_transitions.rs:417`)

## Testing

- ✅ Migration ran successfully on `soar_dev`
- ✅ Verified no other database functions/triggers reference non-existent columns
- ✅ Verified no foreign keys point to old `devices` table
- ✅ Code compiles without errors

## Impact

This fixes a critical bug preventing all flight creation from working properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)