### PR TITLE
perf: optimize area subscriptions with bulk bounding box protocol

### DIFF
--- a/src/web.rs
+++ b/src/web.rs
@@ -559,6 +559,9 @@ pub async fn start_web_server(interface: String, port: u16, pool: PgPool) -> Res
     metrics::counter!("websocket_aircraft_unsubscribes").absolute(0);
     metrics::counter!("websocket_area_subscribes").absolute(0);
     metrics::counter!("websocket_area_unsubscribes").absolute(0);
+    metrics::counter!("websocket_area_bulk_subscribes").absolute(0);
+    metrics::counter!("websocket_area_bulk_unsubscribes").absolute(0);
+    metrics::counter!("websocket_area_bulk_validation_errors").absolute(0);
 
     // Initialize analytics metrics
     crate::metrics::initialize_analytics_metrics();

--- a/web/src/lib/services/FixFeed.ts
+++ b/web/src/lib/services/FixFeed.ts
@@ -17,20 +17,26 @@ export type FixFeedEvent =
 
 export type FixFeedSubscriber = (event: FixFeedEvent) => void;
 
+export interface GeoBounds {
+	north: number;
+	south: number;
+	east: number;
+	west: number;
+}
+
 export interface AircraftSubscriptionMessage {
 	action: string; // "subscribe" or "unsubscribe"
 	type: 'aircraft';
 	id: string;
 }
 
-export interface AreaSubscriptionMessage {
+export interface BulkAreaSubscriptionMessage {
 	action: string; // "subscribe" or "unsubscribe"
-	type: 'area';
-	latitude: number;
-	longitude: number;
+	type: 'area_bulk';
+	bounds: GeoBounds;
 }
 
-export type SubscriptionMessage = AircraftSubscriptionMessage | AreaSubscriptionMessage;
+export type SubscriptionMessage = AircraftSubscriptionMessage | BulkAreaSubscriptionMessage;
 
 export class FixFeed {
 	private static instance: FixFeed | null = null;

--- a/web/src/routes/operations/+page.svelte
+++ b/web/src/routes/operations/+page.svelte
@@ -1790,94 +1790,73 @@
 	}
 
 	function updateAreaSubscriptions(): void {
-		if (!areaTrackerActive || !areaTrackerAvailable) return;
+		if (!areaTrackerActive || !areaTrackerAvailable || !map) return;
 
+		const bounds = map.getBounds();
+		if (!bounds) return;
+
+		const ne = bounds.getNorthEast();
+		const sw = bounds.getSouthWest();
+
+		const geoBounds = {
+			north: ne.lat(),
+			south: sw.lat(),
+			east: ne.lng(),
+			west: sw.lng()
+		};
+
+		const message = {
+			action: 'subscribe',
+			type: 'area_bulk' as const,
+			bounds: geoBounds
+		};
+
+		console.log('[AREA TRACKER] Bulk subscribe:', message);
+		fixFeed.sendWebSocketMessage(message);
+
+		// For debugging: calculate what squares this represents
 		const visibleSquares = getVisibleLatLonSquares();
-		const newSubscriptions = new SvelteSet<string>();
+		console.log(`[AREA TRACKER] Bulk subscription covers ${visibleSquares.length} squares`);
 
-		// Create subscription keys for visible squares
+		// Update current subscriptions for debugging display
+		const newSubscriptions = new SvelteSet<string>();
 		visibleSquares.forEach((square) => {
 			const key = `area.${square.lat}.${square.lon}`;
 			newSubscriptions.add(key);
 		});
-
-		// Find squares to unsubscribe from (no longer visible)
-		const toUnsubscribe = new SvelteSet<string>();
-		currentAreaSubscriptions.forEach((key) => {
-			if (!newSubscriptions.has(key)) {
-				toUnsubscribe.add(key);
-			}
-		});
-
-		// Find squares to subscribe to (newly visible)
-		const toSubscribe = new SvelteSet<string>();
-		newSubscriptions.forEach((key) => {
-			if (!currentAreaSubscriptions.has(key)) {
-				toSubscribe.add(key);
-			}
-		});
-
-		// Unsubscribe from areas no longer visible
-		toUnsubscribe.forEach((key) => {
-			const [, lat, lon] = key.split('.');
-			unsubscribeFromArea(parseInt(lat), parseInt(lon));
-		});
-
-		// Subscribe to newly visible areas
-		toSubscribe.forEach((key) => {
-			const [, lat, lon] = key.split('.');
-			subscribeToArea(parseInt(lat), parseInt(lon));
-		});
-
-		// Update current subscriptions
 		currentAreaSubscriptions = newSubscriptions;
 
-		console.log(
-			`[AREA TRACKER] Updated subscriptions: ${toSubscribe.size} new, ${toUnsubscribe.size} removed, ${currentAreaSubscriptions.size} total`
-		);
-
-		// Explicitly update debug status to ensure WebSocket status panel shows area subscriptions
+		// Update debug status to show area subscription count
 		debugStatus.update((current) => ({
 			...current,
-			activeAreaSubscriptions: currentAreaSubscriptions.size
+			activeAreaSubscriptions: visibleSquares.length
 		}));
 	}
 
 	function clearAreaSubscriptions(): void {
-		currentAreaSubscriptions.forEach((key) => {
-			const [, lat, lon] = key.split('.');
-			unsubscribeFromArea(parseInt(lat), parseInt(lon));
-		});
-		currentAreaSubscriptions.clear();
-		console.log('[AREA TRACKER] Cleared all area subscriptions');
+		if (!map) return;
 
-		// Explicitly update debug status to ensure WebSocket status panel updates
+		const message = {
+			action: 'unsubscribe',
+			type: 'area_bulk' as const,
+			bounds: {
+				north: 0,
+				south: 0,
+				east: 0,
+				west: 0
+			}
+		};
+
+		console.log('[AREA TRACKER] Bulk unsubscribe');
+		fixFeed.sendWebSocketMessage(message);
+
+		currentAreaSubscriptions.clear();
+
+		// Update debug status
 		debugStatus.update((current) => ({
 			...current,
 			activeAreaSubscriptions: 0
 		}));
-	}
-
-	function subscribeToArea(latitude: number, longitude: number): void {
-		const message = {
-			action: 'subscribe',
-			type: 'area' as const,
-			latitude,
-			longitude
-		};
-		console.log('[AREA TRACKER] Subscribe to area:', message);
-		fixFeed.sendWebSocketMessage(message);
-	}
-
-	function unsubscribeFromArea(latitude: number, longitude: number): void {
-		const message = {
-			action: 'unsubscribe',
-			type: 'area' as const,
-			latitude,
-			longitude
-		};
-		console.log('[AREA TRACKER] Unsubscribe from area:', message);
-		fixFeed.sendWebSocketMessage(message);
 	}
 
 	async function fetchAndDisplayDevicesInViewport(): Promise<void> {


### PR DESCRIPTION
## Summary

Optimize area subscriptions from individual WebSocket messages to a single bulk message containing a bounding box. The server calculates which 1-degree squares fall within the bounds and manages subscriptions atomically with delta calculation.

**Performance improvement: 97% reduction in WebSocket messages** (48→1 for typical viewport)

## Changes

### Backend (`src/`)
- **New message protocol**: Added `GeoBounds` struct and `AreaBulk` variant to `SubscriptionMessage` enum
- **Bulk subscription handler**: Implements delta calculation to only subscribe/unsubscribe changed squares
- **Square calculation**: Handles date line crossing and filters polar regions
- **Validation**: Rejects viewports > 1000 squares to prevent resource exhaustion
- **Metrics**: Added counters and histogram for bulk subscription operations:
  - `websocket_area_bulk_subscribes`
  - `websocket_area_bulk_unsubscribes`
  - `websocket_area_bulk_validation_errors`
  - `websocket_area_bulk_squares_per_subscription`

### Frontend (`web/`)
- **Type updates**: Added `GeoBounds` and `BulkAreaSubscriptionMessage` interfaces
- **Operations page**: Sends single bulk message with map bounds instead of N individual messages
- **Cesium AircraftLayer**: Updated globe view to use bulk subscriptions
- **Removed**: Old individual subscription functions (`subscribeToArea`, `unsubscribeFromArea`)

## Breaking Change

⚠️ **BREAKING CHANGE**: Removed individual `area` subscription type. Clients must use `area_bulk` with bounding box.

**Old protocol:**
```json
{"action": "subscribe", "type": "area", "latitude": 37, "longitude": -122}
```

**New protocol:**
```json
{
  "action": "subscribe",
  "type": "area_bulk",
  "bounds": {
    "north": 38.5,
    "south": 36.5,
    "east": -120.5,
    "west": -123.5
  }
}
```

**Deployment**: Backend and frontend must be deployed together as this is a coordinated breaking change.

## Test Plan

- [x] Backend: `cargo fmt`, `cargo clippy`, compilation successful
- [x] Frontend: `npm run lint`, `npm run check`, `npm run build` all pass
- [ ] Manual testing:
  - [ ] Operations page map panning/zooming
  - [ ] Cesium globe view subscriptions
  - [ ] Multiple simultaneous users
  - [ ] Date line crossing (Pacific Ocean)
  - [ ] Very large viewport validation
  - [ ] Connection loss and reconnection
- [ ] Monitor metrics after deployment:
  - `websocket_area_bulk_subscribes` should show activity
  - `websocket_area_bulk_validation_errors` should be zero or low
  - No increase in `websocket_send_errors`

## Key Design Decisions

- **NATS layer unchanged**: Reference counting and subscription sharing remain efficient
- **Delta calculation**: Server only changes subscriptions for squares that entered/left viewport
- **1000 square limit**: Covers ~31x31 degree viewport while preventing abuse
- **Date line handling**: Splits into two ranges (west→180, -180→east)

## Metrics

The following Grafana dashboard queries should be updated to track the new bulk subscription metrics:
- `infrastructure/grafana-dashboard-web.json`