### PR TITLE
feat: add MCP server setup for database access in Claude Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 .vscode/settings.json
 .logs
+.mcp.json
 
 # Web build artifacts
 web/build/

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "soar-dev-db": {
+      "command": "/path/to/pgedge-postgres-mcp",
+      "env": {
+        "PGHOST": "localhost",
+        "PGPORT": "5432",
+        "PGDATABASE": "soar_dev",
+        "PGUSER": "your_username"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,6 +391,46 @@ git commit -m "feat: add new feature"  # Pre-commit runs automatically
 git push origin feature/new-feature
 ```
 
+### MCP Server Setup (Optional - For Claude Code Database Access)
+
+Claude Code can connect directly to the PostgreSQL database using the **pgEdge Postgres MCP Server**, enabling natural language database queries and schema introspection.
+
+**Installation:**
+
+1. **Clone and build the MCP server:**
+   ```bash
+   cd /tmp
+   git clone https://github.com/pgEdge/pgedge-postgres-mcp.git
+   cd pgedge-postgres-mcp
+   go build -v -o bin/pgedge-postgres-mcp ./cmd/pgedge-pg-mcp-svr
+   cp bin/pgedge-postgres-mcp ~/.local/bin/
+   ```
+
+2. **Configure for your project:**
+   ```bash
+   # Copy the example configuration
+   cp .mcp.json.example .mcp.json
+
+   # Edit .mcp.json with your settings
+   # Update the "command" path to where you installed the binary
+   # Update "PGUSER" to your PostgreSQL username
+   ```
+
+3. **Restart Claude Code** to load the MCP server
+
+**What you get:**
+- 🔍 Schema introspection - Query tables, columns, indexes, constraints
+- 📊 Database queries - Execute SQL queries (read-only for safety)
+- 📈 Performance metrics - Access `pg_stat_statements` and other stats
+- 🧠 Natural language queries - Ask questions about the database in plain English
+
+**Security Notes:**
+- The MCP server runs in **read-only mode** by default
+- `.mcp.json` is gitignored to prevent committing local paths and credentials
+- Use `.pgpass` file for password management instead of storing in `.mcp.json`
+
+**Documentation:** https://www.pgedge.com/blog/introducing-the-pgedge-postgres-mcp-server
+
 ## Common Patterns
 
 ### Error Handling

--- a/make-worktree
+++ b/make-worktree
@@ -127,16 +127,9 @@ echo -e "${BOLD}${CYAN}Launching Claude Code...${NC}"
 echo ""
 
 # Launch Claude Code in the worktree directory
-# After Claude exits, spawn a shell so the user stays in the worktree
 if command -v claude &> /dev/null; then
     claude
-    echo ""
-    echo -e "${YELLOW}Claude Code exited. Spawning shell in worktree...${NC}"
-    echo -e "${CYAN}Current directory: $(pwd)${NC}"
-    exec $SHELL
 else
     echo -e "${YELLOW}Warning: 'claude' command not found${NC}"
-    echo -e "${YELLOW}Spawning shell in worktree instead...${NC}"
-    echo -e "${CYAN}Current directory: $(pwd)${NC}"
-    exec $SHELL
+    echo -e "${CYAN}Worktree is ready at: $(pwd)${NC}"
 fi


### PR DESCRIPTION
## Summary

- Adds pgEdge Postgres MCP server configuration to enable natural language database queries and schema introspection within Claude Code
- Provides setup documentation in CLAUDE.md with installation instructions
- Includes example configuration template (`.mcp.json.example`)
- Adds `.mcp.json` to `.gitignore` to prevent committing local paths and credentials
- Updates `make-worktree` script to exit cleanly after Claude Code closes instead of spawning a new shell

## Changes

- **`.gitignore`** - Added `.mcp.json` to prevent committing local MCP configurations
- **`CLAUDE.md`** - Added "MCP Server Setup" section with comprehensive documentation
- **`.mcp.json.example`** - Created template configuration file for developers to copy
- **`make-worktree`** - Removed shell spawning behavior after Claude Code exits

## MCP Server Features

- 🔍 Schema introspection - Query tables, columns, indexes, constraints
- 📊 Database queries - Execute SQL queries (read-only for safety)
- 📈 Performance metrics - Access `pg_stat_statements` and other stats
- 🧠 Natural language queries - Ask questions about the database in plain English

## Test Plan

- [x] MCP server builds and installs successfully
- [x] MCP server connects to `soar_dev` database
- [x] `.mcp.json` is properly gitignored
- [x] Pre-commit hooks pass
- [x] Documentation is clear and complete