### PR TITLE
feat: add Photon geocoding server deployment

### DIFF
--- a/infrastructure/photon.service
+++ b/infrastructure/photon.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Photon Geocoding Server
+Description=Photon OpenSearch Geocoding Server
 Documentation=https://github.com/komoot/photon
 After=network.target
 
@@ -13,6 +13,7 @@ WorkingDirectory=/opt/photon
 
 # Java heap size - adjust based on available RAM
 # Recommended: Use 50-75% of available RAM for production
+# Requires Java 21+ for Photon OpenSearch 0.7.4
 # Examples:
 #   16GB RAM: -Xmx12G -Xms12G
 #   32GB RAM: -Xmx24G -Xms24G

--- a/scripts/provision
+++ b/scripts/provision
@@ -283,9 +283,9 @@ if ! command -v java &> /dev/null; then
     echo "Installing Java..."
     if [[ "$OS" == "ubuntu" ]] || [[ "$OS" == "debian" ]]; then
         sudo apt-get update
-        sudo apt-get install -y openjdk-17-jre-headless wget curl pbzip2
+        sudo apt-get install -y openjdk-21-jre-headless wget curl pbzip2
     elif [[ "$OS" == "centos" ]] || [[ "$OS" == "rhel" ]] || [[ "$OS" == "rocky" ]] || [[ "$OS" == "almalinux" ]]; then
-        sudo dnf install -y java-17-openjdk-headless wget curl pbzip2
+        sudo dnf install -y java-21-openjdk-headless wget curl pbzip2
     fi
     echo -e "${GREEN}Java and dependencies installed successfully${NC}"
 else
@@ -320,11 +320,11 @@ sudo chown -R photon:photon /opt/photon
 sudo chown -R photon:photon /var/lib/photon
 
 # Download Photon JAR if not already installed
-PHOTON_VERSION="0.5.0"
-PHOTON_JAR="photon-${PHOTON_VERSION}.jar"
+PHOTON_VERSION="0.7.4"
+PHOTON_JAR="photon-opensearch-${PHOTON_VERSION}.jar"
 
 if [ ! -f "/opt/photon/${PHOTON_JAR}" ]; then
-    echo "Downloading Photon ${PHOTON_VERSION}..."
+    echo "Downloading Photon OpenSearch ${PHOTON_VERSION}..."
     PHOTON_URL="https://github.com/komoot/photon/releases/download/${PHOTON_VERSION}/${PHOTON_JAR}"
 
     (
@@ -356,12 +356,12 @@ if [ ! -d "/var/lib/photon/photon_data" ] || [ -z "$(ls -A /var/lib/photon 2>/de
         # Download, decompress with pbzip2, and extract in one pipeline
         # This is much faster than wget + tar xjf as it decompresses in parallel
         sudo -u photon bash -lc '
-          wget -O - https://download1.graphhopper.com/public/photon-db-planet-0.7OS-latest.tar.bz2 \
+          wget -O - https://download1.graphhopper.com/public/experimental/photon-db-planet-0.7OS-latest.tar.bz2 \
           | pbzip2 -cd \
           | tar -x
         ' || {
             echo -e "${YELLOW}Warning: Failed to download Photon data. You can download it manually later.${NC}"
-            echo -e "${YELLOW}Manual command: cd /var/lib/photon && sudo -u photon bash -lc 'wget -O - https://download1.graphhopper.com/public/photon-db-planet-0.7OS-latest.tar.bz2 | pbzip2 -cd | tar -x'${NC}"
+            echo -e "${YELLOW}Manual command: cd /var/lib/photon && sudo -u photon bash -lc 'wget -O - https://download1.graphhopper.com/public/experimental/photon-db-planet-0.7OS-latest.tar.bz2 | pbzip2 -cd | tar -x'${NC}"
             echo -e "${YELLOW}See infrastructure/DEPLOYMENT.md or docs/photon-deployment.md for instructions${NC}"
         }
 


### PR DESCRIPTION
## Summary

Adds Photon OpenSearch geocoding server installation and configuration to the provision script, enabling self-hosted forward and reverse geocoding capabilities for SOAR.

## Changes

- **Photon Installation**:
  - Installs Java 21 runtime and dependencies (pbzip2 for parallel decompression)
  - Creates `photon` system user and directory structure (`/opt/photon`, `/var/lib/photon`)
  - Downloads Photon OpenSearch JAR v0.7.4 (latest stable release)
  - Downloads and extracts worldwide geocoding data (~50-100GB)

- **Systemd Service**:
  - Adds `infrastructure/photon.service` systemd service configuration
  - Configures Photon to run on `127.0.0.1:2322`
  - Sets Java heap size to 16GB (configurable)
  - Enables CORS for API access
  - Includes security hardening (NoNewPrivileges, ProtectSystem, etc.)

- **Provision Script Updates**:
  - Enables and starts Photon service automatically
  - Adds Photon status checks and troubleshooting information
  - Provides API endpoint documentation and test commands

## Version Details

- **Photon Version**: 0.7.4 (OpenSearch)
- **Java Version**: 21+ (required)
- **Database**: OpenSearch-based (recommended stable version)
- **Compatibility**: Ubuntu and Debian Trixie

The OpenSearch version of Photon is now the recommended deployment option as of version 0.7.0+.

## API Endpoints

- Forward geocoding: `http://localhost:2322/api?q=Berlin`
- Reverse geocoding: `http://localhost:2322/reverse?lon=13.388860&lat=52.517037`

## Test Plan

- [ ] Run provision script on fresh server
- [ ] Verify Java 21 installation
- [ ] Verify Photon service starts successfully
- [ ] Test forward geocoding API
- [ ] Test reverse geocoding API
- [ ] Verify systemd service restart on failure
- [ ] Check logs with `journalctl -u photon -f`