### PR TITLE
fix: use CALL for partman maintenance procedure

### DIFF
--- a/infrastructure/systemd/partman-maintenance-staging.service
+++ b/infrastructure/systemd/partman-maintenance-staging.service
@@ -5,6 +5,6 @@ After=postgresql.service
 [Service]
 Type=oneshot
 User=soar
-ExecStart=/usr/bin/psql postgres://localhost/soar_staging -c "SELECT partman.run_maintenance_proc()"
+ExecStart=/usr/bin/psql postgres://localhost/soar_staging -c "CALL partman.run_maintenance_proc()"
 StandardOutput=append:/var/soar/logs/partman-staging.log
 StandardError=append:/var/soar/logs/partman-staging.log

--- a/infrastructure/systemd/partman-maintenance.service
+++ b/infrastructure/systemd/partman-maintenance.service
@@ -5,6 +5,6 @@ After=postgresql.service
 [Service]
 Type=oneshot
 User=soar
-ExecStart=/usr/bin/psql postgres://localhost/soar -c "SELECT partman.run_maintenance_proc()"
+ExecStart=/usr/bin/psql postgres://localhost/soar -c "CALL partman.run_maintenance_proc()"
 StandardOutput=append:/var/soar/logs/partman.log
 StandardError=append:/var/soar/logs/partman.log

--- a/migrations/2025-11-12-191049-0000_convert_fixes_to_partitioned_table/README.md
+++ b/migrations/2025-11-12-191049-0000_convert_fixes_to_partitioned_table/README.md
@@ -109,7 +109,7 @@ After=postgresql.service
 [Service]
 Type=oneshot
 User=soar
-ExecStart=/usr/bin/psql postgres://localhost/soar -c "SELECT partman.run_maintenance_proc()"
+ExecStart=/usr/bin/psql postgres://localhost/soar -c "CALL partman.run_maintenance_proc()"
 StandardOutput=append:/var/soar/logs/partman.log
 StandardError=append:/var/soar/logs/partman.log
 ```
@@ -160,7 +160,7 @@ sudo apt-get install postgresql-16-cron
 ```sql
 -- Run partition maintenance daily at 3 AM for both tables
 SELECT cron.schedule('partman-maintenance', '0 3 * * *',
-    $$SELECT partman.run_maintenance_proc()$$
+    $$CALL partman.run_maintenance_proc()$$
 );
 ```
 


### PR DESCRIPTION
## Summary
- Fixed systemd service files to use `CALL` instead of `SELECT` for `partman.run_maintenance_proc()`
- Updated migration README documentation with correct syntax
- This fixes the failing partman-maintenance timer that was producing PostgreSQL errors

## Problem
The partman-maintenance systemd timer was failing with this error:
```
ERROR:  partman.run_maintenance_proc() is a procedure
LINE 1: SELECT partman.run_maintenance_proc()
               ^
HINT:  To call a procedure, use CALL.
```

The systemd service files were incorrectly using `SELECT` to call `partman.run_maintenance_proc()`, which is a stored procedure, not a function. In PostgreSQL, procedures must be invoked with `CALL`, not `SELECT`.

## Impact
While new partitions were still being created on-demand via pg_partman triggers (configured with `premake = 3`), the maintenance procedure is essential for:
- Pre-creating future partitions (3 days ahead)
- **Detaching old partitions** based on the 30-day retention policy

Without the maintenance procedure running, old partitions were accumulating and not being detached for cleanup.

## Changes
1. `infrastructure/systemd/partman-maintenance.service` - Changed to use `CALL`
2. `infrastructure/systemd/partman-maintenance-staging.service` - Changed to use `CALL`
3. `migrations/2025-11-12-191049-0000_convert_fixes_to_partitioned_table/README.md` - Updated documentation

## Test Plan
- [x] Verify service files have correct syntax
- [ ] Deploy to staging and verify timer runs without errors: `sudo systemctl start partman-maintenance-staging.service`
- [ ] Check logs: `tail -f /var/soar/logs/partman-staging.log`
- [ ] Verify maintenance runs successfully on production timer