### PR TITLE
Migrate database backups from SSH to Wasabi S3 via rclone

### DIFF
--- a/infrastructure/examples/backup-env.example
+++ b/infrastructure/examples/backup-env.example
@@ -21,27 +21,38 @@
 #   - Format: KEY=value (no 'export', no quotes unless needed)
 
 #------------------------------------------------------------------------------
-# SSH BACKUP STORAGE CONFIGURATION
+# WASABI S3 BACKUP STORAGE CONFIGURATION (via rclone)
 #------------------------------------------------------------------------------
 
-# SSH server hostname or IP address (REQUIRED)
-BACKUP_SSH_HOST=cryptobot
+# Rclone remote name (REQUIRED)
+# This should match a configured remote in your rclone config (~/.config/rclone/rclone.conf)
+# Default: wasabi
+BACKUP_RCLONE_REMOTE=wasabi
 
-# SSH user (default: root)
-BACKUP_SSH_USER=root
+# S3 bucket name (REQUIRED)
+# The Wasabi bucket where backups will be stored
+BACKUP_RCLONE_BUCKET=soar-backup-prod
 
-# Remote path on SSH server where backups will be stored
-BACKUP_SSH_PATH=/srv/soar-backups
+# Optional prefix path within the bucket
+# Leave empty to store backups at the root of the bucket
+# Example: BACKUP_RCLONE_PATH=production/database
+BACKUP_RCLONE_PATH=
 
-# Path to SSH private key for authentication
-# Default: /var/soar/keys/backup_key
-BACKUP_SSH_KEY=/var/soar/keys/backup_key
-
-# Note: The SSH public key must be added to the authorized_keys file
-# on the remote server:
-#   ssh-copy-id -i /var/soar/keys/backup_key.pub root@cryptobot
-# Or manually add the contents of /var/soar/keys/backup_key.pub to
-# ~/.ssh/authorized_keys on the remote server
+# Note: You must configure rclone with your Wasabi credentials first:
+#   rclone config
+#
+# Example rclone configuration for Wasabi:
+#   [wasabi]
+#   type = s3
+#   provider = Wasabi
+#   access_key_id = YOUR_ACCESS_KEY
+#   secret_access_key = YOUR_SECRET_KEY
+#   endpoint = s3.wasabisys.com
+#   acl = private
+#
+# The bucket must exist before running backups. The structure will be:
+#   s3://soar-backup-prod/base/YYYY-MM-DD/  (base backups)
+#   s3://soar-backup-prod/wal/              (WAL segments)
 
 #------------------------------------------------------------------------------
 # BACKUP RETENTION CONFIGURATION
@@ -78,8 +89,8 @@ PGUSER=postgres
 
 # PostgreSQL data directory and version (for restore operations)
 # Adjust based on your PostgreSQL installation
-PGDATA=/var/lib/postgresql/17/main
-PG_VERSION=17
+PGDATA=/var/lib/postgresql/18/main
+PG_VERSION=18
 
 #------------------------------------------------------------------------------
 # BACKUP PATHS
@@ -194,9 +205,9 @@ METRICS_PUSHGATEWAY=
 
 # After editing this file, verify the configuration:
 #
-# 1. Test SSH access to backup server:
+# 1. Test rclone access to Wasabi:
 #    source /etc/soar/backup-env
-#    ssh -i ${BACKUP_SSH_KEY} ${BACKUP_SSH_USER}@${BACKUP_SSH_HOST} "ls -la ${BACKUP_SSH_PATH}"
+#    rclone lsd ${BACKUP_RCLONE_REMOTE}:${BACKUP_RCLONE_BUCKET}
 #
 # 2. Test WAL archiving (as postgres user):
 #    sudo -u postgres /usr/local/bin/soar-wal-archive \
@@ -207,6 +218,7 @@ METRICS_PUSHGATEWAY=
 #    sudo systemctl start soar-backup-base.service
 #    sudo journalctl -u soar-backup-base.service -f
 #
-# 4. Verify backup on remote server:
-#    ssh -i ${BACKUP_SSH_KEY} ${BACKUP_SSH_USER}@${BACKUP_SSH_HOST} \
-#      "find ${BACKUP_SSH_PATH}/base -type d"
+# 4. Verify backup in Wasabi S3:
+#    source /etc/soar/backup-env
+#    rclone lsd ${BACKUP_RCLONE_REMOTE}:${BACKUP_RCLONE_BUCKET}/base
+#    rclone ls ${BACKUP_RCLONE_REMOTE}:${BACKUP_RCLONE_BUCKET}/wal | head

--- a/scripts/backup/base-backup
+++ b/scripts/backup/base-backup
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# base-backup - Create full PostgreSQL base backup and upload to remote SSH server
+# base-backup - Create full PostgreSQL base backup and upload to Wasabi S3
 #
 # This script creates a physical backup of the PostgreSQL database using
-# pg_basebackup, compresses it, uploads to remote SSH server, and manages retention.
+# pg_basebackup, compresses it, uploads to Wasabi S3 via rclone, and manages retention.
 #
 # Usage:
 #   base-backup [--no-cleanup]
@@ -17,6 +17,7 @@
 #
 # Configuration:
 #   Source credentials from /etc/soar/backup-env
+#   Requires rclone configured with Wasabi remote
 #
 # Scheduling:
 #   Run via systemd timer: soar-backup-base.timer (weekly, Sunday midnight)
@@ -46,20 +47,32 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# SSH configuration
-SSH_KEY="${BACKUP_SSH_KEY:-/var/soar/keys/backup_key}"
-SSH_HOST="${BACKUP_SSH_HOST:-cryptobot}"
-SSH_PATH="${BACKUP_SSH_PATH:-/srv/soar-backups}"
-SSH_USER="${BACKUP_SSH_USER:-root}"
+# Rclone configuration
+RCLONE_REMOTE="${BACKUP_RCLONE_REMOTE:-wasabi}"
+RCLONE_BUCKET="${BACKUP_RCLONE_BUCKET:-soar-backup-prod}"
+RCLONE_PATH="${BACKUP_RCLONE_PATH:-}"  # Optional prefix within bucket
 
 # Validate configuration
-if [[ -z "${BACKUP_SSH_HOST:-}" ]]; then
-    echo "ERROR: BACKUP_SSH_HOST not set in /etc/soar/backup-env" >&2
+if [[ -z "${BACKUP_RCLONE_REMOTE:-}" ]]; then
+    echo "ERROR: BACKUP_RCLONE_REMOTE not set in /etc/soar/backup-env" >&2
     exit 1
 fi
 
-if [[ ! -f "$SSH_KEY" ]]; then
-    echo "ERROR: SSH key not found: $SSH_KEY" >&2
+if [[ -z "${BACKUP_RCLONE_BUCKET:-}" ]]; then
+    echo "ERROR: BACKUP_RCLONE_BUCKET not set in /etc/soar/backup-env" >&2
+    exit 1
+fi
+
+# Check rclone is available
+if ! command -v rclone >/dev/null 2>&1; then
+    echo "ERROR: rclone not found in PATH" >&2
+    exit 1
+fi
+
+# Verify rclone remote is configured
+if ! rclone listremotes | grep -q "^${RCLONE_REMOTE}:$"; then
+    echo "ERROR: rclone remote '${RCLONE_REMOTE}' not configured" >&2
+    echo "Run: rclone config" >&2
     exit 1
 fi
 
@@ -83,10 +96,13 @@ BACKUP_DATE=$(date -u +"%Y-%m-%d")
 BACKUP_TIMESTAMP=$(date -u +"%Y-%m-%d_%H-%M-%S")
 BACKUP_NAME="backup-${BACKUP_TIMESTAMP}"
 BACKUP_LOCAL_DIR="$TEMP_DIR/$BACKUP_NAME"
-BACKUP_REMOTE_PATH="${SSH_PATH}/base/${BACKUP_DATE}"
 
-# SSH options for rsync
-SSH_OPTS="-i $SSH_KEY -o StrictHostKeyChecking=accept-new -o BatchMode=yes"
+# Construct rclone destination path
+if [[ -n "$RCLONE_PATH" ]]; then
+    BACKUP_REMOTE_PATH="${RCLONE_REMOTE}:${RCLONE_BUCKET}/${RCLONE_PATH}/base/${BACKUP_DATE}"
+else
+    BACKUP_REMOTE_PATH="${RCLONE_REMOTE}:${RCLONE_BUCKET}/base/${BACKUP_DATE}"
+fi
 
 # Metrics and notifications
 NOTIFY_EMAIL="${BACKUP_NOTIFY_EMAIL:-}"
@@ -191,7 +207,7 @@ main() {
     log INFO "Starting base backup: $BACKUP_NAME"
     log INFO "=========================================="
     log INFO "Database: ${PGUSER}@${PGHOST}:${PGPORT}/${PGDATABASE}"
-    log INFO "Destination: ${SSH_USER}@${SSH_HOST}:${BACKUP_REMOTE_PATH}"
+    log INFO "Destination: ${BACKUP_REMOTE_PATH}"
     log INFO "Compression: zstd (multi-threaded)"
     log INFO "Parallel jobs: $PARALLEL_JOBS"
 
@@ -245,22 +261,18 @@ main() {
     local backup_size=$(du -sb "$BACKUP_LOCAL_DIR" | cut -f1)
     log INFO "Backup size: $(numfmt --to=iec-i --suffix=B "$backup_size")"
 
-    # Create remote directory if it doesn't exist
-    log INFO "Creating remote directory..."
-    if ! ssh $SSH_OPTS "${SSH_USER}@${SSH_HOST}" \
-        "mkdir -p ${BACKUP_REMOTE_PATH}"; then
-        log ERROR "Failed to create remote directory"
-        exit 1
-    fi
+    # Upload to Wasabi S3 using rclone
+    log INFO "Uploading backup to Wasabi S3..."
 
-    # Upload to remote server
-    log INFO "Uploading backup to remote server..."
-
-    if ! rsync -avz --progress \
-        -e "ssh $SSH_OPTS" \
+    # Use rclone copy with progress and multiple transfers
+    if ! rclone copy \
+        --progress \
+        --transfers "$PARALLEL_JOBS" \
+        --s3-chunk-size 64M \
+        --s3-upload-concurrency "$PARALLEL_JOBS" \
         "$BACKUP_LOCAL_DIR/" \
-        "${SSH_USER}@${SSH_HOST}:${BACKUP_REMOTE_PATH}/"; then
-        log ERROR "Failed to upload backup to remote server"
+        "${BACKUP_REMOTE_PATH}/"; then
+        log ERROR "Failed to upload backup to Wasabi S3"
         exit 1
     fi
 
@@ -268,15 +280,14 @@ main() {
 
     # Verify uploaded files
     log INFO "Verifying uploaded files..."
-    local uploaded_count=$(ssh $SSH_OPTS "${SSH_USER}@${SSH_HOST}" \
-        "find ${BACKUP_REMOTE_PATH} -type f | wc -l" 2>&1)
+    local uploaded_count=$(rclone ls "${BACKUP_REMOTE_PATH}/" 2>/dev/null | wc -l)
 
     if [[ $uploaded_count -eq 0 ]]; then
-        log ERROR "Verification failed: no files found on remote server"
+        log ERROR "Verification failed: no files found in Wasabi S3"
         exit 1
     fi
 
-    log INFO "Verification passed: found $uploaded_count files on remote server"
+    log INFO "Verification passed: found $uploaded_count files in Wasabi S3"
 
     # Create metadata file
     log INFO "Creating backup metadata..."
@@ -296,10 +307,9 @@ main() {
 }
 EOF
 
-    rsync -az \
-        -e "ssh $SSH_OPTS" \
+    rclone copyto \
         "$TEMP_DIR/backup-metadata.json" \
-        "${SSH_USER}@${SSH_HOST}:${BACKUP_REMOTE_PATH}/backup-metadata.json"
+        "${BACKUP_REMOTE_PATH}/backup-metadata.json"
 
     # Cleanup old backups if enabled
     if [[ "$CLEANUP" == "true" ]]; then
@@ -307,10 +317,20 @@ EOF
         local keep_count=${BASE_BACKUP_KEEP_COUNT:-5}
         log INFO "Cleaning up old backups (keeping most recent: $keep_count)..."
 
-        # List all base backups (sorted newest first)
-        local all_backups=$(ssh $SSH_OPTS "${SSH_USER}@${SSH_HOST}" \
-            "find ${SSH_PATH}/base -maxdepth 1 -type d -name '20*' -printf '%f\n' | sort -r" \
-            2>/dev/null || echo "")
+        # Construct base path for listing backups
+        local base_path
+        if [[ -n "$RCLONE_PATH" ]]; then
+            base_path="${RCLONE_REMOTE}:${RCLONE_BUCKET}/${RCLONE_PATH}/base"
+        else
+            base_path="${RCLONE_REMOTE}:${RCLONE_BUCKET}/base"
+        fi
+
+        # List all base backups (directories starting with 20* for dates like 2025-01-*)
+        # rclone lsd lists directories only
+        local all_backups=$(rclone lsd "$base_path" 2>/dev/null | \
+            awk '{print $5}' | \
+            grep '^20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]$' | \
+            sort -r || echo "")
 
         if [[ -z "$all_backups" ]]; then
             log WARN "No backups found for cleanup"
@@ -336,8 +356,7 @@ EOF
                         # Delete this backup
                         log INFO "Deleting old backup: $backup_date"
 
-                        if ssh $SSH_OPTS "${SSH_USER}@${SSH_HOST}" \
-                            "rm -rf ${SSH_PATH}/base/${backup_date}"; then
+                        if rclone purge "${base_path}/${backup_date}"; then
                             ((deleted_count++))
                             log INFO "Successfully deleted backup: $backup_date"
                         else
@@ -359,7 +378,7 @@ EOF
     log INFO "=========================================="
     log INFO "Backup completed successfully!"
     log INFO "Duration: $duration_formatted"
-    log INFO "Backup location: ${SSH_USER}@${SSH_HOST}:${BACKUP_REMOTE_PATH}"
+    log INFO "Backup location: ${BACKUP_REMOTE_PATH}"
     log INFO "=========================================="
 
     # Send success notification
@@ -368,7 +387,7 @@ Backup: $BACKUP_NAME
 Duration: $duration_formatted
 Database size: $(numfmt --to=iec-i --suffix=B "$db_size")
 Backup size: $(numfmt --to=iec-i --suffix=B "$backup_size")
-Location: ${SSH_USER}@${SSH_HOST}:${BACKUP_REMOTE_PATH}"
+Location: ${BACKUP_REMOTE_PATH}"
 
     # Update metrics (if metrics endpoint is available)
     if [[ -n "${METRICS_PUSHGATEWAY:-}" ]] && command -v curl >/dev/null 2>&1; then

--- a/scripts/backup/wal-archive
+++ b/scripts/backup/wal-archive
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# wal-archive - Archive PostgreSQL WAL segments to remote SSH server
+# wal-archive - Archive PostgreSQL WAL segments to Wasabi S3
 #
 # This script is called by PostgreSQL via archive_command for each completed
-# WAL segment (typically 16MB files). It uploads the WAL file to a remote
-# SSH server using rsync and verifies the upload succeeded.
+# WAL segment (typically 16MB files). It uploads the WAL file to Wasabi S3
+# using rclone and verifies the upload succeeded.
 #
 # Usage (called by PostgreSQL):
 #   wal-archive <wal_path> <wal_filename>
@@ -19,7 +19,7 @@
 #
 # Configuration:
 #   Source configuration from /etc/soar/backup-env
-#   SSH key at /var/soar/keys/backup_key (default)
+#   Requires rclone configured with Wasabi remote
 #
 # Example archive_command in postgresql.conf:
 #   archive_command = '/usr/local/bin/soar-wal-archive %p %f'
@@ -34,11 +34,10 @@ fi
 
 source /etc/soar/backup-env
 
-# SSH configuration
-SSH_KEY="${BACKUP_SSH_KEY:-/var/soar/keys/backup_key}"
-SSH_HOST="${BACKUP_SSH_HOST:-cryptobot}"
-SSH_PATH="${BACKUP_SSH_PATH:-/srv/soar-backups}"
-SSH_USER="${BACKUP_SSH_USER:-root}"
+# Rclone configuration
+RCLONE_REMOTE="${BACKUP_RCLONE_REMOTE:-wasabi}"
+RCLONE_BUCKET="${BACKUP_RCLONE_BUCKET:-soar-backup-prod}"
+RCLONE_PATH="${BACKUP_RCLONE_PATH:-}"  # Optional prefix within bucket
 
 # Arguments
 WAL_PATH="$1"
@@ -51,13 +50,26 @@ if [[ ! -f "$WAL_PATH" ]]; then
 fi
 
 # Validate configuration
-if [[ -z "${BACKUP_SSH_HOST:-}" ]]; then
-    echo "ERROR: BACKUP_SSH_HOST not set in /etc/soar/backup-env" >&2
+if [[ -z "${BACKUP_RCLONE_REMOTE:-}" ]]; then
+    echo "ERROR: BACKUP_RCLONE_REMOTE not set in /etc/soar/backup-env" >&2
     exit 1
 fi
 
-if [[ ! -f "$SSH_KEY" ]]; then
-    echo "ERROR: SSH key not found: $SSH_KEY" >&2
+if [[ -z "${BACKUP_RCLONE_BUCKET:-}" ]]; then
+    echo "ERROR: BACKUP_RCLONE_BUCKET not set in /etc/soar/backup-env" >&2
+    exit 1
+fi
+
+# Check rclone is available
+if ! command -v rclone >/dev/null 2>&1; then
+    echo "ERROR: rclone not found in PATH" >&2
+    exit 1
+fi
+
+# Verify rclone remote is configured
+if ! rclone listremotes | grep -q "^${RCLONE_REMOTE}:$"; then
+    echo "ERROR: rclone remote '${RCLONE_REMOTE}' not configured" >&2
+    echo "Run: rclone config" >&2
     exit 1
 fi
 
@@ -70,24 +82,23 @@ log() {
     echo "[$(date -u +"%Y-%m-%d %H:%M:%S UTC")] WAL Archive: $*" >> "$LOG_DIR/backup.log"
 }
 
-# Destination on remote server
-REMOTE_DEST="${SSH_USER}@${SSH_HOST}:${SSH_PATH}/wal/"
+# Construct rclone destination path
+if [[ -n "$RCLONE_PATH" ]]; then
+    REMOTE_DEST="${RCLONE_REMOTE}:${RCLONE_BUCKET}/${RCLONE_PATH}/wal/"
+else
+    REMOTE_DEST="${RCLONE_REMOTE}:${RCLONE_BUCKET}/wal/"
+fi
 
-# SSH options for rsync
-SSH_OPTS="-i $SSH_KEY -o StrictHostKeyChecking=accept-new -o BatchMode=yes"
-
-# Upload WAL file to remote server using rsync over SSH
+# Upload WAL file to Wasabi S3 using rclone
 log "Archiving WAL segment: $WAL_FILE ($(du -h "$WAL_PATH" | cut -f1))"
 
-if rsync -az \
-    -e "ssh $SSH_OPTS" \
+if rclone copyto \
     "$WAL_PATH" \
     "${REMOTE_DEST}${WAL_FILE}" \
     >> "$LOG_DIR/backup.log" 2>&1; then
 
-    # Verify upload by checking if file exists on remote server
-    if ssh $SSH_OPTS "${SSH_USER}@${SSH_HOST}" \
-        "test -f ${SSH_PATH}/wal/${WAL_FILE}" \
+    # Verify upload by checking if file exists in Wasabi S3
+    if rclone ls "${REMOTE_DEST}${WAL_FILE}" \
         >> "$LOG_DIR/backup.log" 2>&1; then
         log "Successfully archived WAL segment: $WAL_FILE"
         exit 0


### PR DESCRIPTION
## Summary

Migrates the database backup system from SSH/scp (cryptobot server) to Wasabi S3 using rclone for more reliable and scalable cloud backup storage.

## Changes

### Backup Scripts
- **base-backup**: Replace rsync over SSH with `rclone copy` for parallel uploads
- **wal-archive**: Replace rsync over SSH with `rclone copyto` for WAL segment archiving
- Cleanup logic now uses `rclone lsd` and `rclone purge` instead of SSH commands

### Configuration
- Replace SSH configuration (host, user, key, path) with rclone configuration:
  - `BACKUP_RCLONE_REMOTE`: rclone remote name (default: wasabi)
  - `BACKUP_RCLONE_BUCKET`: S3 bucket name (default: soar-backup-prod)
  - `BACKUP_RCLONE_PATH`: optional prefix within bucket
- Updated `backup-env.example` with Wasabi/rclone setup instructions

### Documentation
- Update all PostgreSQL references from version 17 to 18
- Update all backup command examples to use rclone instead of SSH
- Update testing and verification procedures for S3 storage

## Storage Structure

Backups are now stored in Wasabi S3 at:
- `s3://soar-backup-prod/base/YYYY-MM-DD/` - Weekly base backups
- `s3://soar-backup-prod/wal/` - Continuous WAL segments

## Testing

- Scripts validate rclone configuration on startup
- Parallel transfer support for faster uploads
- Verification uses `rclone ls` to confirm file presence in S3

## Deployment Notes

Before deploying to production:
1. Configure rclone with Wasabi credentials in `~/.config/rclone/rclone.conf`
2. Update `/etc/soar/backup-env` with new rclone configuration
3. Ensure bucket `soar-backup-prod` exists in Wasabi (us-east-1)
4. Enable WAL archiving in PostgreSQL if not already enabled (see docs/BACKUP-QUICKSTART.md)