### PR TITLE
fix: prevent pull-data from running on every deployment

### DIFF
--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -204,16 +204,10 @@ for service in "${ALL_SERVICES[@]}"; do
     fi
 done
 
-# Stop all timers
-log_info "Stopping SOAR timers..."
-for timer in "${TIMERS[@]}"; do
-    if systemctl is-active --quiet "$timer"; then
-        log_info "Stopping $timer..."
-        systemctl stop "$timer" || log_warn "Failed to stop $timer"
-    else
-        log_info "$timer is not running"
-    fi
-done
+# Note: We intentionally do NOT stop timers during deployment
+# Timers pick up configuration changes via daemon-reload without needing to be stopped/started
+# Stopping and restarting timers with Persistent=yes can trigger immediate runs
+log_info "Skipping timer stop (timers will continue on their schedule)"
 
 # Wait for services to fully terminate
 log_info "Waiting for services to fully terminate..."
@@ -392,15 +386,21 @@ done
 # Timer-invoked services are installed but not enabled or started
 log_info "Timer-invoked services (${TIMER_SERVICES[*]}) will only be invoked by their timers"
 
-# Enable and start timers to ensure they are properly scheduled
-log_info "Enabling and starting SOAR timers..."
+# Enable and start timers only if they're not already running
+# Timers pick up configuration changes via daemon-reload without restart
+log_info "Ensuring SOAR timers are enabled and active..."
 for timer in "${TIMERS[@]}"; do
     if [ -f "/etc/systemd/system/$timer" ]; then
-        log_info "Enabling $timer..."
+        # Enable timer for automatic start on boot
         systemctl enable "$timer" || log_warn "Failed to enable $timer"
 
-        log_info "Starting $timer..."
-        systemctl restart "$timer" || log_warn "Failed to restart $timer"
+        # Start timer only if it's not already active (never restart to avoid triggering Persistent logic)
+        if ! systemctl is-active --quiet "$timer"; then
+            log_info "Starting $timer (was not active)..."
+            systemctl start "$timer" || log_warn "Failed to start $timer"
+        else
+            log_info "$timer is already active and will continue on schedule"
+        fi
     fi
 done
 


### PR DESCRIPTION
## Summary

Fixes an issue where `soar-pull-data` runs on every staging deployment instead of only on its scheduled daily 3:00 AM timer.

## Root Cause

The deployment script was stopping and restarting all systemd timers. The `soar-pull-data-staging.timer` has `Persistent=yes`, which causes systemd to immediately trigger the service when the timer restarts, thinking a scheduled run was "missed" while the timer was inactive.

### Evidence

Correlation between deployments and pull-data runs over the last 3 days shows pull-data triggered within 1 minute of every deployment:

| Deployment Time | Pull-Data Start | Delay |
|-----------------|-----------------|-------|
| Dec 13 20:53:38 | Dec 13 20:54:22 | < 1 min |
| Dec 13 22:18:59 | Dec 13 22:19:43 | < 1 min |
| Dec 14 09:01:00 | Dec 14 09:01:56 | < 1 min |
| Dec 14 19:30:46 | Dec 14 19:31:32 | < 1 min |

## Changes

**infrastructure/soar-deploy:**
- Removed timer stops during deployment (timers don't need restart to pick up config changes)
- Changed `systemctl restart` to conditional `systemctl start` (only if not already active)
- Added comments explaining the Persistent timer behavior

Timers now pick up configuration changes via `daemon-reload` without needing to be stopped/restarted, and will continue running on their normal schedules.

## Test Plan

- [x] Verified deployment script syntax
- [x] Analyzed journalctl logs showing correlation between deployments and pull-data runs
- [ ] Deploy to staging and verify pull-data does NOT run immediately
- [ ] Verify pull-data still runs on its 3:00 AM schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)