### PR TITLE
fix: correct aircraft address type display and add country flag

### DIFF
--- a/src/actions/views/flight.rs
+++ b/src/actions/views/flight.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::aircraft::AddressType;
+use crate::aircraft::{AddressType, address_type_from_str, address_type_to_str};
 use crate::flights::{Flight, FlightState};
 use crate::ogn_aprs_aircraft::AircraftType;
 
@@ -28,6 +28,10 @@ pub struct FlightView {
     pub id: Uuid,
     pub aircraft_id: Option<Uuid>,
     pub device_address: String,
+    #[serde(
+        deserialize_with = "address_type_from_str",
+        serialize_with = "address_type_to_str"
+    )]
     pub device_address_type: AddressType,
     pub takeoff_time: Option<DateTime<Utc>>,
     pub landing_time: Option<DateTime<Utc>>,

--- a/src/aircraft.rs
+++ b/src/aircraft.rs
@@ -62,7 +62,7 @@ impl std::fmt::Display for AddressType {
 }
 
 // Custom deserializer for AddressType to handle single character strings
-fn address_type_from_str<'de, D>(deserializer: D) -> Result<AddressType, D::Error>
+pub fn address_type_from_str<'de, D>(deserializer: D) -> Result<AddressType, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -71,7 +71,7 @@ where
 }
 
 // Custom serializer for AddressType to output single character strings
-fn address_type_to_str<S>(address_type: &AddressType, serializer: S) -> Result<S::Ok, S::Error>
+pub fn address_type_to_str<S>(address_type: &AddressType, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -254,6 +254,7 @@ export interface Flight {
 	aircraft_model?: string;
 	registration?: string;
 	aircraft_type_ogn?: string;
+	aircraft_country_code?: string;
 	// Latest fix information (for active flights)
 	latest_altitude_msl_feet: number | null;
 	latest_altitude_agl_feet: number | null;

--- a/web/src/routes/flights/[id]/+page.svelte
+++ b/web/src/routes/flights/[id]/+page.svelte
@@ -33,7 +33,8 @@
 		getAircraftTypeOgnDescription,
 		formatAircraftAddress,
 		getAircraftTypeColor,
-		getFlagPath
+		getFlagPath,
+		getCountryName
 	} from '$lib/formatters';
 	import { GOOGLE_MAPS_API_KEY } from '$lib/config';
 	import { serverCall } from '$lib/api/server';
@@ -1346,6 +1347,14 @@
 							<span class="text-surface-400-500-token">•</span>
 						{/if}
 						{#if data.flight.aircraft_id && data.flight.device_address && data.flight.device_address_type}
+							{#if data.flight.aircraft_country_code}
+								<img
+									src={getFlagPath(data.flight.aircraft_country_code)}
+									alt={getCountryName(data.flight.aircraft_country_code) || ''}
+									title={getCountryName(data.flight.aircraft_country_code) || ''}
+									class="h-4 rounded-sm"
+								/>
+							{/if}
 							<a
 								href="/aircraft/{data.flight.aircraft_id}"
 								target="_blank"
@@ -1638,7 +1647,14 @@
 							<!-- Desktop: relative time with full datetime -->
 							<span class="hidden md:inline">{formatDateTime(data.fixes[0].timestamp)}</span>
 						</div>
-						<div class="text-surface-600-300-token text-sm">Most recent position update</div>
+						<div class="text-surface-600-300-token text-sm">
+							Most recent position update
+							{#if data.flight.callsign}
+								<span class="text-surface-500-400-token ml-1"
+									>• Callsign: {data.flight.callsign}</span
+								>
+							{/if}
+						</div>
 					</div>
 				</div>
 			{/if}


### PR DESCRIPTION
## Summary
- Fix FlightView.device_address_type serialization to output single character ("I" instead of "Icao")
- Add custom serde serializers to FlightView for consistent AddressType formatting
- Add aircraft_country_code field to frontend Flight interface
- Display country flag next to aircraft address on flight detail page
- Show callsign in "Latest fix" section for active flights

## Problem
Flight detail pages were showing "UNKNOWN-4BA9C4" instead of "ICAO-4BA9C4" because the backend was serializing AddressType enum variants as full names ("Icao", "Flarm", "Ogn") instead of single characters ("I", "F", "O").

The frontend's `formatAircraftAddress()` function expects single-character address types:
- "I" → ICAO
- "F" → FLARM
- "O" → OGN
- Anything else → UNKNOWN

## Solution
Applied the existing custom serde serializers (`address_type_from_str` / `address_type_to_str`) to the `FlightView.device_address_type` field, ensuring consistent single-character serialization across all API responses.

## Changes
### Backend (Rust)
- **src/aircraft.rs**: Made `address_type_from_str` and `address_type_to_str` public
- **src/actions/views/flight.rs**: Added serde attributes to `FlightView.device_address_type` field

### Frontend (TypeScript/Svelte)
- **web/src/lib/types/index.ts**: Added `aircraft_country_code` field to Flight interface
- **web/src/routes/flights/[id]/+page.svelte**: 
  - Display country flag next to aircraft address
  - Show callsign in "Latest fix" section for active flights

## Test Plan
- [x] Backend compiles (`cargo check`)
- [x] Frontend type-checks (`npm run check`)
- [x] Code formatted (`cargo fmt`, Prettier)
- [ ] Verify flight detail page shows "ICAO-4BA9C4" instead of "UNKNOWN-4BA9C4"
- [ ] Verify country flag displays next to aircraft address
- [ ] Verify callsign shows in "Latest fix" section when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)