### PR TITLE
fix: include Grafana SMTP template in deployment package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -662,6 +662,13 @@ jobs:
           cp infrastructure/systemd/*.timer deploy-pkg/ || echo "No timer files found"
           cp infrastructure/systemd/*.target deploy-pkg/ || echo "No target files found"
 
+          # Copy systemd directory (includes template files for Grafana SMTP config)
+          if [ -d infrastructure/systemd ]; then
+            mkdir -p deploy-pkg/systemd
+            cp infrastructure/systemd/*.template deploy-pkg/systemd/ 2>/dev/null || echo "No systemd template files found"
+            echo "Systemd template files included in deployment package"
+          fi
+
           # Copy Prometheus job configuration files
           if [ -d infrastructure/prometheus-jobs ]; then
             cp -r infrastructure/prometheus-jobs deploy-pkg/
@@ -807,6 +814,13 @@ jobs:
           cp infrastructure/systemd/*.service deploy-pkg/ || echo "No service files found"
           cp infrastructure/systemd/*.timer deploy-pkg/ || echo "No timer files found"
           cp infrastructure/systemd/*.target deploy-pkg/ || echo "No target files found"
+
+          # Copy systemd directory (includes template files for Grafana SMTP config)
+          if [ -d infrastructure/systemd ]; then
+            mkdir -p deploy-pkg/systemd
+            cp infrastructure/systemd/*.template deploy-pkg/systemd/ 2>/dev/null || echo "No systemd template files found"
+            echo "Systemd template files included in deployment package"
+          fi
 
           # Copy Prometheus job configuration files
           if [ -d infrastructure/prometheus-jobs ]; then


### PR DESCRIPTION
## Summary

Fixes Grafana SMTP configuration issue where alert emails were not being sent because the SMTP template file was missing from the deployment package.

## Problem

The `soar-deploy` script expects to find the Grafana SMTP configuration template at `$DEPLOY_DIR/systemd/grafana-server.service.d-smtp.conf.template` to process SMTP credentials from `/etc/soar/env` or `/etc/soar/env-staging`.

However, the CI pipeline was only copying `.service`, `.timer`, and `.target` files from `infrastructure/systemd/` to the deployment package, but **not `.template` files**.

This caused the deployment script to skip SMTP configuration, preventing Grafana from sending alert emails even though the credentials were properly configured in the environment files.

## Changes

Updated `.github/workflows/ci.yml` (both `deploy-staging` and `deploy-production` jobs) to copy all `.template` files from `infrastructure/systemd/` to the deployment package:

```bash
# Copy systemd directory (includes template files for Grafana SMTP config)
if [ -d infrastructure/systemd ]; then
  mkdir -p deploy-pkg/systemd
  cp infrastructure/systemd/*.template deploy-pkg/systemd/ 2>/dev/null || echo "No systemd template files found"
  echo "Systemd template files included in deployment package"
fi
```

## Impact

After deployment, Grafana will be properly configured with SMTP credentials and will be able to send alert emails for:
- OGN Message Ingestion Rate Too Low (critical)
- OGN Ingest Service Disconnected (critical)
- OGN NATS Publishing Errors (warning)

## Test Plan

- [ ] Verify CI pipeline includes systemd templates in deployment package
- [ ] After staging deployment, verify `/etc/systemd/system/grafana-server.service.d/smtp.conf` exists and contains proper SMTP config
- [ ] Test Grafana alert email delivery using Grafana UI contact point test
- [ ] Verify alerts fire and send emails when triggered

## Related

- Infrastructure: Grafana Alerting (see `infrastructure/GRAFANA-ALERTING.md`)
- SMTP configuration extracted from `/etc/soar/env` or `/etc/soar/env-staging`