### PR TITLE
docs: update architecture documentation to reflect current implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,12 @@ SOAR is a comprehensive aircraft tracking and club management system built with:
 
 ## Critical Development Rules
 
+### DOCUMENTATION PRIORITY
+- **KEEP DOCUMENTATION UP TO DATE** - Documentation (including README.md, CLAUDE.md, and other docs) must be updated when features change
+- When renaming services, commands, or changing architecture, update all relevant documentation
+- Documentation changes should be part of the same PR that changes the implementation
+- Outdated documentation is a bug - treat it with the same priority as code bugs
+
 ### NO BYPASSING QUALITY CONTROLS
 - **NEVER commit directly to main** - The main branch is protected. ALWAYS create a feature/topic branch first
 - **NEVER use `git commit --no-verify`** - All commits must pass pre-commit hooks
@@ -44,9 +50,10 @@ SOAR is a comprehensive aircraft tracking and club management system built with:
 - **Verify dashboard queries after changes** - After updating code, search all dashboard files for the old metric name and update them
 - **Dashboard locations:**
   - `infrastructure/grafana-dashboard-run.json` - Main processing (`run` command)
-  - `infrastructure/grafana-dashboard-aprs-ingest.json` - APRS connection (`ingest-aprs` command)
+  - `infrastructure/grafana-dashboard-aprs-ingest.json` - OGN/APRS ingestion (`ingest-ogn` command)
+  - `infrastructure/grafana-dashboard-beast-ingest.json` - ADS-B Beast ingestion (`ingest-adsb` command)
   - `infrastructure/grafana-dashboard-web.json` - Web server (`web` command)
-  - `infrastructure/grafana-dashboard-nats-jetstream.json` - NATS/JetStream metrics
+  - `infrastructure/grafana-dashboard-nats.json` - NATS/JetStream metrics
   - `infrastructure/grafana-dashboard-analytics.json` - Analytics API and cache performance
 
 **Metric Standards:**


### PR DESCRIPTION
## Summary

Updates documentation (README.md and CLAUDE.md) to reflect the current architecture, fixing outdated service names and correcting the architecture diagram.

## Changes

### CLAUDE.md
- ✅ Added **Documentation Priority** section emphasizing that docs must be kept up to date
- ✅ Updated Grafana dashboard references:
  - Fixed `ingest-aprs` → `ingest-ogn`
  - Added missing `grafana-dashboard-beast-ingest.json` for ADS-B ingestion
  - Fixed dashboard filename: `grafana-dashboard-nats-jetstream.json` → `grafana-dashboard-nats.json`

### README.md

#### Service Name Fixes
- ✅ `soar-aprs-ingest` → `soar ingest-ogn` (corrected to actual command syntax)
- ✅ Updated all references throughout the document

#### Architecture Diagram Corrections
- ✅ **Fixed NATS architecture**: Changed from NATS JetStream to NATS Pub/Sub (fire-and-forget)
- ✅ **Fixed duplicate node**: Renamed nodes to `AprsNatsPublisher` vs `LiveFixPublisher`
- ✅ **Corrected queue sizes**:
  - Aircraft Queue: 100 → **1,000 messages** ✓
  - Receiver Status Queue: 100 → **50 messages** ✓
  - Receiver Position Queue: 100 → **50 messages** ✓
  - Server Status Queue: 100 → **50 messages** ✓
- ✅ **Fixed real-time broadcasting flow**: 
  - Old: `AircraftProc → NatsQueue → NatsPublisher → WebClients`
  - New: `FixProc → LiveFixQueue → LiveFixPublisher → LiveNats → WebClients`

#### Text Updates
- ✅ Updated NATS provisioning section to reflect pub/sub semantics (not durable queue)
- ✅ Expanded deployment section with comprehensive systemd service list
- ✅ Updated key components descriptions with correct queue sizes and NATS subjects

## Testing
- ✅ Pre-commit hooks passed
- ✅ Verified queue sizes against source code (`src/commands/run.rs`)
- ✅ Verified NATS subjects against source code (`src/commands/ingest_ogn.rs`, `src/nats_publisher.rs`)

## Motivation

Many architectural changes have occurred since the README was last updated. The documentation incorrectly referenced:
- Old service names (`soar-aprs-ingest` instead of `soar ingest-ogn`)
- NATS JetStream instead of NATS Pub/Sub
- Wrong queue sizes
- Incorrect data flow for real-time broadcasting

This PR brings the documentation in sync with the actual codebase.