### PR TITLE
fix: replace vite-plugin-cesium with vite-plugin-static-copy for production builds

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,8 +17,7 @@
 				"cesium": "^1.136.0",
 				"country-flag-icons": "^1.6.4",
 				"dayjs": "^1.11.18",
-				"plotly.js-dist-min": "^3.1.2",
-				"vite-plugin-cesium": "^1.2.23"
+				"plotly.js-dist-min": "^3.1.2"
 			},
 			"devDependencies": {
 				"@eslint/compat": "^1.4.1",
@@ -41,13 +40,15 @@
 				"prettier": "^3.4.2",
 				"prettier-plugin-svelte": "^3.3.3",
 				"prettier-plugin-tailwindcss": "^0.7.1",
+				"rollup-plugin-external-globals": "^0.13.0",
 				"svelte": "^5.43.5",
 				"svelte-check": "^4.3.4",
 				"tailwindcss": "^4.1",
 				"typescript": "^5.9.3",
 				"typescript-eslint": "^8.49.0",
 				"vite": "^7.2.4",
-				"vite-plugin-devtools-json": "^1.0.0"
+				"vite-plugin-devtools-json": "^1.0.0",
+				"vite-plugin-static-copy": "^3.1.4"
 			},
 			"engines": {
 				"node": ">=24.0.0",
@@ -1788,29 +1789,34 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@rollup/pluginutils": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.2.1.tgz",
-			"integrity": "sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+			"integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"estree-walker": "^2.0.1",
-				"picomatch": "^2.2.2"
+				"@types/estree": "^1.0.0",
+				"estree-walker": "^2.0.2",
+				"picomatch": "^4.0.2"
 			},
 			"engines": {
-				"node": ">= 8.0.0"
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@rollup/pluginutils/node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
+		"node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.50.0",
@@ -4748,15 +4754,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/at-least-node": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-			"license": "ISC",
-			"engines": {
-				"node": ">= 4.0.0"
-			}
-		},
 		"node_modules/autolinker": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/autolinker/-/autolinker-4.1.5.tgz",
@@ -5128,25 +5125,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/depd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/destroy": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8",
-				"npm": "1.2.8000 || >= 1.4.16"
-			}
-		},
 		"node_modules/detect-libc": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -5196,26 +5174,11 @@
 			"integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
 			"license": "ISC"
 		},
-		"node_modules/ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-			"license": "MIT"
-		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.214",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.214.tgz",
 			"integrity": "sha512-TpvUNdha+X3ybfU78NoQatKvQEm1oq3lf2QbnmCEdw+Bd9RuIAY+hJTvq1avzHM0f7EJfnH3vbCnbzKzisc/9Q==",
 			"license": "ISC"
-		},
-		"node_modules/encodeurl": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
 		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.18.3",
@@ -5280,12 +5243,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-			"license": "MIT"
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -5536,10 +5493,14 @@
 			}
 		},
 		"node_modules/estree-walker": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-			"license": "MIT"
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
 		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
@@ -5549,15 +5510,6 @@
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -5677,30 +5629,6 @@
 			"funding": {
 				"type": "patreon",
 				"url": "https://github.com/sponsors/rawify"
-			}
-		},
-		"node_modules/fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/fs-extra": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-			"license": "MIT",
-			"dependencies": {
-				"at-least-node": "^1.0.0",
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -5825,6 +5753,7 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/grapheme-splitter": {
@@ -5841,26 +5770,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/http-errors": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-			"license": "MIT",
-			"dependencies": {
-				"depd": "~2.0.0",
-				"inherits": "~2.0.4",
-				"setprototypeof": "~1.2.0",
-				"statuses": "~2.0.2",
-				"toidentifier": "~1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/https-proxy-agent": {
@@ -5924,12 +5833,6 @@
 			"engines": {
 				"node": ">=0.8.19"
 			}
-		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"license": "ISC"
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -6069,18 +5972,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/jsonfile": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
 			}
 		},
 		"node_modules/kdbush": {
@@ -6471,18 +6362,6 @@
 			"integrity": "sha512-ewwuAo3ujPZ7T3Y2oTkEoLlXvNOqnr0cjyAxfv5djXJqwD9QlxDDO0qGtsqB4Z9QUVvhruKXg9q/xfK9I5S1xQ==",
 			"license": "MIT"
 		},
-		"node_modules/mime": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-			"license": "MIT",
-			"bin": {
-				"mime": "cli.js"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/mini-svg-data-uri": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
@@ -6642,18 +6521,6 @@
 			"integrity": "sha512-9d1HbpKLh3sdWlhXMhU6MMH+wQzKkrgfRkYV0EBdvt99YJfj0ilCJrWRDYG2130Tm4GXbEoTCx5b34JSaP+HhA==",
 			"license": "MIT"
 		},
-		"node_modules/on-finished": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-			"license": "MIT",
-			"dependencies": {
-				"ee-first": "1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6702,6 +6569,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/p-map": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+			"integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/pako": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
@@ -6719,15 +6599,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/parseurl": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/path-exists": {
@@ -7210,15 +7081,6 @@
 			"integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
 			"license": "ISC"
 		},
-		"node_modules/range-parser": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/rbush": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
@@ -7321,6 +7183,22 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/rollup-plugin-external-globals": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-external-globals/-/rollup-plugin-external-globals-0.13.0.tgz",
+			"integrity": "sha512-wBS3hmoF0OtEnA0lWsmTC6Nhnkk2zjZbfhaX2gLo8VnfNGFdGhiYKwMpIPQPrYbAw+mAYUYmoHYktAl1eZHgVw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rollup/pluginutils": "^5.1.0",
+				"estree-walker": "^3.0.3",
+				"is-reference": "^3.0.2",
+				"magic-string": "^0.30.10"
+			},
+			"peerDependencies": {
+				"rollup": "^2.25.0 || ^3.3.0 || ^4.1.4"
+			}
+		},
 		"node_modules/sade": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -7346,71 +7224,11 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/send": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-			"integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"fresh": "~0.5.2",
-				"http-errors": "~2.0.1",
-				"mime": "1.6.0",
-				"ms": "2.1.3",
-				"on-finished": "~2.4.1",
-				"range-parser": "~1.2.1",
-				"statuses": "~2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/send/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/send/node_modules/debug/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"license": "MIT"
-		},
-		"node_modules/serve-static": {
-			"version": "1.16.3",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-			"integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
-			"license": "MIT",
-			"dependencies": {
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"parseurl": "~1.3.3",
-				"send": "~0.19.1"
-			},
-			"engines": {
-				"node": ">= 0.8.0"
-			}
-		},
 		"node_modules/set-cookie-parser": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
 			"integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
 			"license": "MIT"
-		},
-		"node_modules/setprototypeof": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-			"license": "ISC"
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
@@ -7479,22 +7297,6 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/sourcemap-codec": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-			"deprecated": "Please use @jridgewell/sourcemap-codec instead",
-			"license": "MIT"
-		},
-		"node_modules/statuses": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"node_modules/strip-json-comments": {
@@ -7697,15 +7499,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/toidentifier": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
 		"node_modules/topojson-client": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
@@ -7810,15 +7603,6 @@
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
 			"integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
 			"license": "MIT"
-		},
-		"node_modules/universalify": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
 		},
 		"node_modules/unplugin": {
 			"version": "1.0.1",
@@ -8033,70 +7817,6 @@
 				}
 			}
 		},
-		"node_modules/vite-plugin-cesium": {
-			"version": "1.2.23",
-			"resolved": "https://registry.npmjs.org/vite-plugin-cesium/-/vite-plugin-cesium-1.2.23.tgz",
-			"integrity": "sha512-x9A8ZCEoegceXg/E+LnxKr0XBsI9CR4cgYWQ2Dd3cUEYwKcTnHQ3kBfpol7BUcGtgQnQos/mtVrRmuVQBXFjHw==",
-			"license": "MIT",
-			"dependencies": {
-				"fs-extra": "^9.1.0",
-				"rollup-plugin-external-globals": "^0.6.1",
-				"serve-static": "^1.14.1"
-			},
-			"peerDependencies": {
-				"cesium": "^1.95.0",
-				"vite": ">=2.7.1"
-			}
-		},
-		"node_modules/vite-plugin-cesium/node_modules/is-reference": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
-			"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "*"
-			}
-		},
-		"node_modules/vite-plugin-cesium/node_modules/magic-string": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-			"license": "MIT",
-			"dependencies": {
-				"sourcemap-codec": "^1.4.8"
-			}
-		},
-		"node_modules/vite-plugin-cesium/node_modules/rollup": {
-			"version": "2.79.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
-			"integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
-			"license": "MIT",
-			"peer": true,
-			"bin": {
-				"rollup": "dist/bin/rollup"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"optionalDependencies": {
-				"fsevents": "~2.3.2"
-			}
-		},
-		"node_modules/vite-plugin-cesium/node_modules/rollup-plugin-external-globals": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-external-globals/-/rollup-plugin-external-globals-0.6.1.tgz",
-			"integrity": "sha512-mlp3KNa5sE4Sp9UUR2rjBrxjG79OyZAh/QC18RHIjM+iYkbBwNXSo8DHRMZWtzJTrH8GxQ+SJvCTN3i14uMXIA==",
-			"license": "MIT",
-			"dependencies": {
-				"@rollup/pluginutils": "^4.0.0",
-				"estree-walker": "^2.0.1",
-				"is-reference": "^1.2.1",
-				"magic-string": "^0.25.7"
-			},
-			"peerDependencies": {
-				"rollup": "^2.25.0"
-			}
-		},
 		"node_modules/vite-plugin-devtools-json": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/vite-plugin-devtools-json/-/vite-plugin-devtools-json-1.0.0.tgz",
@@ -8108,6 +7828,89 @@
 			},
 			"peerDependencies": {
 				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+			}
+		},
+		"node_modules/vite-plugin-static-copy": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.1.4.tgz",
+			"integrity": "sha512-iCmr4GSw4eSnaB+G8zc2f4dxSuDjbkjwpuBLLGvQYR9IW7rnDzftnUjOH5p4RYR+d4GsiBqXRvzuFhs5bnzVyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chokidar": "^3.6.0",
+				"p-map": "^7.0.3",
+				"picocolors": "^1.1.1",
+				"tinyglobby": "^0.2.15"
+			},
+			"engines": {
+				"node": "^18.0.0 || >=20.0.0"
+			},
+			"peerDependencies": {
+				"vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+			}
+		},
+		"node_modules/vite-plugin-static-copy/node_modules/chokidar": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"anymatch": "~3.1.2",
+				"braces": "~3.0.2",
+				"glob-parent": "~5.1.2",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.6.0"
+			},
+			"engines": {
+				"node": ">= 8.10.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/vite-plugin-static-copy/node_modules/glob-parent": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/vite-plugin-static-copy/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/vite-plugin-static-copy/node_modules/readdirp": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+			"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"picomatch": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8.10.0"
 			}
 		},
 		"node_modules/vite/node_modules/fsevents": {

--- a/web/package.json
+++ b/web/package.json
@@ -41,13 +41,15 @@
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.3",
 		"prettier-plugin-tailwindcss": "^0.7.1",
+		"rollup-plugin-external-globals": "^0.13.0",
 		"svelte": "^5.43.5",
 		"svelte-check": "^4.3.4",
 		"tailwindcss": "^4.1",
 		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.49.0",
 		"vite": "^7.2.4",
-		"vite-plugin-devtools-json": "^1.0.0"
+		"vite-plugin-devtools-json": "^1.0.0",
+		"vite-plugin-static-copy": "^3.1.4"
 	},
 	"dependencies": {
 		"@googlemaps/js-api-loader": "^2.0.2",
@@ -59,7 +61,6 @@
 		"cesium": "^1.136.0",
 		"country-flag-icons": "^1.6.4",
 		"dayjs": "^1.11.18",
-		"plotly.js-dist-min": "^3.1.2",
-		"vite-plugin-cesium": "^1.2.23"
+		"plotly.js-dist-min": "^3.1.2"
 	}
 }

--- a/web/src/app.html
+++ b/web/src/app.html
@@ -3,6 +3,8 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<!-- Load Cesium before app bundle to ensure window.Cesium is available -->
+		<script src="/cesium/Cesium.js"></script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,10 +2,54 @@ import tailwindcss from '@tailwindcss/vite';
 import devtoolsJson from 'vite-plugin-devtools-json';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
-import cesium from 'vite-plugin-cesium';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
+import externalGlobals from 'rollup-plugin-external-globals';
 
 export default defineConfig({
-	plugins: [tailwindcss(), sveltekit(), devtoolsJson(), cesium()],
+	plugins: [
+		tailwindcss(),
+		sveltekit(),
+		devtoolsJson(),
+		viteStaticCopy({
+			targets: [
+				{
+					src: 'node_modules/cesium/Build/Cesium/Workers/*',
+					dest: 'cesium/Workers'
+				},
+				{
+					src: 'node_modules/cesium/Build/Cesium/Assets/*',
+					dest: 'cesium/Assets'
+				},
+				{
+					src: 'node_modules/cesium/Build/Cesium/Widgets/*',
+					dest: 'cesium/Widgets'
+				},
+				{
+					src: 'node_modules/cesium/Build/Cesium/ThirdParty/*',
+					dest: 'cesium/ThirdParty'
+				},
+				{
+					src: 'node_modules/cesium/Build/Cesium/Cesium.js',
+					dest: 'cesium'
+				}
+			]
+		})
+	],
+	// Define CESIUM_BASE_URL for the application
+	define: {
+		CESIUM_BASE_URL: JSON.stringify('/cesium/')
+	},
+	// Configure build to externalize cesium and use the global Cesium object
+	build: {
+		rollupOptions: {
+			external: ['cesium'],
+			plugins: [
+				externalGlobals({
+					cesium: 'Cesium'
+				})
+			]
+		}
+	},
 	// Proxy /data/* requests to the Rust backend for local development
 	server: {
 		proxy: {


### PR DESCRIPTION
## Summary

Fixes the "Cesium is not defined" error in production builds of the 3D globe feature.

The discontinued `vite-plugin-cesium` doesn't work properly with SvelteKit's static adapter. This PR replaces it with a manual approach using `vite-plugin-static-copy` and `rollup-plugin-external-globals`.

## Changes

- ✅ Removed `vite-plugin-cesium` (discontinued, incompatible with static adapter)
- ✅ Added `vite-plugin-static-copy` to copy Cesium assets (Workers, Assets, Widgets, ThirdParty, Cesium.js) to build output
- ✅ Added `rollup-plugin-external-globals` to map cesium imports to `window.Cesium`
- ✅ Added Cesium.js script tag to `app.html` to load before app bundle
- ✅ Configured `CESIUM_BASE_URL` for proper asset loading

## How It Works

1. **Build time**: `vite-plugin-static-copy` copies all Cesium assets to `/cesium/` in build output
2. **Runtime**: `<script src="/cesium/Cesium.js">` loads the global `Cesium` object before app code runs
3. **Module resolution**: `rollup-plugin-external-globals` transforms `import { Viewer } from 'cesium'` → `window.Cesium.Viewer`

## Test Plan

- [x] Production build completes successfully
- [x] 144 Cesium assets copied to build output
- [x] All pre-commit hooks pass (ESLint, Prettier, TypeScript)
- [x] Cesium.js loads in production HTML
- [x] Globe imports use global Cesium object

## References

- [Cesium with Vite Discussion](https://community.cesium.com/t/is-there-a-good-way-to-use-cesium-with-vite/27545)
- [Configuring Vite for CesiumJS (Official)](https://cesium.com/blog/2024/02/13/configuring-vite-or-webpack-for-cesiumjs/)
- [vite-plugin-static-copy Discussion](https://github.com/sveltejs/kit/discussions/11553)

🤖 Generated with [Claude Code](https://claude.com/claude-code)