### PR TITLE
fix: PostgreSQL point type error in aircraft geocoding

### DIFF
--- a/src/commands/load_data/mod.rs
+++ b/src/commands/load_data/mod.rs
@@ -403,7 +403,7 @@ async fn geocode_aircraft_registration_locations(
                         .or(locations::state.is_not_null()),
                 )
                 .select(soar::locations::LocationModel::as_select())
-                .distinct()
+                .distinct_on(locations::id)
                 .limit(MAX_TOTAL_GEOCODE as i64)
                 .load(&mut conn)?;
 


### PR DESCRIPTION
## Summary
- Fixes "could not identify an equality operator for type point" error when geocoding aircraft registration addresses in pull-data

## Changes
- Changed `.distinct()` to `.distinct_on(locations::id)` in aircraft registration geocoding query (src/commands/load_data/mod.rs:406)

## Root Cause
The `.distinct()` call was trying to compare all columns including the `geolocation` field (PostgreSQL `point` type), which doesn't have a standard equality operator that works with DISTINCT in PostgreSQL.

## Solution
Using `.distinct_on(locations::id)` only compares the UUID ID column to determine uniqueness, which is the correct approach since we're querying for distinct location records anyway.

## Testing
- ✅ Passes `cargo check`
- ✅ Passes `cargo fmt`
- ✅ Passes `cargo clippy`
- ✅ All pre-commit hooks pass

## Related
Fixes the error reported when running `pull-data --geocode` for aircraft registration addresses.