### PR TITLE
Add fix intervals and gap analysis to flight details

### DIFF
--- a/src/actions/flights.rs
+++ b/src/actions/flights.rs
@@ -12,7 +12,7 @@ use crate::aircraft_repo::AircraftRepository;
 use crate::airports_repo::AirportsRepository;
 use crate::fixes::FixWithRawPacket;
 use crate::fixes_repo::FixesRepository;
-use crate::flights::Flight;
+use crate::flights::{Flight, haversine_distance};
 use crate::flights_repo::FlightsRepository;
 use crate::geometry::spline::{GeoPoint, generate_spline_path};
 use crate::web::AppState;
@@ -53,6 +53,40 @@ pub struct FlightSplinePathResponse {
 pub struct FlightsListResponse {
     pub flights: Vec<FlightView>,
     pub total_count: i64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FlightGap {
+    /// Start time of the gap (timestamp of last fix before gap)
+    pub gap_start: String,
+    /// End time of the gap (timestamp of first fix after gap)
+    pub gap_end: String,
+    /// Duration of the gap in seconds
+    pub duration_seconds: i64,
+    /// Straight-line distance covered during the gap in meters
+    pub distance_meters: f64,
+    /// Callsign before the gap (if available)
+    pub callsign_before: Option<String>,
+    /// Callsign after the gap (if available)
+    pub callsign_after: Option<String>,
+    /// Squawk code before the gap (if available)
+    pub squawk_before: Option<String>,
+    /// Squawk code after the gap (if available)
+    pub squawk_after: Option<String>,
+    /// Climb rate (fpm) for the fix immediately before the gap
+    pub climb_rate_before: Option<i32>,
+    /// Climb rate (fpm) for the fix immediately after the gap
+    pub climb_rate_after: Option<i32>,
+    /// Average climb rate (fpm) for 10 fixes before the gap
+    pub avg_climb_rate_10_before: Option<i32>,
+    /// Average climb rate (fpm) for 10 fixes after the gap
+    pub avg_climb_rate_10_after: Option<i32>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FlightGapsResponse {
+    pub gaps: Vec<FlightGap>,
+    pub count: usize,
 }
 
 /// Get a flight by its UUID
@@ -663,4 +697,141 @@ pub async fn get_nearby_flights(
             .into_response()
         }
     }
+}
+
+/// Calculate average climb rate from a slice of fixes
+fn calculate_avg_climb_rate(fixes: &[FixWithRawPacket]) -> Option<i32> {
+    if fixes.len() < 2 {
+        return None;
+    }
+
+    let first = &fixes[0];
+    let last = &fixes[fixes.len() - 1];
+
+    // Get altitude MSL for both fixes
+    let first_alt = first.altitude_msl_feet?;
+    let last_alt = last.altitude_msl_feet?;
+
+    // Calculate time difference in minutes
+    let time_diff = (last.timestamp - first.timestamp).num_seconds() as f64 / 60.0;
+
+    if time_diff == 0.0 {
+        return None;
+    }
+
+    // Calculate climb rate in feet per minute
+    let climb_rate = (last_alt - first_alt) as f64 / time_diff;
+
+    Some(climb_rate.round() as i32)
+}
+
+/// Get gaps in position fixes for a flight (5+ minutes between fixes)
+/// This is useful for debugging flight detection and understanding tracking coverage
+pub async fn get_flight_gaps(
+    Path(id): Path<Uuid>,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    let flights_repo = FlightsRepository::new(state.pool.clone());
+    let fixes_repo = FixesRepository::new(state.pool.clone());
+
+    // First verify the flight exists
+    let flight = match flights_repo.get_flight_by_id(id).await {
+        Ok(Some(flight)) => flight,
+        Ok(None) => return json_error(StatusCode::NOT_FOUND, "Flight not found").into_response(),
+        Err(e) => {
+            tracing::error!("Failed to get flight by ID {}: {}", id, e);
+            return json_error(StatusCode::INTERNAL_SERVER_ERROR, "Failed to get flight")
+                .into_response();
+        }
+    };
+
+    // Get all fixes for the flight in chronological order
+    let start_time = flight.takeoff_time.unwrap_or(flight.created_at);
+    let end_time = flight.landing_time.unwrap_or_else(chrono::Utc::now);
+
+    let mut fixes = match fixes_repo
+        .get_fixes_for_aircraft_with_time_range(
+            &flight.aircraft_id.unwrap_or(Uuid::nil()),
+            start_time,
+            end_time,
+            None,
+        )
+        .await
+    {
+        Ok(fixes) => fixes,
+        Err(e) => {
+            tracing::error!("Failed to get fixes for flight {}: {}", id, e);
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to get flight fixes",
+            )
+            .into_response();
+        }
+    };
+
+    // Reverse to get chronological order (earliest first)
+    fixes.reverse();
+
+    const GAP_THRESHOLD_SECONDS: i64 = 5 * 60; // 5 minutes
+    const LOOKBACK_COUNT: usize = 10;
+
+    let mut gaps = Vec::new();
+
+    // Iterate through consecutive fixes to find gaps
+    for i in 0..fixes.len().saturating_sub(1) {
+        let current = &fixes[i];
+        let next = &fixes[i + 1];
+
+        let time_diff = (next.timestamp - current.timestamp).num_seconds();
+
+        if time_diff >= GAP_THRESHOLD_SECONDS {
+            // Calculate distance covered during the gap
+            let distance_meters = haversine_distance(
+                current.latitude,
+                current.longitude,
+                next.latitude,
+                next.longitude,
+            );
+
+            // Get callsign before and after (only if different)
+            let callsign_before = current.flight_number.clone();
+            let callsign_after = next.flight_number.clone();
+
+            // Get squawk codes
+            let squawk_before = current.squawk.clone();
+            let squawk_after = next.squawk.clone();
+
+            // Climb rate for fixes immediately before and after
+            let climb_rate_before = current.climb_fpm;
+            let climb_rate_after = next.climb_fpm;
+
+            // Calculate average climb rate for 10 fixes before the gap
+            let start_lookback = i.saturating_sub(LOOKBACK_COUNT);
+            let fixes_before = &fixes[start_lookback..=i];
+            let avg_climb_rate_10_before = calculate_avg_climb_rate(fixes_before);
+
+            // Calculate average climb rate for 10 fixes after the gap
+            let end_lookback = (i + 1 + LOOKBACK_COUNT).min(fixes.len());
+            let fixes_after = &fixes[(i + 1)..end_lookback];
+            let avg_climb_rate_10_after = calculate_avg_climb_rate(fixes_after);
+
+            gaps.push(FlightGap {
+                gap_start: current.timestamp.to_rfc3339(),
+                gap_end: next.timestamp.to_rfc3339(),
+                duration_seconds: time_diff,
+                distance_meters,
+                callsign_before,
+                callsign_after,
+                squawk_before,
+                squawk_after,
+                climb_rate_before,
+                climb_rate_after,
+                avg_climb_rate_10_before,
+                avg_climb_rate_10_after,
+            });
+        }
+    }
+
+    let count = gaps.len();
+    Json(FlightGapsResponse { gaps, count }).into_response()
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -623,6 +623,7 @@ pub async fn start_web_server(interface: String, port: u16, pool: PgPool) -> Res
         .route("/flights/{id}/device", get(actions::get_flight_device))
         .route("/flights/{id}/kml", get(actions::get_flight_kml))
         .route("/flights/{id}/fixes", get(actions::get_flight_fixes))
+        .route("/flights/{id}/gaps", get(actions::get_flight_gaps))
         .route(
             "/flights/{id}/spline-path",
             get(actions::get_flight_spline_path),


### PR DESCRIPTION
## Summary
- Add "Show intervals" toggle to position fixes table with HH:MM:SS format (red if >1 hour)
- Add new `/data/flights/{id}/gaps` endpoint to analyze position fix gaps (5+ minutes)
- Add "Fix Gaps" section to flight detail page showing comprehensive debugging information

## Changes

### Backend
- **New endpoint**: `/data/flights/{id}/gaps`
  - Identifies gaps of 5+ minutes between consecutive position fixes
  - Returns gap duration, distance covered, callsign/squawk changes
  - Calculates immediate and average climb rates before/after each gap
  - Location: `src/actions/flights.rs:746-849`

### Frontend
- **FixesList component** (`web/src/lib/components/FixesList.svelte`):
  - Added "Show intervals" toggle control
  - Displays time between consecutive fixes in HH:MM:SS format
  - Intervals over 1 hour highlighted in red with bold font
  - Works in both desktop table and mobile card views

- **Flight detail page** (`web/src/routes/flights/[id]/+page.svelte`):
  - New "Fix Gaps" section below Position Fixes table
  - "Show fix gaps" button to load data on demand
  - Displays each gap in a card with:
    - Gap number and total duration
    - Start/end times with dates
    - Distance covered (nautical miles and kilometers)
    - Callsign changes (before → after if different)
    - Squawk code changes
    - Immediate climb rates before/after gap
    - Average climb rates for 10 fixes before/after gap
  - Empty state when no gaps found

## Use Case
This helps debug flight detection issues by:
- Visualizing time between position fixes to identify tracking quality
- Analyzing significant gaps in coverage
- Examining aircraft state changes during interruptions
- Understanding climb/descent behavior around gaps

## Test plan
- [x] Backend passes `cargo clippy` with no errors
- [x] Frontend passes `npm run check` (TypeScript validation)
- [x] Frontend passes `npm run lint` (ESLint + Prettier)
- [x] All pre-commit hooks pass
- [ ] Manual testing: View flight detail page and verify intervals display
- [ ] Manual testing: Click "Show fix gaps" and verify gap analysis displays
- [ ] Manual testing: Verify red highlighting for intervals >1 hour