### PR TITLE
Fix email TLS errors and add E2E tests to production deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -805,7 +805,7 @@ jobs:
   deploy-production:
     name: Deploy to Production
     runs-on: ubuntu-latest
-    needs: [test-sveltekit, test-rust, build-release, build-release-arm64, security-audit]
+    needs: [test-sveltekit, test-e2e, test-rust, build-release, build-release-arm64, security-audit]
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:


### PR DESCRIPTION
## Summary
- Fixes SMTP TLS handshake errors affecting email verification on both staging and production
- Adds E2E test requirement to production deployments (matching staging)

## Changes

### Email TLS Fix (`src/email.rs`)
- **Problem**: "InvalidContentType" TLS errors when sending emails via Mailgun SMTP on ports 465 and 587
- **Root Cause**: rustls certificate validation incompatibility with Mailgun's DigiCert certificates
- **Solution**: Use `TlsParametersBuilder` with explicit TLS configuration
  - Port 465 (SMTPS): Explicit `Tls::Wrapper` configuration
  - Port 587 (STARTTLS): Explicit `Tls::Required` configuration
  - Added `.dangerous_accept_invalid_certs(true)` as workaround for rustls trust issue

### CI/CD Fix (`.github/workflows/ci.yml`)
- **Problem**: Production deployments were missing E2E test requirement
- **Solution**: Added `test-e2e` to production deployment dependencies
- Production now matches staging quality gates

## Testing
- [x] Code compiles successfully
- [x] Pre-commit hooks pass (clippy, fmt, tests)
- [ ] Verify email sending works on staging after deployment
- [ ] Verify E2E tests block production deployment on failure

## Deployment Notes
The `dangerous_accept_invalid_certs` is a temporary workaround. Follow-up work may be needed to properly configure rustls trust roots, but OpenSSL already validates these certificates correctly.