### PR TITLE
feat: add environment context to all email notifications

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -5,6 +5,15 @@ use lettre::{
     transport::smtp::{authentication::Credentials, response::Response},
 };
 
+/// Get the staging prefix for email subjects
+/// Returns "[STAGING] " if SOAR_ENV=staging, empty string otherwise
+fn get_staging_prefix() -> &'static str {
+    match std::env::var("SOAR_ENV").unwrap_or_default().as_str() {
+        "staging" => "[STAGING] ",
+        _ => "",
+    }
+}
+
 pub struct EmailService {
     mailer: AsyncSmtpTransport<Tokio1Executor>,
     from_email: String,
@@ -70,7 +79,7 @@ impl EmailService {
 
         let reset_url = format!("{}/reset-password?token={}", base_url, reset_token);
 
-        let subject = "Password Reset Request - SOAR";
+        let subject = format!("{}Password Reset Request - SOAR", get_staging_prefix());
         let body = format!(
             r#"Hello {},
 
@@ -110,7 +119,7 @@ The SOAR Team"#,
 
         let verification_url = format!("{}/verify-email?token={}", base_url, verification_token);
 
-        let subject = "Verify Your Email Address - SOAR";
+        let subject = format!("{}Verify Your Email Address - SOAR", get_staging_prefix());
         let body = format!(
             r#"Hello {},
 


### PR DESCRIPTION
## Summary

- Add `[STAGING]` prefix to email subjects when running in staging environment
- Include environment name (Production/Staging/Development) in email body HTML
- Production emails remain unchanged (no prefix in subject)

## Changes

### Data Load Report Emails (`email_reporter.rs`)
- Subject: `[STAGING] ✓ SOAR Data Load Complete - 2025-01-13` (staging only)
- Body: Shows environment in title and summary section

### Archive Report Emails (`archive_email_reporter.rs`)
- Subject: `[STAGING] ✓ SOAR Archive Complete - 2025-01-13` (staging only)
- Body: Shows environment in title and summary section

### User-Facing Emails (`email.rs`)
- Password reset emails get `[STAGING]` prefix in staging
- Email verification emails get `[STAGING]` prefix in staging
- Production emails unchanged

## Implementation

- Environment detection uses `SOAR_ENV` environment variable
- Helper functions:
  - `get_environment_name()` - Returns display name
  - `get_staging_prefix()` - Returns `"[STAGING] "` or `""`
- All email sending code updated consistently

## Testing

- ✅ Code compiles cleanly (`cargo check`)
- ✅ Formatted with `cargo fmt`
- ✅ Pre-commit hooks passed

## Impact

This ensures staging emails are clearly distinguishable from production emails, reducing the risk of confusion when monitoring automated tasks.