### PR TITLE
perf: reduce elevation cache sizes by 50% to decrease memory usage

### DIFF
--- a/src/elevation/service.rs
+++ b/src/elevation/service.rs
@@ -40,11 +40,11 @@ type CacheKey = (i32, i32);
 pub struct ElevationService {
     storage_path: PathBuf,
     /// Concurrent cache for elevation results: (rounded_lat, rounded_lon) -> elevation_meters
-    /// 500,000 entries ≈ 28MB of memory, provides excellent hit rate for multi-aircraft operations
+    /// 250,000 entries ≈ 14MB of memory, provides excellent hit rate for multi-aircraft operations
     /// Uses moka for lock-free concurrent access across multiple workers
     elevation_cache: Cache<CacheKey, Option<i16>>,
     /// Concurrent cache for HGT tiles: (lat_floor, lon_floor) -> HGT
-    /// 1000 entries ≈ 25GB for 1-arcsec tiles (25MB each), less for 3-arcsec
+    /// 500 entries ≈ 12.5GB for 1-arcsec tiles (25MB each), less for 3-arcsec
     /// Uses moka for lock-free concurrent access across multiple workers
     tile_cache: Cache<(i32, i32), Arc<HGT>>,
 }
@@ -66,8 +66,8 @@ impl ElevationService {
 
         Ok(Self {
             storage_path,
-            elevation_cache: Cache::builder().max_capacity(500_000).build(),
-            tile_cache: Cache::builder().max_capacity(1000).build(),
+            elevation_cache: Cache::builder().max_capacity(250_000).build(),
+            tile_cache: Cache::builder().max_capacity(500).build(),
         })
     }
 
@@ -82,8 +82,8 @@ impl ElevationService {
 
         Ok(Self {
             storage_path,
-            elevation_cache: Cache::builder().max_capacity(500_000).build(),
-            tile_cache: Cache::builder().max_capacity(1000).build(),
+            elevation_cache: Cache::builder().max_capacity(250_000).build(),
+            tile_cache: Cache::builder().max_capacity(500).build(),
         })
     }
 


### PR DESCRIPTION
## Summary
- Reduces elevation result cache from 500,000 to 250,000 entries (~28MB → ~14MB)
- Reduces HGT tile cache from 1,000 to 500 entries (~25GB max → ~12.5GB max)

The tile cache reduction provides the primary memory savings, potentially saving up to 12.5GB of memory when fully populated. This addresses high memory consumption in the `soar run` process.

## Test plan
- [ ] CI passes (fmt, clippy, tests)
- [ ] Monitor memory usage in production after deployment
- [ ] Monitor elevation cache hit rates in Grafana to ensure performance is maintained