### PR TITLE
Add Sentry notifications for flight completion email failures

### DIFF
--- a/src/flight_tracker/flight_lifecycle.rs
+++ b/src/flight_tracker/flight_lifecycle.rs
@@ -492,6 +492,13 @@ pub(crate) async fn complete_flight(
                     Ok(svc) => svc,
                     Err(e) => {
                         tracing::error!("Failed to create email service: {}", e);
+                        sentry::capture_message(
+                            &format!(
+                                "Failed to create email service for flight completion notifications: {}",
+                                e
+                            ),
+                            sentry::Level::Error,
+                        );
                         metrics::counter!("watchlist.emails.failed").increment(1);
                         return;
                     }
@@ -525,6 +532,13 @@ pub(crate) async fn complete_flight(
                                         user.email,
                                         e
                                     );
+                                    sentry::capture_message(
+                                        &format!(
+                                            "Failed to send flight completion email to {}: {}",
+                                            user.email, e
+                                        ),
+                                        sentry::Level::Error,
+                                    );
                                     metrics::counter!("watchlist.emails.failed").increment(1);
                                 }
                             }
@@ -545,6 +559,13 @@ pub(crate) async fn complete_flight(
             }
             Err(e) => {
                 tracing::error!("Failed to get watchlist users: {}", e);
+                sentry::capture_message(
+                    &format!(
+                        "Failed to get watchlist users for flight completion notifications: {}",
+                        e
+                    ),
+                    sentry::Level::Error,
+                );
                 metrics::counter!("watchlist.emails.failed").increment(1);
             }
         }


### PR DESCRIPTION
## Summary
Add Sentry notifications for all flight completion email failure scenarios to ensure the ops team is alerted when email delivery fails.

## Changes
This PR adds `sentry::capture_message()` calls for three email failure scenarios in flight completion notifications:

1. **Email service initialization failures** - When `EmailService::new()` fails
2. **Individual email send failures** - When `send_flight_completion_email()` fails for a specific user  
3. **Watchlist user lookup failures** - When getting watchlist users from the database fails

## Motivation
Previously, flight completion email failures were only logged and tracked in metrics. Auth-related emails (password reset, email verification) already report failures to Sentry, but flight completion emails did not.

This change brings flight completion email error handling in line with the existing pattern for auth emails, providing better visibility into email delivery issues.

## Testing
- ✅ Passes `cargo clippy`
- ✅ Passes `cargo fmt --check`
- ✅ Passes pre-commit hooks

All errors continue to be:
- Logged with `tracing::error!()`
- Sent to Sentry at Error level
- Tracked in `watchlist.emails.failed` metric counter