### PR TITLE
Fix ADS-B topic naming and shutdown handling

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1033,9 +1033,9 @@ pub async fn handle_run(
     // This runs concurrently with the APRS subscriber
     if let Some((beast_intake_tx, _)) = beast_intake_opt.as_ref() {
         let beast_subject = if is_production {
-            "beast.raw"
+            "adsb.raw"
         } else {
-            "staging.beast.raw"
+            "staging.adsb.raw"
         };
 
         info!("Will subscribe to Beast NATS subject: {}", beast_subject);


### PR DESCRIPTION
## Summary

This PR fixes two issues with the ADS-B ingestion system:

### 1. Topic Name Consistency
- Changed NATS topics from `beast.raw`/`staging.beast.raw` to `adsb.raw`/`staging.adsb.raw` in the `run` command
- Now matches the topic names used by the `ingest-adsb` command
- Ensures proper message routing between ADS-B ingest and processing components

### 2. Shutdown Signal Handling
- Fixed `ingest-adsb` command not responding to Ctrl+C properly
- Shutdown signal is now properly broadcast to all concurrent tasks:
  - Main connection loop
  - Beast TCP connection processing  
  - NATS publisher task
- Uses `tokio::sync::broadcast` channel to distribute shutdown signal
- Ensures immediate and clean shutdown when SIGINT or SIGTERM is received

## Changes

**Files Modified:**
- `src/commands/run.rs` - Updated topic names to use `adsb.raw`
- `src/beast/client.rs` - Implemented proper shutdown signal propagation

## Test Plan

- [x] Code compiles and passes clippy
- [x] Pre-commit hooks pass
- [ ] Manually test `ingest-adsb` responds to Ctrl+C immediately
- [ ] Verify ADS-B messages route correctly between ingest and run commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)