### PR TITLE
fix: resolve airspace display issues and add modal UI

### DIFF
--- a/web/src/lib/components/AirspaceModal.svelte
+++ b/web/src/lib/components/AirspaceModal.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+	import { X, Shield, MapPin, Info } from '@lucide/svelte';
+	import type { Airspace } from '$lib/types';
+
+	// Props
+	let { showModal = $bindable(), selectedAirspace = $bindable() } = $props<{
+		showModal: boolean;
+		selectedAirspace: Airspace | null;
+	}>();
+
+	function closeModal() {
+		showModal = false;
+		selectedAirspace = null;
+	}
+
+	function getAirspaceClassDisplay(airspaceClass: string | null): string {
+		if (!airspaceClass) return 'Unknown';
+		return `Class ${airspaceClass}`;
+	}
+
+	function getAirspaceTypeDisplay(type: string): string {
+		// Convert snake_case or PascalCase to Title Case
+		return type
+			.replace(/([A-Z])/g, ' $1')
+			.replace(/_/g, ' ')
+			.trim()
+			.split(' ')
+			.map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+			.join(' ');
+	}
+
+	function getAirspaceColor(airspaceClass: string | null): string {
+		switch (airspaceClass) {
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+				return 'error'; // Red - Controlled airspace
+			case 'E':
+				return 'warning'; // Amber - Class E
+			case 'F':
+			case 'G':
+				return 'success'; // Green - Uncontrolled
+			default:
+				return 'secondary'; // Gray - Other/SUA
+		}
+	}
+</script>
+
+<!-- Airspace Modal -->
+{#if showModal && selectedAirspace}
+	<div
+		class="fixed inset-0 z-50 flex items-start justify-center bg-surface-950-50/50 pt-20"
+		onclick={closeModal}
+		onkeydown={(e) => e.key === 'Escape' && closeModal()}
+		role="presentation"
+	>
+		<div
+			class="max-h-[calc(90vh-5rem)] w-full max-w-2xl overflow-y-auto card bg-surface-50 text-surface-900 shadow-xl dark:bg-surface-900 dark:text-surface-50"
+			onclick={(e) => e.stopPropagation()}
+			onkeydown={(e) => e.key === 'Escape' && closeModal()}
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="airspace-modal-title"
+			tabindex="-1"
+		>
+			<!-- Header -->
+			<div
+				class="flex items-center justify-between border-b border-surface-300 p-6 dark:border-surface-600"
+			>
+				<div class="flex items-center gap-3">
+					<div
+						class="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500 text-white"
+					>
+						<Shield size={24} />
+					</div>
+					<div>
+						<h2 id="airspace-modal-title" class="text-xl font-bold">
+							{selectedAirspace.properties.name}
+						</h2>
+						<p class="text-sm text-surface-600 dark:text-surface-400">
+							{getAirspaceTypeDisplay(selectedAirspace.properties.airspace_type)}
+						</p>
+					</div>
+				</div>
+				<button class="preset-tonal-surface-500 btn btn-sm" onclick={closeModal}>
+					<X size={20} />
+				</button>
+			</div>
+
+			<div class="p-6">
+				<div class="space-y-6">
+					<!-- Airspace Classification -->
+					<div class="space-y-4">
+						<h3 class="flex items-center gap-2 text-lg font-semibold">
+							<Info size={20} />
+							Classification
+						</h3>
+
+						<div class="space-y-3">
+							<div class="grid grid-cols-2 gap-4">
+								<div>
+									<dt class="text-sm font-medium text-surface-600 dark:text-surface-400">
+										Airspace Class
+									</dt>
+									<dd class="mt-1">
+										<span
+											class="badge preset-filled-{getAirspaceColor(
+												selectedAirspace.properties.airspace_class
+											)}"
+										>
+											{getAirspaceClassDisplay(selectedAirspace.properties.airspace_class)}
+										</span>
+									</dd>
+								</div>
+								<div>
+									<dt class="text-sm font-medium text-surface-600 dark:text-surface-400">Type</dt>
+									<dd class="mt-1 text-sm">
+										{getAirspaceTypeDisplay(selectedAirspace.properties.airspace_type)}
+									</dd>
+								</div>
+							</div>
+
+							{#if selectedAirspace.properties.country_code}
+								<div>
+									<dt class="text-sm font-medium text-surface-600 dark:text-surface-400">
+										Country
+									</dt>
+									<dd class="mt-1 font-mono text-sm">
+										{selectedAirspace.properties.country_code}
+									</dd>
+								</div>
+							{/if}
+
+							{#if selectedAirspace.properties.activity_type}
+								<div>
+									<dt class="text-sm font-medium text-surface-600 dark:text-surface-400">
+										Activity Type
+									</dt>
+									<dd class="mt-1 text-sm">
+										{getAirspaceTypeDisplay(selectedAirspace.properties.activity_type)}
+									</dd>
+								</div>
+							{/if}
+						</div>
+					</div>
+
+					<!-- Altitude Limits -->
+					<div class="space-y-4">
+						<h3 class="flex items-center gap-2 text-lg font-semibold">
+							<MapPin size={20} />
+							Altitude Limits
+						</h3>
+
+						<div class="space-y-3">
+							<div class="grid grid-cols-2 gap-4">
+								<div>
+									<dt class="text-sm font-medium text-surface-600 dark:text-surface-400">
+										Lower Limit
+									</dt>
+									<dd class="mt-1 font-mono text-sm">
+										{selectedAirspace.properties.lower_limit}
+									</dd>
+								</div>
+								<div>
+									<dt class="text-sm font-medium text-surface-600 dark:text-surface-400">
+										Upper Limit
+									</dt>
+									<dd class="mt-1 font-mono text-sm">
+										{selectedAirspace.properties.upper_limit}
+									</dd>
+								</div>
+							</div>
+						</div>
+					</div>
+
+					<!-- Remarks -->
+					{#if selectedAirspace.properties.remarks}
+						<div class="space-y-4">
+							<h3 class="text-lg font-semibold">Remarks</h3>
+							<div
+								class="rounded-lg border border-surface-300 bg-surface-100 p-4 dark:border-surface-600 dark:bg-surface-800"
+							>
+								<p class="text-sm whitespace-pre-wrap">{selectedAirspace.properties.remarks}</p>
+							</div>
+						</div>
+					{/if}
+				</div>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/web/src/routes/operations/+page.svelte
+++ b/web/src/routes/operations/+page.svelte
@@ -10,6 +10,7 @@
 	import SettingsModal from '$lib/components/SettingsModal.svelte';
 	import AircraftStatusModal from '$lib/components/AircraftStatusModal.svelte';
 	import AirportModal from '$lib/components/AirportModal.svelte';
+	import AirspaceModal from '$lib/components/AirspaceModal.svelte';
 	import { AircraftRegistry } from '$lib/services/AircraftRegistry';
 	import { FixFeed } from '$lib/services/FixFeed';
 	import type { Aircraft, Receiver, Airspace, AirspaceFeatureCollection } from '$lib/types';
@@ -121,6 +122,10 @@
 	// Airport modal state
 	let showAirportModal = $state(false);
 	let selectedAirport: AirportView | null = $state(null);
+
+	// Airspace modal state
+	let showAirspaceModal = $state(false);
+	let selectedAirspace: Airspace | null = $state(null);
 
 	// Settings state - these will be updated by the SettingsModal
 	let currentSettings = $state({
@@ -1153,7 +1158,7 @@
 				limit: '500'
 			});
 
-			const data = await serverCall<AirspaceFeatureCollection>(`/data/airspaces?${params}`);
+			const data = await serverCall<AirspaceFeatureCollection>(`/airspaces?${params}`);
 
 			if (data && data.type === 'FeatureCollection' && Array.isArray(data.features)) {
 				displayAirspacesOnMap(data.features);
@@ -1204,27 +1209,10 @@
 					zIndex: 50 // Below airports (100) and receivers (150)
 				});
 
-				// Add click listener to show airspace info
-				polygon.addListener('click', (event: google.maps.PolyMouseEvent) => {
-					if (!event.latLng) return;
-
-					const infoWindow = new google.maps.InfoWindow({
-						content: `
-							<div style="padding: 8px;">
-								<h3 style="margin: 0 0 8px 0; font-weight: bold;">${airspace.properties.name}</h3>
-								<div style="font-size: 13px;">
-									<div><strong>Class:</strong> ${airspace.properties.airspace_class || 'N/A'}</div>
-									<div><strong>Type:</strong> ${airspace.properties.airspace_type}</div>
-									<div><strong>Lower:</strong> ${airspace.properties.lower_limit}</div>
-									<div><strong>Upper:</strong> ${airspace.properties.upper_limit}</div>
-									${airspace.properties.remarks ? `<div style="margin-top: 4px;"><strong>Remarks:</strong> ${airspace.properties.remarks}</div>` : ''}
-								</div>
-							</div>
-						`,
-						position: event.latLng
-					});
-
-					infoWindow.open(map);
+				// Add click listener to show airspace modal
+				polygon.addListener('click', () => {
+					selectedAirspace = airspace;
+					showAirspaceModal = true;
 				});
 
 				airspacePolygons.push(polygon);
@@ -2121,6 +2109,9 @@
 
 <!-- Airport Modal -->
 <AirportModal bind:showModal={showAirportModal} bind:selectedAirport />
+
+<!-- Airspace Modal -->
+<AirspaceModal bind:showModal={showAirspaceModal} bind:selectedAirspace />
 
 <style>
 	/* Location button styling */


### PR DESCRIPTION
## Summary
- Fix duplicate `/data` prefix in airspaces API endpoint that was causing 404 errors
- Replace Google Maps InfoWindow with custom AirspaceModal component for better UX and proper dark/light theme support
- Add color-coded airspace class badges matching polygon colors

## Changes
### Bug Fix
- **API endpoint fix**: Changed `/data/airspaces` → `/airspaces` in `serverCall()` since the function already prepends `/data`
  - Before: `https://glider.flights/data/data/airspaces` ❌
  - After: `https://glider.flights/data/airspaces` ✅

### UI Enhancement
- **New component**: `AirspaceModal.svelte` following existing modal patterns (AirportModal, AircraftStatusModal)
- **Improved UX**: Click on any airspace polygon to view detailed information in a modal dialog
- **Color-coded badges**: 
  - 🔴 Red - Class A, B, C, D (Controlled airspace)
  - 🟠 Amber - Class E
  - 🟢 Green - Class F, G (Uncontrolled)
  - ⚪ Gray - Other/SUA

### Modal Features
- Displays airspace name, class, type, country code
- Shows altitude limits (lower/upper)
- Includes activity type and remarks when available
- Proper dark/light theme support (no more white-on-white text!)
- Consistent styling with other SOAR modals

## Behavior
Airspaces display when:
- Viewport area < 100,000 sq mi (zoom in to see them)
- "Show Airspace Boundaries" setting is enabled

## Testing
- [x] Airspaces load correctly when zoomed in
- [x] Click on airspace polygon opens modal
- [x] Modal displays all airspace properties
- [x] Color-coded badges match polygon colors
- [x] Dark/light theme switching works
- [x] Modal closes on X button or outside click