### PR TITLE
feat: add country flags to flight airport displays

### DIFF
--- a/src/actions/clubs.rs
+++ b/src/actions/clubs.rs
@@ -190,6 +190,7 @@ pub async fn get_club_flights(
                             aircraft_model: Some(aircraft.aircraft_model),
                             registration: Some(aircraft.registration),
                             aircraft_type_ogn: aircraft.aircraft_type_ogn,
+                            country_code: aircraft.country_code,
                         }),
                         _ => None,
                     }

--- a/src/actions/flights.rs
+++ b/src/actions/flights.rs
@@ -431,6 +431,7 @@ pub async fn search_flights(
                                 aircraft_model: Some(aircraft.aircraft_model),
                                 registration: Some(aircraft.registration),
                                 aircraft_type_ogn: aircraft.aircraft_type_ogn,
+                                country_code: aircraft.country_code,
                             }),
                             _ => None,
                         }
@@ -475,6 +476,7 @@ pub async fn search_flights(
                                 aircraft_model: Some(aircraft.aircraft_model),
                                 registration: Some(aircraft.registration),
                                 aircraft_type_ogn: aircraft.aircraft_type_ogn,
+                                country_code: aircraft.country_code,
                             }),
                             _ => None,
                         }
@@ -584,6 +586,7 @@ pub async fn get_airport_flights(
                             aircraft_model: Some(aircraft.aircraft_model),
                             registration: Some(aircraft.registration),
                             aircraft_type_ogn: aircraft.aircraft_type_ogn,
+                            country_code: aircraft.country_code,
                         }),
                         _ => None,
                     }
@@ -637,6 +640,7 @@ pub async fn get_nearby_flights(
                             aircraft_model: Some(aircraft.aircraft_model),
                             registration: Some(aircraft.registration),
                             aircraft_type_ogn: aircraft.aircraft_type_ogn,
+                            country_code: aircraft.country_code,
                         }),
                         _ => None,
                     }

--- a/src/actions/views/flight.rs
+++ b/src/actions/views/flight.rs
@@ -19,6 +19,7 @@ pub struct AircraftInfo {
     pub aircraft_model: Option<String>,
     pub registration: Option<String>,
     pub aircraft_type_ogn: Option<AircraftType>,
+    pub country_code: Option<String>,
 }
 
 /// Flight view for API responses with computed fields
@@ -59,6 +60,7 @@ pub struct FlightView {
     pub aircraft_model: Option<String>,
     pub registration: Option<String>,
     pub aircraft_type_ogn: Option<AircraftType>,
+    pub aircraft_country_code: Option<String>,
 
     // Latest altitude information (for active flights)
     pub latest_altitude_msl_feet: Option<i32>,
@@ -149,6 +151,7 @@ impl FlightView {
             aircraft_model: device_info.aircraft_model,
             registration: device_info.registration,
             aircraft_type_ogn: device_info.aircraft_type_ogn,
+            aircraft_country_code: device_info.country_code,
             latest_altitude_msl_feet,
             latest_altitude_agl_feet,
             latest_fix_timestamp,

--- a/web/src/lib/components/FlightsList.svelte
+++ b/web/src/lib/components/FlightsList.svelte
@@ -2,7 +2,11 @@
 	import { MapPin, Clock, ExternalLink, MoveUp, AlertCircle } from '@lucide/svelte';
 	import dayjs from 'dayjs';
 	import relativeTime from 'dayjs/plugin/relativeTime';
-	import { getAircraftTypeOgnDescription, getAircraftTypeColor } from '$lib/formatters';
+	import {
+		getAircraftTypeOgnDescription,
+		getAircraftTypeColor,
+		getFlagPath
+	} from '$lib/formatters';
 	import type { Flight } from '$lib/types';
 	import TowAircraftLink from '$lib/components/TowAircraftLink.svelte';
 	import AircraftLink from '$lib/components/AircraftLink.svelte';
@@ -188,6 +192,13 @@
 								{#if flight.departure_airport}
 									<div class="text-surface-500-400-token flex items-center gap-1 text-xs">
 										<MapPin class="h-3 w-3" />
+										{#if flight.departure_airport_country}
+											<img
+												src={getFlagPath(flight.departure_airport_country)}
+												alt=""
+												class="inline-block h-3 rounded-sm"
+											/>
+										{/if}
 										{flight.departure_airport}
 									</div>
 								{/if}
@@ -230,6 +241,13 @@
 										{#if flight.arrival_airport}
 											<div class="text-surface-500-400-token flex items-center gap-1 text-xs">
 												<MapPin class="h-3 w-3" />
+												{#if flight.arrival_airport_country}
+													<img
+														src={getFlagPath(flight.arrival_airport_country)}
+														alt=""
+														class="inline-block h-3 rounded-sm"
+													/>
+												{/if}
 												{flight.arrival_airport}
 											</div>
 										{/if}
@@ -334,6 +352,13 @@
 					<span class="text-surface-500-400-token text-xs">Start:</span>
 					{#if flight.departure_airport}
 						<span class="font-medium">
+							{#if flight.departure_airport_country}
+								<img
+									src={getFlagPath(flight.departure_airport_country)}
+									alt=""
+									class="inline-block h-3 rounded-sm"
+								/>
+							{/if}
 							{flight.departure_airport}{#if flight.takeoff_runway_ident}/{flight.takeoff_runway_ident}{/if}
 						</span>
 					{/if}
@@ -372,6 +397,13 @@
 						{:else}
 							{#if flight.arrival_airport}
 								<span class="font-medium">
+									{#if flight.arrival_airport_country}
+										<img
+											src={getFlagPath(flight.arrival_airport_country)}
+											alt=""
+											class="inline-block h-3 rounded-sm"
+										/>
+									{/if}
 									{flight.arrival_airport}{#if flight.landing_runway_ident}/{flight.landing_runway_ident}{/if}
 								</span>
 							{/if}

--- a/web/src/routes/flights/[id]/+page.svelte
+++ b/web/src/routes/flights/[id]/+page.svelte
@@ -32,7 +32,8 @@
 	import {
 		getAircraftTypeOgnDescription,
 		formatAircraftAddress,
-		getAircraftTypeColor
+		getAircraftTypeColor,
+		getFlagPath
 	} from '$lib/formatters';
 	import { GOOGLE_MAPS_API_KEY } from '$lib/config';
 	import { serverCall } from '$lib/api/server';
@@ -1427,10 +1428,24 @@
 					</div>
 					<div class="text-surface-600-300-token text-sm">
 						{#if data.flight.departure_airport && data.flight.departure_airport_id}
+							{#if data.flight.departure_airport_country}
+								<img
+									src={getFlagPath(data.flight.departure_airport_country)}
+									alt=""
+									class="mr-1 inline-block h-3.5 rounded-sm"
+								/>
+							{/if}
 							<a href="/airports/{data.flight.departure_airport_id}" class="anchor">
 								{data.flight.departure_airport}
 							</a>
 						{:else if data.flight.departure_airport}
+							{#if data.flight.departure_airport_country}
+								<img
+									src={getFlagPath(data.flight.departure_airport_country)}
+									alt=""
+									class="mr-1 inline-block h-3.5 rounded-sm"
+								/>
+							{/if}
 							{data.flight.departure_airport}
 						{:else}
 							Unknown
@@ -1481,10 +1496,24 @@
 								No beacons received for 5+ minutes
 							{:else if data.flight.landing_time}
 								{#if data.flight.arrival_airport && data.flight.arrival_airport_id}
+									{#if data.flight.arrival_airport_country}
+										<img
+											src={getFlagPath(data.flight.arrival_airport_country)}
+											alt=""
+											class="mr-1 inline-block h-3.5 rounded-sm"
+										/>
+									{/if}
 									<a href="/airports/{data.flight.arrival_airport_id}" class="anchor">
 										{data.flight.arrival_airport}
 									</a>
 								{:else if data.flight.arrival_airport}
+									{#if data.flight.arrival_airport_country}
+										<img
+											src={getFlagPath(data.flight.arrival_airport_country)}
+											alt=""
+											class="mr-1 inline-block h-3.5 rounded-sm"
+										/>
+									{/if}
 									{data.flight.arrival_airport}
 								{:else}
 									Unknown


### PR DESCRIPTION
## Summary
Adds country flags next to airport identifiers in flight list and detail views to improve visual identification of international flights.

## Changes

### Backend (Rust)
- Added `aircraft_country_code` field to `FlightView` API response
- Extended `AircraftInfo` helper struct to include `country_code`
- Updated all flight endpoints to populate country code data:
  - `search_flights` (completed and in-progress flights)
  - `get_airport_flights`
  - `get_nearby_flights`
  - `get_club_flights`

### Frontend (Svelte)
- Added airport country flags to `FlightsList` component:
  - Desktop table view: flags in departure/arrival columns
  - Mobile card view: flags inline with airport identifiers
- Added airport country flags to flight detail page:
  - Departure airport (takeoff section)
  - Arrival airport (landing section)
- Leveraged existing `getFlagPath()` formatter and flag infrastructure

## Visual Changes
- Country flags now appear next to airport codes (e.g., 🇺🇸 KSFO) in:
  - Flights list page (both desktop table and mobile cards)
  - Flight detail page (takeoff and landing sections)
- Flag styling matches existing aircraft country flag implementation (h-3 to h-3.5, rounded corners)

## Testing
- ✅ Backend: All changes pass `cargo clippy` with no warnings
- ✅ Frontend: Passes `npm run check` (TypeScript validation)
- ✅ Pre-commit hooks: All formatting, linting, and type checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)