### PR TITLE
fix: prevent soar-deploy from exiting when counting obsolete files

### DIFF
--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -316,7 +316,7 @@ for file_basename in "${ALL_SOAR_FILES[@]}"; do
         log_warn "  sudo systemctl stop $file_basename 2>/dev/null || true"
         log_warn "  sudo systemctl disable $file_basename 2>/dev/null || true"
         log_warn "  sudo rm -f /etc/systemd/system/$file_basename"
-        ((OBSOLETE_FILES_FOUND++))
+        ((OBSOLETE_FILES_FOUND++)) || true
     fi
 done
 


### PR DESCRIPTION
## Problem

The staging deployment was failing with exit code 1 after running migrations but before installing service files or restarting services. This left services stopped and the system in a broken state.

## Root Cause

At line 319 in `infrastructure/soar-deploy`:

```bash
((OBSOLETE_FILES_FOUND++))
```

When `OBSOLETE_FILES_FOUND` is 0:
1. The postfix `++` increments the variable to 1
2. But the expression **returns the original value** (0)  
3. In bash `((...))`, a result of 0 is treated as **false** and returns exit code 1
4. With `set -e` active, exit code 1 causes the script to immediately exit

This happened when detecting the first obsolete file (e.g., `soar-ogn-ingest-staging.service` vs the new `soar-ingest-ogn-staging.service` naming from PR #551).

## Solution

Added `|| true` to line 319:

```bash
((OBSOLETE_FILES_FOUND++)) || true
```

This ensures the arithmetic expression never causes the script to exit, allowing deployment to continue past the obsolete file check.

## Testing

- Verified the issue locally by tracing through the failed Dec 20 05:09 deployment logs
- Confirmed that `/usr/local/bin/soar-staging` was updated but no systemd files were modified
- Confirmed services remained stopped after the deployment
- The fix allows the deployment to complete successfully even when obsolete files are detected

## Related

- Relates to PR #554 which made the obsolete file check non-fatal (warn instead of delete)
- Fixes issue introduced by service renaming in PR #551 (ogn-ingest → ingest-ogn)