### PR TITLE
fix: rename partitions from aprs_messages to raw_messages

### DIFF
--- a/migrations/2025-12-14-211747-0000_rename_partitions_to_raw_messages/down.sql
+++ b/migrations/2025-12-14-211747-0000_rename_partitions_to_raw_messages/down.sql
@@ -1,0 +1,51 @@
+-- Reverse the renaming from raw_messages back to aprs_messages
+-- NOTE: This does not restore the aprs_messages_old table that was dropped
+
+-- 1. Update pg_partman configuration to reference the old template table name
+UPDATE partman.part_config
+SET template_table = 'partman.template_public_aprs_messages'
+WHERE parent_table = 'public.raw_messages'
+AND template_table = 'partman.template_public_raw_messages';
+
+-- 2. Rename the default partition back
+ALTER TABLE IF EXISTS raw_messages_default
+    RENAME TO aprs_messages_default;
+
+-- 3. Rename all existing partition tables back to aprs_messages_*
+DO $$
+DECLARE
+    partition_name TEXT;
+BEGIN
+    FOR partition_name IN
+        SELECT tablename
+        FROM pg_tables
+        WHERE schemaname = 'public'
+        AND tablename LIKE 'raw_messages_p%'
+    LOOP
+        EXECUTE format('ALTER TABLE %I RENAME TO %I',
+            partition_name,
+            replace(partition_name, 'raw_messages_', 'aprs_messages_')
+        );
+    END LOOP;
+END $$;
+
+-- 4. Rename the foreign key constraint back
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE constraint_name = 'raw_messages_receiver_id_fkey'
+        AND table_name = 'raw_messages'
+    ) THEN
+        ALTER TABLE raw_messages
+            RENAME CONSTRAINT raw_messages_receiver_id_fkey TO aprs_messages_receiver_id_fkey;
+    END IF;
+END $$;
+
+-- 5. Rename the primary key index back
+ALTER INDEX IF EXISTS raw_messages_pkey
+    RENAME TO aprs_messages_pkey1;
+
+-- 6. Rename the template table back
+ALTER TABLE IF EXISTS partman.template_public_raw_messages
+    RENAME TO template_public_aprs_messages;

--- a/migrations/2025-12-14-211747-0000_rename_partitions_to_raw_messages/up.sql
+++ b/migrations/2025-12-14-211747-0000_rename_partitions_to_raw_messages/up.sql
@@ -1,0 +1,55 @@
+-- Rename partitions and related objects from aprs_messages to raw_messages
+-- This migration ensures consistency after the table was renamed from aprs_messages to raw_messages
+
+-- 1. Rename the template table used by pg_partman
+ALTER TABLE IF EXISTS partman.template_public_aprs_messages
+    RENAME TO template_public_raw_messages;
+
+-- 2. Rename the primary key index on the parent table
+ALTER INDEX IF EXISTS aprs_messages_pkey1
+    RENAME TO raw_messages_pkey;
+
+-- 3. Rename the foreign key constraint on the parent table
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE constraint_name = 'aprs_messages_receiver_id_fkey'
+        AND table_name = 'raw_messages'
+    ) THEN
+        ALTER TABLE raw_messages
+            RENAME CONSTRAINT aprs_messages_receiver_id_fkey TO raw_messages_receiver_id_fkey;
+    END IF;
+END $$;
+
+-- 4. Rename all existing partition tables
+-- This uses dynamic SQL to rename any aprs_messages_* partitions that exist
+DO $$
+DECLARE
+    partition_name TEXT;
+BEGIN
+    FOR partition_name IN
+        SELECT tablename
+        FROM pg_tables
+        WHERE schemaname = 'public'
+        AND tablename LIKE 'aprs_messages_p%'
+    LOOP
+        EXECUTE format('ALTER TABLE %I RENAME TO %I',
+            partition_name,
+            replace(partition_name, 'aprs_messages_', 'raw_messages_')
+        );
+    END LOOP;
+END $$;
+
+-- 5. Rename the default partition if it exists
+ALTER TABLE IF EXISTS aprs_messages_default
+    RENAME TO raw_messages_default;
+
+-- 6. Update pg_partman configuration to reference the new template table
+UPDATE partman.part_config
+SET template_table = 'partman.template_public_raw_messages'
+WHERE parent_table = 'public.raw_messages'
+AND template_table = 'partman.template_public_aprs_messages';
+
+-- 7. Drop the old aprs_messages_old table if it exists
+DROP TABLE IF EXISTS aprs_messages_old CASCADE;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -242,137 +242,6 @@ diesel::table! {
 }
 
 diesel::table! {
-    use diesel::sql_types::*;
-    use super::sql_types::MessageSource;
-
-    aprs_messages_default (id, received_at) {
-        id -> Uuid,
-        received_at -> Timestamptz,
-        receiver_id -> Uuid,
-        unparsed -> Nullable<Text>,
-        raw_message_hash -> Bytea,
-        raw_message -> Bytea,
-        source -> MessageSource,
-    }
-}
-
-diesel::table! {
-    aprs_messages_old (id) {
-        id -> Uuid,
-        raw_message -> Text,
-        received_at -> Timestamptz,
-        receiver_id -> Uuid,
-        unparsed -> Nullable<Text>,
-        raw_message_hash -> Bytea,
-    }
-}
-
-diesel::table! {
-    use diesel::sql_types::*;
-    use super::sql_types::MessageSource;
-
-    aprs_messages_p20251114 (id, received_at) {
-        id -> Uuid,
-        received_at -> Timestamptz,
-        receiver_id -> Uuid,
-        unparsed -> Nullable<Text>,
-        raw_message_hash -> Bytea,
-        raw_message -> Bytea,
-        source -> MessageSource,
-    }
-}
-
-diesel::table! {
-    use diesel::sql_types::*;
-    use super::sql_types::MessageSource;
-
-    aprs_messages_p20251115 (id, received_at) {
-        id -> Uuid,
-        received_at -> Timestamptz,
-        receiver_id -> Uuid,
-        unparsed -> Nullable<Text>,
-        raw_message_hash -> Bytea,
-        raw_message -> Bytea,
-        source -> MessageSource,
-    }
-}
-
-diesel::table! {
-    use diesel::sql_types::*;
-    use super::sql_types::MessageSource;
-
-    aprs_messages_p20251116 (id, received_at) {
-        id -> Uuid,
-        received_at -> Timestamptz,
-        receiver_id -> Uuid,
-        unparsed -> Nullable<Text>,
-        raw_message_hash -> Bytea,
-        raw_message -> Bytea,
-        source -> MessageSource,
-    }
-}
-
-diesel::table! {
-    use diesel::sql_types::*;
-    use super::sql_types::MessageSource;
-
-    aprs_messages_p20251117 (id, received_at) {
-        id -> Uuid,
-        received_at -> Timestamptz,
-        receiver_id -> Uuid,
-        unparsed -> Nullable<Text>,
-        raw_message_hash -> Bytea,
-        raw_message -> Bytea,
-        source -> MessageSource,
-    }
-}
-
-diesel::table! {
-    use diesel::sql_types::*;
-    use super::sql_types::MessageSource;
-
-    aprs_messages_p20251118 (id, received_at) {
-        id -> Uuid,
-        received_at -> Timestamptz,
-        receiver_id -> Uuid,
-        unparsed -> Nullable<Text>,
-        raw_message_hash -> Bytea,
-        raw_message -> Bytea,
-        source -> MessageSource,
-    }
-}
-
-diesel::table! {
-    use diesel::sql_types::*;
-    use super::sql_types::MessageSource;
-
-    aprs_messages_p20251119 (id, received_at) {
-        id -> Uuid,
-        received_at -> Timestamptz,
-        receiver_id -> Uuid,
-        unparsed -> Nullable<Text>,
-        raw_message_hash -> Bytea,
-        raw_message -> Bytea,
-        source -> MessageSource,
-    }
-}
-
-diesel::table! {
-    use diesel::sql_types::*;
-    use super::sql_types::MessageSource;
-
-    aprs_messages_p20251120 (id, received_at) {
-        id -> Uuid,
-        received_at -> Timestamptz,
-        receiver_id -> Uuid,
-        unparsed -> Nullable<Text>,
-        raw_message_hash -> Bytea,
-        raw_message -> Bytea,
-        source -> MessageSource,
-    }
-}
-
-diesel::table! {
     club_analytics_daily (club_id, date) {
         club_id -> Uuid,
         date -> Date,
@@ -546,7 +415,7 @@ diesel::table! {
     use super::sql_types::Geography;
     use super::sql_types::Geometry;
 
-    fixes_p20251114 (id, received_at) {
+    fixes_p20251209 (id, received_at) {
         id -> Uuid,
         #[max_length = 9]
         source -> Varchar,
@@ -585,7 +454,7 @@ diesel::table! {
     use super::sql_types::Geography;
     use super::sql_types::Geometry;
 
-    fixes_p20251115 (id, received_at) {
+    fixes_p20251210 (id, received_at) {
         id -> Uuid,
         #[max_length = 9]
         source -> Varchar,
@@ -624,7 +493,7 @@ diesel::table! {
     use super::sql_types::Geography;
     use super::sql_types::Geometry;
 
-    fixes_p20251116 (id, received_at) {
+    fixes_p20251211 (id, received_at) {
         id -> Uuid,
         #[max_length = 9]
         source -> Varchar,
@@ -663,7 +532,7 @@ diesel::table! {
     use super::sql_types::Geography;
     use super::sql_types::Geometry;
 
-    fixes_p20251117 (id, received_at) {
+    fixes_p20251212 (id, received_at) {
         id -> Uuid,
         #[max_length = 9]
         source -> Varchar,
@@ -702,7 +571,7 @@ diesel::table! {
     use super::sql_types::Geography;
     use super::sql_types::Geometry;
 
-    fixes_p20251118 (id, received_at) {
+    fixes_p20251213 (id, received_at) {
         id -> Uuid,
         #[max_length = 9]
         source -> Varchar,
@@ -741,7 +610,7 @@ diesel::table! {
     use super::sql_types::Geography;
     use super::sql_types::Geometry;
 
-    fixes_p20251119 (id, received_at) {
+    fixes_p20251214 (id, received_at) {
         id -> Uuid,
         #[max_length = 9]
         source -> Varchar,
@@ -780,7 +649,7 @@ diesel::table! {
     use super::sql_types::Geography;
     use super::sql_types::Geometry;
 
-    fixes_p20251120 (id, received_at) {
+    fixes_p20251215 (id, received_at) {
         id -> Uuid,
         #[max_length = 9]
         source -> Varchar,
@@ -944,6 +813,126 @@ diesel::table! {
     use super::sql_types::MessageSource;
 
     raw_messages (id, received_at) {
+        id -> Uuid,
+        received_at -> Timestamptz,
+        receiver_id -> Uuid,
+        unparsed -> Nullable<Text>,
+        raw_message_hash -> Bytea,
+        raw_message -> Bytea,
+        source -> MessageSource,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::MessageSource;
+
+    raw_messages_default (id, received_at) {
+        id -> Uuid,
+        received_at -> Timestamptz,
+        receiver_id -> Uuid,
+        unparsed -> Nullable<Text>,
+        raw_message_hash -> Bytea,
+        raw_message -> Bytea,
+        source -> MessageSource,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::MessageSource;
+
+    raw_messages_p20251209 (id, received_at) {
+        id -> Uuid,
+        received_at -> Timestamptz,
+        receiver_id -> Uuid,
+        unparsed -> Nullable<Text>,
+        raw_message_hash -> Bytea,
+        raw_message -> Bytea,
+        source -> MessageSource,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::MessageSource;
+
+    raw_messages_p20251210 (id, received_at) {
+        id -> Uuid,
+        received_at -> Timestamptz,
+        receiver_id -> Uuid,
+        unparsed -> Nullable<Text>,
+        raw_message_hash -> Bytea,
+        raw_message -> Bytea,
+        source -> MessageSource,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::MessageSource;
+
+    raw_messages_p20251211 (id, received_at) {
+        id -> Uuid,
+        received_at -> Timestamptz,
+        receiver_id -> Uuid,
+        unparsed -> Nullable<Text>,
+        raw_message_hash -> Bytea,
+        raw_message -> Bytea,
+        source -> MessageSource,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::MessageSource;
+
+    raw_messages_p20251212 (id, received_at) {
+        id -> Uuid,
+        received_at -> Timestamptz,
+        receiver_id -> Uuid,
+        unparsed -> Nullable<Text>,
+        raw_message_hash -> Bytea,
+        raw_message -> Bytea,
+        source -> MessageSource,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::MessageSource;
+
+    raw_messages_p20251213 (id, received_at) {
+        id -> Uuid,
+        received_at -> Timestamptz,
+        receiver_id -> Uuid,
+        unparsed -> Nullable<Text>,
+        raw_message_hash -> Bytea,
+        raw_message -> Bytea,
+        source -> MessageSource,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::MessageSource;
+
+    raw_messages_p20251214 (id, received_at) {
+        id -> Uuid,
+        received_at -> Timestamptz,
+        receiver_id -> Uuid,
+        unparsed -> Nullable<Text>,
+        raw_message_hash -> Bytea,
+        raw_message -> Bytea,
+        source -> MessageSource,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::MessageSource;
+
+    raw_messages_p20251215 (id, received_at) {
         id -> Uuid,
         received_at -> Timestamptz,
         receiver_id -> Uuid,
@@ -1195,15 +1184,6 @@ diesel::joinable!(aircraft_registrations -> clubs (club_id));
 diesel::joinable!(aircraft_registrations -> locations (location_id));
 diesel::joinable!(aircraft_registrations -> status_codes (status_code));
 diesel::joinable!(aircraft_registrations -> type_engines (type_engine_code));
-diesel::joinable!(aprs_messages_default -> receivers (receiver_id));
-diesel::joinable!(aprs_messages_old -> receivers (receiver_id));
-diesel::joinable!(aprs_messages_p20251114 -> receivers (receiver_id));
-diesel::joinable!(aprs_messages_p20251115 -> receivers (receiver_id));
-diesel::joinable!(aprs_messages_p20251116 -> receivers (receiver_id));
-diesel::joinable!(aprs_messages_p20251117 -> receivers (receiver_id));
-diesel::joinable!(aprs_messages_p20251118 -> receivers (receiver_id));
-diesel::joinable!(aprs_messages_p20251119 -> receivers (receiver_id));
-diesel::joinable!(aprs_messages_p20251120 -> receivers (receiver_id));
 diesel::joinable!(clubs -> airports (home_base_airport_id));
 diesel::joinable!(clubs -> locations (location_id));
 diesel::joinable!(fixes -> aircraft (aircraft_id));
@@ -1213,36 +1193,43 @@ diesel::joinable!(fixes_default -> aircraft (aircraft_id));
 diesel::joinable!(fixes_default -> flights (flight_id));
 diesel::joinable!(fixes_default -> receivers (receiver_id));
 diesel::joinable!(fixes_old -> aircraft (aircraft_id));
-diesel::joinable!(fixes_old -> aprs_messages_old (aprs_message_id));
 diesel::joinable!(fixes_old -> flights (flight_id));
 diesel::joinable!(fixes_old -> receivers (receiver_id));
-diesel::joinable!(fixes_p20251114 -> aircraft (aircraft_id));
-diesel::joinable!(fixes_p20251114 -> flights (flight_id));
-diesel::joinable!(fixes_p20251114 -> receivers (receiver_id));
-diesel::joinable!(fixes_p20251115 -> aircraft (aircraft_id));
-diesel::joinable!(fixes_p20251115 -> flights (flight_id));
-diesel::joinable!(fixes_p20251115 -> receivers (receiver_id));
-diesel::joinable!(fixes_p20251116 -> aircraft (aircraft_id));
-diesel::joinable!(fixes_p20251116 -> flights (flight_id));
-diesel::joinable!(fixes_p20251116 -> receivers (receiver_id));
-diesel::joinable!(fixes_p20251117 -> aircraft (aircraft_id));
-diesel::joinable!(fixes_p20251117 -> flights (flight_id));
-diesel::joinable!(fixes_p20251117 -> receivers (receiver_id));
-diesel::joinable!(fixes_p20251118 -> aircraft (aircraft_id));
-diesel::joinable!(fixes_p20251118 -> flights (flight_id));
-diesel::joinable!(fixes_p20251118 -> receivers (receiver_id));
-diesel::joinable!(fixes_p20251119 -> aircraft (aircraft_id));
-diesel::joinable!(fixes_p20251119 -> flights (flight_id));
-diesel::joinable!(fixes_p20251119 -> receivers (receiver_id));
-diesel::joinable!(fixes_p20251120 -> aircraft (aircraft_id));
-diesel::joinable!(fixes_p20251120 -> flights (flight_id));
-diesel::joinable!(fixes_p20251120 -> receivers (receiver_id));
+diesel::joinable!(fixes_p20251209 -> aircraft (aircraft_id));
+diesel::joinable!(fixes_p20251209 -> flights (flight_id));
+diesel::joinable!(fixes_p20251209 -> receivers (receiver_id));
+diesel::joinable!(fixes_p20251210 -> aircraft (aircraft_id));
+diesel::joinable!(fixes_p20251210 -> flights (flight_id));
+diesel::joinable!(fixes_p20251210 -> receivers (receiver_id));
+diesel::joinable!(fixes_p20251211 -> aircraft (aircraft_id));
+diesel::joinable!(fixes_p20251211 -> flights (flight_id));
+diesel::joinable!(fixes_p20251211 -> receivers (receiver_id));
+diesel::joinable!(fixes_p20251212 -> aircraft (aircraft_id));
+diesel::joinable!(fixes_p20251212 -> flights (flight_id));
+diesel::joinable!(fixes_p20251212 -> receivers (receiver_id));
+diesel::joinable!(fixes_p20251213 -> aircraft (aircraft_id));
+diesel::joinable!(fixes_p20251213 -> flights (flight_id));
+diesel::joinable!(fixes_p20251213 -> receivers (receiver_id));
+diesel::joinable!(fixes_p20251214 -> aircraft (aircraft_id));
+diesel::joinable!(fixes_p20251214 -> flights (flight_id));
+diesel::joinable!(fixes_p20251214 -> receivers (receiver_id));
+diesel::joinable!(fixes_p20251215 -> aircraft (aircraft_id));
+diesel::joinable!(fixes_p20251215 -> flights (flight_id));
+diesel::joinable!(fixes_p20251215 -> receivers (receiver_id));
 diesel::joinable!(flight_pilots -> flights (flight_id));
 diesel::joinable!(flight_pilots -> pilots (pilot_id));
 diesel::joinable!(flights -> clubs (club_id));
 diesel::joinable!(pilots -> clubs (club_id));
 diesel::joinable!(pilots -> users (user_id));
 diesel::joinable!(raw_messages -> receivers (receiver_id));
+diesel::joinable!(raw_messages_default -> receivers (receiver_id));
+diesel::joinable!(raw_messages_p20251209 -> receivers (receiver_id));
+diesel::joinable!(raw_messages_p20251210 -> receivers (receiver_id));
+diesel::joinable!(raw_messages_p20251211 -> receivers (receiver_id));
+diesel::joinable!(raw_messages_p20251212 -> receivers (receiver_id));
+diesel::joinable!(raw_messages_p20251213 -> receivers (receiver_id));
+diesel::joinable!(raw_messages_p20251214 -> receivers (receiver_id));
+diesel::joinable!(raw_messages_p20251215 -> receivers (receiver_id));
 diesel::joinable!(receiver_statuses -> receivers (receiver_id));
 diesel::joinable!(receivers_links -> receivers (receiver_id));
 diesel::joinable!(receivers_photos -> receivers (receiver_id));
@@ -1258,15 +1245,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     aircraft_registrations,
     airport_analytics_daily,
     airports,
-    aprs_messages_default,
-    aprs_messages_old,
-    aprs_messages_p20251114,
-    aprs_messages_p20251115,
-    aprs_messages_p20251116,
-    aprs_messages_p20251117,
-    aprs_messages_p20251118,
-    aprs_messages_p20251119,
-    aprs_messages_p20251120,
     club_analytics_daily,
     clubs,
     countries,
@@ -1274,13 +1252,13 @@ diesel::allow_tables_to_appear_in_same_query!(
     fixes,
     fixes_default,
     fixes_old,
-    fixes_p20251114,
-    fixes_p20251115,
-    fixes_p20251116,
-    fixes_p20251117,
-    fixes_p20251118,
-    fixes_p20251119,
-    fixes_p20251120,
+    fixes_p20251209,
+    fixes_p20251210,
+    fixes_p20251211,
+    fixes_p20251212,
+    fixes_p20251213,
+    fixes_p20251214,
+    fixes_p20251215,
     flight_analytics_daily,
     flight_analytics_hourly,
     flight_duration_buckets,
@@ -1289,6 +1267,14 @@ diesel::allow_tables_to_appear_in_same_query!(
     locations,
     pilots,
     raw_messages,
+    raw_messages_default,
+    raw_messages_p20251209,
+    raw_messages_p20251210,
+    raw_messages_p20251211,
+    raw_messages_p20251212,
+    raw_messages_p20251213,
+    raw_messages_p20251214,
+    raw_messages_p20251215,
     receiver_statuses,
     receivers,
     receivers_links,


### PR DESCRIPTION
## Summary

Ensures naming consistency after the `raw_messages` table was renamed from `aprs_messages`. The partition child tables and related objects were not automatically renamed when the parent table was renamed.

## Changes

- Renamed pg_partman template table to `template_public_raw_messages`
- Renamed all partition tables (`aprs_messages_p*` → `raw_messages_p*`)
- Renamed default partition (`aprs_messages_default` → `raw_messages_default`)
- Renamed primary key index (`aprs_messages_pkey1` → `raw_messages_pkey`)
- Renamed foreign key constraint for consistency
- Updated pg_partman configuration to reference new template
- Dropped obsolete `aprs_messages_old` table

## Technical Details

The migration uses dynamic SQL to handle existing partitions at the time of migration, ensuring it works regardless of which specific partition dates exist.

All naming is now consistent:
- Parent table: `raw_messages`
- Partitions: `raw_messages_p*` and `raw_messages_default`
- Template: `partman.template_public_raw_messages`

## Testing

✅ Tested on `soar_staging` database - migration ran successfully
✅ Pre-commit hooks passed (Clippy, formatting, tests)