### PR TITLE
feat: add systemd target support and improve deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -660,6 +660,7 @@ jobs:
           cp infrastructure/soar-deploy deploy-pkg/
           cp infrastructure/systemd/*.service deploy-pkg/ || echo "No service files found"
           cp infrastructure/systemd/*.timer deploy-pkg/ || echo "No timer files found"
+          cp infrastructure/systemd/*.target deploy-pkg/ || echo "No target files found"
 
           # Copy Prometheus job configuration files
           if [ -d infrastructure/prometheus-jobs ]; then
@@ -805,6 +806,7 @@ jobs:
           cp infrastructure/soar-deploy deploy-pkg/
           cp infrastructure/systemd/*.service deploy-pkg/ || echo "No service files found"
           cp infrastructure/systemd/*.timer deploy-pkg/ || echo "No timer files found"
+          cp infrastructure/systemd/*.target deploy-pkg/ || echo "No target files found"
 
           # Copy Prometheus job configuration files
           if [ -d infrastructure/prometheus-jobs ]; then

--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -11,11 +11,18 @@
 #
 # The deployment directory should contain:
 #   - soar (the binary)
+#   - soar-deploy (this script - for self-update)
 #   - *.service files (production) or *-staging.service files (staging)
 #   - *.timer files (production) or *-staging.timer files (staging)
+#   - *.target files (soar.target or soar-staging.target)
 #   - prometheus-jobs/ directory (optional, contains Prometheus job configs)
 #   - grafana-provisioning/ directory (optional, contains Grafana provisioning configs)
 #   - grafana-dashboard-*.json files (optional, Grafana dashboards)
+#
+# Self-Update:
+#   This script will automatically update itself if the version in the deployment
+#   directory differs from /usr/local/bin/soar-deploy, then re-execute with the
+#   same arguments to ensure the latest deployment logic is used.
 #
 
 set -e
@@ -67,6 +74,24 @@ if [ ! -d "$DEPLOY_DIR" ]; then
 fi
 
 log_info "Starting SOAR deployment for $ENVIRONMENT from: $DEPLOY_DIR"
+
+# Self-update: Check if deployment script itself has changed
+if [ -f "$DEPLOY_DIR/soar-deploy" ]; then
+    if ! diff -q "$0" "$DEPLOY_DIR/soar-deploy" >/dev/null 2>&1; then
+        log_warn "Deployment script has changed - updating /usr/local/bin/soar-deploy and re-executing..."
+
+        # Install updated deployment script
+        install -m 755 -o root -g root "$DEPLOY_DIR/soar-deploy" /usr/local/bin/soar-deploy
+
+        log_info "Deployment script updated, re-executing with same arguments..."
+        # Re-exec the updated script with original arguments
+        exec /usr/local/bin/soar-deploy "$@"
+    else
+        log_info "Deployment script is up-to-date"
+    fi
+else
+    log_warn "No soar-deploy found in deployment directory, skipping self-update check"
+fi
 
 # Set environment-specific variables
 if [ "$ENVIRONMENT" = "staging" ]; then
@@ -259,6 +284,16 @@ for timer in "${TIMERS[@]}"; do
     fi
 done
 
+# Install target file
+TARGET_FILE="soar${SERVICE_SUFFIX}.target"
+if [ -f "$DEPLOY_DIR/$TARGET_FILE" ]; then
+    log_info "Installing $TARGET_FILE..."
+    cp "$DEPLOY_DIR/$TARGET_FILE" /etc/systemd/system/
+    chmod 644 "/etc/systemd/system/$TARGET_FILE"
+else
+    log_warn "$TARGET_FILE not found in deployment directory, skipping"
+fi
+
 # Install backup scripts
 if [ -d "$DEPLOY_DIR/scripts/backup" ]; then
     log_info "Installing backup scripts to /usr/local/bin/..."
@@ -351,6 +386,12 @@ fi
 # Reload systemd daemon
 log_info "Reloading systemd daemon..."
 systemctl daemon-reload
+
+# Enable target file
+if [ -f "/etc/systemd/system/$TARGET_FILE" ]; then
+    log_info "Enabling $TARGET_FILE..."
+    systemctl enable "$TARGET_FILE" || log_warn "Failed to enable $TARGET_FILE"
+fi
 
 # Enable and start services - start ogn-ingest first, then others
 log_info "Enabling and starting SOAR services..."

--- a/infrastructure/systemd/soar-staging.target
+++ b/infrastructure/systemd/soar-staging.target
@@ -1,0 +1,32 @@
+# SOAR Staging Target - Group all SOAR staging services together
+#
+# This systemd target allows you to control all SOAR staging services as a group while
+# still maintaining individual control over each service.
+#
+# Usage:
+#   sudo systemctl start soar-staging      # Start all SOAR staging services
+#   sudo systemctl stop soar-staging       # Stop all SOAR staging services
+#   sudo systemctl restart soar-staging    # Restart all SOAR staging services
+#   sudo systemctl status soar-staging     # Check status of all SOAR staging services
+#   sudo systemctl enable soar-staging     # Enable all SOAR staging services to start on boot
+#   sudo systemctl disable soar-staging    # Disable all SOAR staging services from starting on boot
+#
+# Individual service control still works:
+#   sudo systemctl start soar-web-staging.service
+#   sudo systemctl stop soar-run-staging.service
+#   sudo systemctl restart soar-pull-data-staging.timer
+#
+# Installation:
+#   sudo cp soar-staging.target /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable soar-staging.target
+
+[Unit]
+Description=SOAR Staging - Soaring Observation And Records System (Staging Environment)
+Documentation=https://github.com/hut8/soar
+After=network-online.target postgresql.service nats-server.service
+Wants=soar-ogn-ingest-staging.service soar-run-staging.service soar-web-staging.service soar-pull-data-staging.timer soar-sitemap-staging.timer soar-archive-staging.timer
+Requires=postgresql.service nats-server.service
+
+[Install]
+WantedBy=multi-user.target

--- a/infrastructure/systemd/soar.target
+++ b/infrastructure/systemd/soar.target
@@ -25,7 +25,7 @@
 Description=SOAR - Soaring Observation And Records System
 Documentation=https://github.com/hut8/soar
 After=network-online.target postgresql.service nats-server.service
-Wants=soar-ogn-ingest.service soar-run.service soar-web.service soar-pull-data.timer soar-archive.timer
+Wants=soar-ogn-ingest.service soar-run.service soar-web.service soar-pull-data.timer soar-sitemap.timer soar-archive.timer soar-backup-base.timer soar-backup-verify.timer
 Requires=postgresql.service nats-server.service
 
 [Install]

--- a/src/geocoding.rs
+++ b/src/geocoding.rs
@@ -5,7 +5,7 @@ use reqwest;
 use serde::Deserialize;
 use std::env;
 use std::time::Duration;
-use tracing::{debug, info, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::locations::Point;
 
@@ -201,7 +201,7 @@ impl Geocoder {
         // Initialize Photon base URL if configured
         let photon_base_url = if let Ok(url) = env::var("PHOTON_BASE_URL") {
             if !url.trim().is_empty() {
-                info!("Using Photon geocoding server at: {}", url);
+                trace!("Using Photon geocoding server at: {}", url);
                 Some(url.trim().to_string())
             } else {
                 debug!("PHOTON_BASE_URL is set but empty, skipping Photon");
@@ -251,7 +251,7 @@ impl Geocoder {
         // Initialize Photon base URL if configured
         let photon_base_url = if let Ok(url) = env::var("PHOTON_BASE_URL") {
             if !url.trim().is_empty() {
-                info!("Using Photon geocoding server at: {}", url);
+                trace!("Using Photon geocoding server at: {}", url);
                 Some(url.trim().to_string())
             } else {
                 debug!("PHOTON_BASE_URL is set but empty, skipping Photon");


### PR DESCRIPTION
## Summary
- ✅ Add `soar.target` for production services grouping with all core services and timers
- ✅ Add `soar-staging.target` for staging environment
- ✅ Update `soar-deploy` script with self-update capability
- ✅ Update CI workflow to deploy `.target` files
- ✅ Change Photon geocoding log message from info to trace level

## Changes

### systemd Target Files
- **`soar.target`** - Groups all production SOAR services:
  - Services: `soar-ogn-ingest.service`, `soar-run.service`, `soar-web.service`
  - Timers: `soar-pull-data.timer`, `soar-sitemap.timer`, `soar-archive.timer`, `soar-backup-base.timer`, `soar-backup-verify.timer`
- **`soar-staging.target`** - Groups all staging SOAR services (no backup timers)

### Deployment Script Self-Update
The `soar-deploy` script now:
1. Checks if the deployment package contains a newer version of itself
2. Automatically updates `/usr/local/bin/soar-deploy` if different
3. Re-executes with the same arguments using the updated script
4. Deploys and enables `.target` files for the appropriate environment

### CI/CD Updates
- Deployment packages now include `.target` files
- Both staging and production deployments will install the appropriate target file

### Logging Improvement
- Changed "Using Photon geocoding server at: ..." from `info!` to `trace!` level
  - This message was creating noise in logs (logged on every aircraft position processed)
  - Now only visible with `RUST_LOG=trace`

## Benefits

**Simplified Operations:**
```bash
sudo systemctl start soar        # Start all services at once
sudo systemctl stop soar         # Stop all services at once  
sudo systemctl status soar       # Check status of all services
```

**Self-Healing Deployment:**
- Deployment script automatically updates itself
- No manual intervention needed when deployment logic changes
- Always uses the latest deployment procedure

## Test Plan
- [x] Pre-commit hooks passed (clippy, fmt, tests)
- [ ] CI build passes
- [ ] Staging deployment succeeds
- [ ] `systemctl start soar-staging` works
- [ ] Production deployment succeeds
- [ ] `systemctl start soar` works