### PR TITLE
fix: use rsync with compression for ADSB deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -759,6 +759,11 @@ jobs:
             soar@"${{ secrets.ADSB_SERVER_HOSTNAME }}" \
             "mkdir -p /tmp/soar/deploy/$ADSB_TIMESTAMP"
 
+      - name: Install rsync
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rsync
+
       - name: Create ADSB deployment package
         run: |
           mkdir -p adsb-deploy-pkg
@@ -771,9 +776,9 @@ jobs:
 
       - name: Upload ADSB deployment package
         run: |
-          scp -i ~/.ssh/adsb_deploy \
-            -o StrictHostKeyChecking=no \
-            -r adsb-deploy-pkg/* \
+          rsync -avz --progress \
+            -e "ssh -i ~/.ssh/adsb_deploy -o StrictHostKeyChecking=no" \
+            adsb-deploy-pkg/ \
             soar@"${{ secrets.ADSB_SERVER_HOSTNAME }}":/tmp/soar/deploy/${{ env.ADSB_DEPLOY_TIMESTAMP }}/
 
       - name: Execute ADSB deployment
@@ -972,6 +977,11 @@ jobs:
             soar@"${{ secrets.ADSB_SERVER_HOSTNAME }}" \
             "mkdir -p /tmp/soar/deploy/$ADSB_TIMESTAMP"
 
+      - name: Install rsync
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rsync
+
       - name: Create ADSB deployment package
         run: |
           mkdir -p adsb-deploy-pkg
@@ -984,9 +994,9 @@ jobs:
 
       - name: Upload ADSB deployment package
         run: |
-          scp -i ~/.ssh/adsb_deploy \
-            -o StrictHostKeyChecking=no \
-            -r adsb-deploy-pkg/* \
+          rsync -avz --progress \
+            -e "ssh -i ~/.ssh/adsb_deploy -o StrictHostKeyChecking=no" \
+            adsb-deploy-pkg/ \
             soar@"${{ secrets.ADSB_SERVER_HOSTNAME }}":/tmp/soar/deploy/${{ env.ADSB_DEPLOY_TIMESTAMP }}/
 
       - name: Execute ADSB deployment


### PR DESCRIPTION
## Summary
Replace `scp` with `rsync` for uploading ADSB deployment packages to prevent connection timeouts during long uploads.

## Problem
- ADSB deployments sometimes take 30 minutes to upload
- Connections get closed before upload completes
- `scp` doesn't provide compression or good handling of interrupted transfers

## Solution
- Install rsync on GitHub Actions runners
- Use `rsync -avz --progress` instead of `scp -r`
- Compression (`-z`) reduces transfer time
- Archive mode (`-a`) preserves file attributes
- Better handling of interrupted transfers

## Changes
- Added rsync installation step for both staging and production ADSB deployments
- Replaced scp commands with rsync for ADSB deployment package uploads in both workflows

## Testing
- Pre-commit hooks passed
- CI will validate the changes