### PR TITLE
Fix NATS client names to respect SOAR_ENV environment variable

### DIFF
--- a/src/commands/consume_beast.rs
+++ b/src/commands/consume_beast.rs
@@ -159,8 +159,13 @@ pub async fn handle_consume_beast(
         }
 
         info!("Connecting to NATS at {}...", nats_url);
+        let nats_client_name = if std::env::var("SOAR_ENV") == Ok("production".into()) {
+            "soar-beast-consumer"
+        } else {
+            "soar-beast-consumer-staging"
+        };
         let nats_result = async_nats::ConnectOptions::new()
-            .name("soar-beast-consumer")
+            .name(nats_client_name)
             .connect(&nats_url)
             .await;
 

--- a/src/commands/ingest_aprs.rs
+++ b/src/commands/ingest_aprs.rs
@@ -162,8 +162,13 @@ pub async fn handle_ingest_aprs(
         }
 
         info!("Connecting to NATS at {}...", nats_url);
+        let nats_client_name = if std::env::var("SOAR_ENV") == Ok("production".into()) {
+            "soar-aprs-ingester"
+        } else {
+            "soar-aprs-ingester-staging"
+        };
         let nats_result = async_nats::ConnectOptions::new()
-            .name("soar-aprs-ingester")
+            .name(nats_client_name)
             .client_capacity(65536) // Increase from default 2048 to prevent blocking on publish
             .subscription_capacity(1024 * 128) // Increase subscription buffer
             .connect(&nats_url)

--- a/src/commands/ingest_beast.rs
+++ b/src/commands/ingest_beast.rs
@@ -152,8 +152,13 @@ pub async fn handle_ingest_beast(
         }
 
         info!("Connecting to NATS at {}...", nats_url);
+        let nats_client_name = if std::env::var("SOAR_ENV") == Ok("production".into()) {
+            "soar-beast-ingester"
+        } else {
+            "soar-beast-ingester-staging"
+        };
         let nats_result = async_nats::ConnectOptions::new()
-            .name("soar-beast-ingester")
+            .name(nats_client_name)
             .connect(&nats_url)
             .await;
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -725,8 +725,13 @@ pub async fn handle_run(
     // Retry loop for JetStream consumer connection and consumption
     loop {
         info!("Connecting to NATS at {}...", nats_url);
+        let nats_client_name = if std::env::var("SOAR_ENV") == Ok("production".into()) {
+            "soar-run"
+        } else {
+            "soar-run-staging"
+        };
         let nats_result = async_nats::ConnectOptions::new()
-            .name("soar-run")
+            .name(nats_client_name)
             .connect(&nats_url)
             .await;
 


### PR DESCRIPTION
## Summary

Fixed NATS client name inconsistency across all commands. All NATS connections now respect the `SOAR_ENV` environment variable to prevent client name conflicts between production and staging environments.

**Before:** Commands hardcoded production client names, causing conflicts when running locally  
**After:** All commands check `SOAR_ENV` and use `-staging` suffix for non-production environments

## Changes

Updated NATS client naming in all command files:
- `ingest_aprs`: soar-aprs-ingester / soar-aprs-ingester-staging
- `run`: soar-run / soar-run-staging
- `consume_beast`: soar-beast-consumer / soar-beast-consumer-staging
- `ingest_beast`: soar-beast-ingester / soar-beast-ingester-staging

This aligns with existing behavior in `nats_publisher.rs` and `live_fixes.rs`.

## Test Plan

- [x] Verify commands connect with correct client names based on SOAR_ENV
- [x] Test local development uses `-staging` suffix by default
- [x] Confirm production deployments use production names
- [x] Pre-commit hooks passed (formatting, clippy)