### PR TITLE
fix: improve error display and add Sentry alerts for email failures

### DIFF
--- a/src/actions/auth.rs
+++ b/src/actions/auth.rs
@@ -53,6 +53,13 @@ pub async fn register_user(
                                 .await
                             {
                                 error!("Failed to send email verification: {}", e);
+                                sentry::capture_message(
+                                    &format!(
+                                        "Failed to send email verification to {}: {}",
+                                        user.email, e
+                                    ),
+                                    sentry::Level::Error,
+                                );
                                 return json_error(
                                     StatusCode::INTERNAL_SERVER_ERROR,
                                     "Failed to send email verification",
@@ -62,6 +69,10 @@ pub async fn register_user(
                         }
                         Err(e) => {
                             error!("Email service initialization failed: {}", e);
+                            sentry::capture_message(
+                                &format!("Email service initialization failed: {}", e),
+                                sentry::Level::Error,
+                            );
                             return json_error(
                                 StatusCode::INTERNAL_SERVER_ERROR,
                                 "Email service not configured",
@@ -115,6 +126,13 @@ pub async fn login_user(
                                 .await
                         {
                             error!("Failed to send email verification: {}", e);
+                            sentry::capture_message(
+                                &format!(
+                                    "Failed to send email verification to {} during login: {}",
+                                    user.email, e
+                                ),
+                                sentry::Level::Error,
+                            );
                         }
                         return json_error(
                             StatusCode::FORBIDDEN,
@@ -222,6 +240,13 @@ pub async fn request_password_reset(
                         .await
                     {
                         error!("Failed to send password reset email: {}", e);
+                        sentry::capture_message(
+                            &format!(
+                                "Failed to send password reset email to {}: {}",
+                                user.email, e
+                            ),
+                            sentry::Level::Error,
+                        );
                         return json_error(
                             StatusCode::INTERNAL_SERVER_ERROR,
                             "Failed to send password reset email",
@@ -229,6 +254,10 @@ pub async fn request_password_reset(
                         .into_response();
                     }
                 } else {
+                    sentry::capture_message(
+                        "Email service not configured for password reset",
+                        sentry::Level::Error,
+                    );
                     return (
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "Email service not configured",

--- a/web/src/lib/api/server.ts
+++ b/web/src/lib/api/server.ts
@@ -69,14 +69,17 @@ export async function serverCall<T>(endpoint: string, options?: ServerCallOption
 		if (!response.ok) {
 			// Try to parse error as JSON first (standard format: {"errors": "message"})
 			const errorText = await response.text();
+			let errorMessage = errorText || 'Request failed';
+
 			try {
 				const errorData = JSON.parse(errorText);
-				const errorMessage = errorData.errors || errorData.message || errorText;
-				throw new ServerError(errorMessage, response.status);
+				// Extract the actual error message from the JSON response
+				errorMessage = errorData.errors || errorData.message || errorText;
 			} catch {
-				// If JSON parsing fails, use the raw text
-				throw new ServerError(errorText || 'Request failed', response.status);
+				// If JSON parsing fails, use the raw text (already set above)
 			}
+
+			throw new ServerError(errorMessage, response.status);
 		}
 
 		if (response.status === 204) {


### PR DESCRIPTION
## Summary
- Fixed login page displaying raw JSON error `{"errors":"..."}` instead of just the error message
- Added Sentry notifications for all email sending failures to ensure ops team is alerted

## Changes

### Frontend (web/src/lib/api/server.ts)
- Fixed error handling logic that was incorrectly catching and re-throwing errors
- Now properly extracts error message from JSON response (`errors` or `message` field)
- Falls back to raw text only if JSON parsing actually fails

### Backend (src/actions/auth.rs)
- Added `sentry::capture_message()` calls for all email sending failures:
  - Registration email verification failures
  - Login email verification failures (when user tries to login with unverified email)
  - Password reset email failures
  - Email service initialization failures

## Testing
- ✅ Pre-commit hooks passed (ESLint, Prettier, TypeScript, Clippy)
- ✅ All Rust tests passed
- ✅ Manual verification: error messages now display cleanly on frontend

## Impact
- Users will see clean error messages instead of JSON blobs
- Ops team will receive Sentry alerts when emails fail to send, improving incident response