### PR TITLE
fix: update soar-run to subscribe to ogn.raw NATS subject

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -303,9 +303,9 @@ pub async fn handle_run(
     let is_staging = soar_env == "staging";
 
     let nats_subject = if is_production {
-        "aprs.raw"
+        "ogn.raw"
     } else {
-        "staging.aprs.raw"
+        "staging.ogn.raw"
     };
 
     // Log which consumers are enabled


### PR DESCRIPTION
## Summary

Fixed NATS subject mismatch between OGN ingester and soar-run:

- **OGN ingester** publishes to `ogn.raw` (production) / `staging.ogn.raw` (staging)
- **soar-run** was subscribing to `aprs.raw` / `staging.aprs.raw` ❌
- Updated soar-run to subscribe to `ogn.raw` / `staging.ogn.raw` ✅

This mismatch was causing all OGN messages to be dropped, preventing soar-run from processing any aircraft position data from the OGN ingester.

## Changes

- Updated `src/commands/run.rs` to use `ogn.raw` and `staging.ogn.raw` NATS subjects

## Test Plan

- [x] Verify OGN ingester is publishing to `ogn.raw`
- [x] Verify soar-run now subscribes to `ogn.raw`
- [ ] Deploy and confirm messages are flowing from ingester to processor