### PR TITLE
fix: add release event trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main ]
+  release:
+    types: [ published ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- Adds `release` event trigger to CI workflow so production deployments actually run

## Problem
The `deploy-production` job had a condition `if: github.event_name == 'release'` but the workflow was never triggered by release events because `release` was missing from the `on:` section.

This meant that running `./scripts/create-release patch` would create a GitHub Release, but the production deployment job would never execute.

## Solution
Add `release: types: [published]` to the workflow triggers.

## Test Plan
- [x] Commit pushed to main triggers CI (existing behavior)
- [ ] Creating a new release triggers CI workflow with deploy-production job