### PR TITLE
fix: replace zsh-specific >! with bash-compatible > in soar-deploy

### DIFF
--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -469,7 +469,7 @@ if [ -d "$DEPLOY_DIR/grafana-provisioning" ]; then
                 log_info "Processing contact-points.yml.template with SMTP config from $ENV_FILE..."
                 sed -e "s|{{ALERT_EMAIL}}|$ALERT_EMAIL|g" \
                     "$DEPLOY_DIR/grafana-provisioning/alerting/contact-points.yml.template" \
-                    >! /etc/grafana/provisioning/alerting/contact-points.yml
+                    > /etc/grafana/provisioning/alerting/contact-points.yml
                 chmod 640 /etc/grafana/provisioning/alerting/contact-points.yml
                 log_info "Alert contact point configured for: $ALERT_EMAIL"
             fi
@@ -499,7 +499,7 @@ if [ -d "$DEPLOY_DIR/grafana-provisioning" ]; then
                     -e "s|{{FROM_EMAIL}}|$FROM_ADDR|g" \
                     -e "s|{{FROM_NAME}}|$FROM_NAME_VAL|g" \
                     "$DEPLOY_DIR/systemd/grafana-server.service.d-smtp.conf.template" \
-                    >! /etc/systemd/system/grafana-server.service.d/smtp.conf
+                    > /etc/systemd/system/grafana-server.service.d/smtp.conf
                 chmod 640 /etc/systemd/system/grafana-server.service.d/smtp.conf
                 log_info "Grafana SMTP configured: $SMTP_HOST:$SMTP_PORT_VAL as $FROM_ADDR"
 


### PR DESCRIPTION
## Summary
- Fixed staging deployment failure caused by incorrect shell redirect syntax
- Changed `>!` (zsh-specific) to `>` (bash-compatible) in soar-deploy script

## Problem
The `soar-deploy` script uses `#!/bin/bash` but was using `>!` for file redirection, which is zsh-specific syntax for overriding noclobber.

In bash, `>!` is not recognized as a redirect operator, causing bash to parse:
```bash
sed -e "s|{{ALERT_EMAIL}}|$ALERT_EMAIL|g" \
    "$DEPLOY_DIR/grafana-provisioning/alerting/contact-points.yml.template" \
    >! /etc/grafana/provisioning/alerting/contact-points.yml
```

as:
```bash
sed -e "s|{{ALERT_EMAIL}}|$ALERT_EMAIL|g" \
    "$DEPLOY_DIR/grafana-provisioning/alerting/contact-points.yml.template" \
    /etc/grafana/provisioning/alerting/contact-points.yml
```

This made sed try to read the output file as a second input file, resulting in:
```
sed: can't read /etc/grafana/provisioning/alerting/contact-points.yml: No such file or directory
```

## Solution
- Replaced both instances of `>!` with `>` (standard bash redirect)
- Bash doesn't have noclobber enabled by default, so plain `>` works correctly
- If needed in the future, bash's equivalent to zsh's `>!` is `>|`

## Testing
- Fixed syntax is bash-compatible and will work correctly on deployment
- No behavior change when noclobber is disabled (the default)

## Files Changed
- `infrastructure/soar-deploy`: Lines 472 and 502

Fixes staging deployment errors seen in https://github.com/hut8/soar/actions/runs/20403163686