### PR TITLE
feat: separate Grafana alerts by environment and adjust repeat intervals

### DIFF
--- a/infrastructure/grafana-provisioning/alerting/alert-rules-production.yml
+++ b/infrastructure/grafana-provisioning/alerting/alert-rules-production.yml
@@ -1,0 +1,208 @@
+# Grafana Alerting Rules Configuration - PRODUCTION ONLY
+# This defines the alert conditions and thresholds for SOAR production monitoring
+#
+# This file should ONLY be deployed to production Grafana instances.
+# For staging alerts, see alert-rules-staging.yml
+
+apiVersion: 1
+
+groups:
+  # ============================================================================
+  # PRODUCTION ENVIRONMENT ALERTS
+  # ============================================================================
+  - orgId: 1
+    name: soar-ogn-ingest-alerts-production
+    folder: SOAR
+    interval: 1m
+    rules:
+      # Alert when production OGN/APRS message ingestion rate drops below 1 message per minute
+      - uid: ogn_message_rate_low_production
+        title: "[Production] OGN Message Ingestion Rate Too Low"
+        condition: C
+        data:
+          # Query A: Get the rate of APRS messages processed per minute (production only)
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: Prometheus
+            model:
+              expr: rate(aprs_raw_message_processed_total{environment="production"}[1m]) * 60
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+
+          # Query B: Get the rate of messages published to NATS per minute (production only)
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: Prometheus
+            model:
+              expr: rate(aprs_nats_published_total{environment="production"}[1m]) * 60
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: B
+
+          # Condition C: Alert if metric is below 1 msg/min
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 1
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              hide: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+
+        for: 2m
+        noDataState: OK
+        execErrState: Alerting
+        annotations:
+          summary: "[Production] OGN/APRS message ingestion rate is critically low"
+          description: 'Production OGN ingestion rate: {{ printf "%.2f" $values.A.Value }} messages/min (threshold: 1.0 msg/min). Check if ingest-ogn service is running and connected to APRS-IS.'
+        labels:
+          severity: critical
+          service: ogn-ingest
+          environment: production
+          team: ops
+
+      # Alert when production OGN ingest service is disconnected
+      - uid: ogn_service_disconnected_production
+        title: "[Production] OGN Ingest Service Disconnected"
+        condition: B
+        data:
+          # Query A: Check if APRS connection is established (production only)
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: Prometheus
+            model:
+              expr: aprs_connection_connected{environment="production"}
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+
+          # Condition B: Alert if connection gauge is 0 (disconnected)
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.5
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              hide: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: B
+              type: threshold
+
+        for: 1m
+        noDataState: OK
+        execErrState: Alerting
+        annotations:
+          summary: "[Production] OGN/APRS ingest service is disconnected"
+          description: 'The production OGN ingest service has lost connection to APRS-IS. Check service status and network connectivity.'
+        labels:
+          severity: critical
+          service: ogn-ingest
+          environment: production
+          team: ops
+
+      # Alert when production NATS publishing errors are occurring
+      - uid: ogn_nats_publish_errors_production
+        title: "[Production] OGN NATS Publishing Errors"
+        condition: B
+        data:
+          # Query A: Get the rate of NATS publish errors (production only)
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: Prometheus
+            model:
+              expr: rate(aprs_nats_publish_error_total{environment="production"}[5m]) * 60
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+
+          # Condition B: Alert if error rate > 0.1 errors/min
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.1
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              hide: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: B
+              type: threshold
+
+        for: 3m
+        noDataState: OK
+        execErrState: Alerting
+        annotations:
+          summary: "[Production] OGN ingest service is experiencing NATS publishing errors"
+          description: 'Production NATS publish error rate: {{ printf "%.2f" $values.A.Value }} errors/min. Check NATS connectivity and queue depth.'
+        labels:
+          severity: warning
+          service: ogn-ingest
+          environment: production
+          team: ops

--- a/infrastructure/grafana-provisioning/alerting/alert-rules-staging.yml
+++ b/infrastructure/grafana-provisioning/alerting/alert-rules-staging.yml
@@ -1,0 +1,208 @@
+# Grafana Alerting Rules Configuration - STAGING ONLY
+# This defines the alert conditions and thresholds for SOAR staging monitoring
+#
+# This file should ONLY be deployed to staging Grafana instances.
+# For production alerts, see alert-rules-production.yml
+
+apiVersion: 1
+
+groups:
+  # ============================================================================
+  # STAGING ENVIRONMENT ALERTS
+  # ============================================================================
+  - orgId: 1
+    name: soar-ogn-ingest-alerts-staging
+    folder: SOAR
+    interval: 1m
+    rules:
+      # Alert when staging OGN/APRS message ingestion rate drops below 1 message per minute
+      - uid: ogn_message_rate_low_staging
+        title: "[Staging] OGN Message Ingestion Rate Too Low"
+        condition: C
+        data:
+          # Query A: Get the rate of APRS messages processed per minute (staging only)
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: Prometheus
+            model:
+              expr: rate(aprs_raw_message_processed_total{environment="staging"}[1m]) * 60
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+
+          # Query B: Get the rate of messages published to NATS per minute (staging only)
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: Prometheus
+            model:
+              expr: rate(aprs_nats_published_total{environment="staging"}[1m]) * 60
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: B
+
+          # Condition C: Alert if metric is below 1 msg/min
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 1
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              hide: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+
+        for: 2m
+        noDataState: OK
+        execErrState: Alerting
+        annotations:
+          summary: "[Staging] OGN/APRS message ingestion rate is critically low"
+          description: 'Staging OGN ingestion rate: {{ printf "%.2f" $values.A.Value }} messages/min (threshold: 1.0 msg/min). Check if ingest-ogn-staging service is running and connected to APRS-IS.'
+        labels:
+          severity: critical
+          service: ogn-ingest
+          environment: staging
+          team: ops
+
+      # Alert when staging OGN ingest service is disconnected
+      - uid: ogn_service_disconnected_staging
+        title: "[Staging] OGN Ingest Service Disconnected"
+        condition: B
+        data:
+          # Query A: Check if APRS connection is established (staging only)
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: Prometheus
+            model:
+              expr: aprs_connection_connected{environment="staging"}
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+
+          # Condition B: Alert if connection gauge is 0 (disconnected)
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.5
+                    type: lt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              hide: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: B
+              type: threshold
+
+        for: 1m
+        noDataState: OK
+        execErrState: Alerting
+        annotations:
+          summary: "[Staging] OGN/APRS ingest service is disconnected"
+          description: 'The staging OGN ingest service has lost connection to APRS-IS. Check service status and network connectivity.'
+        labels:
+          severity: critical
+          service: ogn-ingest
+          environment: staging
+          team: ops
+
+      # Alert when staging NATS publishing errors are occurring
+      - uid: ogn_nats_publish_errors_staging
+        title: "[Staging] OGN NATS Publishing Errors"
+        condition: B
+        data:
+          # Query A: Get the rate of NATS publish errors (staging only)
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: Prometheus
+            model:
+              expr: rate(aprs_nats_publish_error_total{environment="staging"}[5m]) * 60
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+
+          # Condition B: Alert if error rate > 0.1 errors/min
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.1
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - A
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              hide: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: B
+              type: threshold
+
+        for: 3m
+        noDataState: OK
+        execErrState: Alerting
+        annotations:
+          summary: "[Staging] OGN ingest service is experiencing NATS publishing errors"
+          description: 'Staging NATS publish error rate: {{ printf "%.2f" $values.A.Value }} errors/min. Check NATS connectivity and queue depth.'
+        labels:
+          severity: warning
+          service: ogn-ingest
+          environment: staging
+          team: ops

--- a/infrastructure/grafana-provisioning/alerting/notification-policies.yml
+++ b/infrastructure/grafana-provisioning/alerting/notification-policies.yml
@@ -11,18 +11,18 @@ policies:
     group_interval: 5m
     repeat_interval: 1h  # Re-send alert every hour while active
     routes:
-      # Critical alerts - send immediately and repeat every 30 minutes
+      # Critical alerts - send immediately and repeat every 12 hours
       - receiver: soar-ops-email
         matchers:
           - severity = critical
         group_wait: 10s
-        repeat_interval: 30m
+        repeat_interval: 12h
         continue: false
 
-      # Warning alerts - normal handling, repeat every hour
+      # Warning alerts - normal handling, repeat every 24 hours
       - receiver: soar-ops-email
         matchers:
           - severity = warning
         group_wait: 30s
-        repeat_interval: 1h
+        repeat_interval: 24h
         continue: false

--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -480,6 +480,16 @@ if [ -d "$DEPLOY_DIR/grafana-provisioning" ]; then
                     filename=$(basename "$alerting_file")
                     # Skip template files
                     if [[ "$filename" != *.template ]]; then
+                        # Skip environment-specific alert rules that don't match current environment
+                        if [[ "$filename" == "alert-rules-production.yml" && "$ENVIRONMENT" == "staging" ]]; then
+                            log_info "Skipping $filename (production-only alerts)"
+                            continue
+                        fi
+                        if [[ "$filename" == "alert-rules-staging.yml" && "$ENVIRONMENT" == "production" ]]; then
+                            log_info "Skipping $filename (staging-only alerts)"
+                            continue
+                        fi
+
                         cp "$alerting_file" /etc/grafana/provisioning/alerting/
                         chmod 644 "/etc/grafana/provisioning/alerting/$filename"
                         log_info "Installed alerting config: $filename"


### PR DESCRIPTION
## Summary

Fixes two issues with Grafana alerting:
1. Separates alert rules by environment to prevent cross-environment failures
2. Adjusts repeat intervals to reduce alert noise (critical: 12h, warning: 24h)

## Problems

### Issue 1: Staging alerts deployed to production
Staging and production use separate Grafana instances, but both staging and production alert rules were being deployed to both environments. This caused staging alerts to fail on production (and vice versa) because the metrics with the wrong environment label don't exist.

### Issue 2: Alert repeat intervals too aggressive
- Critical alerts were repeating every 30 minutes
- Warning alerts were repeating every 1 hour
This generated too much noise for persistent issues.

## Changes

### 1. Split alert rules by environment
- Created `alert-rules-production.yml` (production-only alerts)
- Created `alert-rules-staging.yml` (staging-only alerts)
- Removed combined `alert-rules.yml` file
- Updated `soar-deploy` to install only environment-specific alerts:
  - Production deployments skip staging alerts
  - Staging deployments skip production alerts

### 2. Adjusted repeat intervals in `notification-policies.yml`
- **Critical alerts**: 30 minutes → **12 hours**
- **Warning alerts**: 1 hour → **24 hours**

### 3. Updated documentation
- Documented environment-specific alert deployment in `GRAFANA-ALERTING.md`
- Updated repeat interval documentation
- Added guidance for managing environment-specific alerts

## Impact

After deployment:
- ✅ Production Grafana will only have production alerts
- ✅ Staging Grafana will only have staging alerts
- ✅ No more cross-environment alert failures
- ✅ Reduced alert noise with longer repeat intervals (12h/24h)
- ✅ Alerts still fire immediately on first detection

## Test Plan

- [ ] After staging deployment, verify only staging alerts appear in Grafana
- [ ] After production deployment, verify only production alerts appear in Grafana
- [ ] Verify critical alerts repeat every 12 hours
- [ ] Verify warning alerts repeat every 24 hours
- [ ] Trigger a test alert and confirm repeat interval timing

## Related

- Depends on: #575 (SMTP configuration fix)
- Infrastructure: Grafana Alerting (see `infrastructure/GRAFANA-ALERTING.md`)