### PR TITLE
Fix Wasabi backup failures by adding RCLONE_CONFIG environment variable

### DIFF
--- a/infrastructure/examples/backup-env.example
+++ b/infrastructure/examples/backup-env.example
@@ -38,10 +38,18 @@ BACKUP_RCLONE_BUCKET=soar-backup-prod
 # Example: BACKUP_RCLONE_PATH=production/database
 BACKUP_RCLONE_PATH=
 
-# Note: You must configure rclone with your Wasabi credentials first:
-#   rclone config
+#------------------------------------------------------------------------------
+# RCLONE CONFIGURATION
+#------------------------------------------------------------------------------
+
+# Path to rclone configuration file (REQUIRED)
+# This file contains the Wasabi S3 credentials
+# The file should be owned by postgres:soar with 640 permissions
+RCLONE_CONFIG=/etc/soar/rclone.conf
+
+# Note: The rclone configuration file should contain:
 #
-# Example rclone configuration for Wasabi:
+# Example /etc/soar/rclone.conf:
 #   [wasabi]
 #   type = s3
 #   provider = Wasabi
@@ -49,6 +57,12 @@ BACKUP_RCLONE_PATH=
 #   secret_access_key = YOUR_SECRET_KEY
 #   endpoint = s3.wasabisys.com
 #   acl = private
+#
+# Setup instructions:
+#   sudo mkdir -p /etc/soar
+#   sudo nano /etc/soar/rclone.conf  # Add configuration above
+#   sudo chown postgres:soar /etc/soar/rclone.conf
+#   sudo chmod 640 /etc/soar/rclone.conf
 #
 # The bucket must exist before running backups. The structure will be:
 #   s3://soar-backup-prod/base/YYYY-MM-DD/  (base backups)
@@ -207,7 +221,7 @@ METRICS_PUSHGATEWAY=
 #
 # 1. Test rclone access to Wasabi:
 #    source /etc/soar/backup-env
-#    rclone lsd ${BACKUP_RCLONE_REMOTE}:${BACKUP_RCLONE_BUCKET}
+#    rclone --config ${RCLONE_CONFIG} lsd ${BACKUP_RCLONE_REMOTE}:${BACKUP_RCLONE_BUCKET}
 #
 # 2. Test WAL archiving (as postgres user):
 #    sudo -u postgres /usr/local/bin/soar-wal-archive \
@@ -220,5 +234,5 @@ METRICS_PUSHGATEWAY=
 #
 # 4. Verify backup in Wasabi S3:
 #    source /etc/soar/backup-env
-#    rclone lsd ${BACKUP_RCLONE_REMOTE}:${BACKUP_RCLONE_BUCKET}/base
-#    rclone ls ${BACKUP_RCLONE_REMOTE}:${BACKUP_RCLONE_BUCKET}/wal | head
+#    rclone --config ${RCLONE_CONFIG} lsd ${BACKUP_RCLONE_REMOTE}:${BACKUP_RCLONE_BUCKET}/base
+#    rclone --config ${RCLONE_CONFIG} ls ${BACKUP_RCLONE_REMOTE}:${BACKUP_RCLONE_BUCKET}/wal | head


### PR DESCRIPTION
## Summary

- Fixed backup service failures caused by rclone not finding its configuration file
- Added `RCLONE_CONFIG=/etc/soar/rclone.conf` to backup environment configuration
- Updated example configuration with setup instructions

## Problem

The backup service was failing with:
```
ERROR: rclone remote 'wasabi' not configured
INFO: Config file "/var/lib/postgresql/.config/rclone/rclone.conf" not found
```

## Root Cause

The rclone configuration was stored in `/etc/soar/rclone.conf` for centralized management, but rclone was looking for it in the default location (`~/.config/rclone/rclone.conf`) because the `RCLONE_CONFIG` environment variable wasn't set in `/etc/soar/backup-env`.

## Changes

1. **Production Fix Applied**: Added `RCLONE_CONFIG=/etc/soar/rclone.conf` to `/etc/soar/backup-env` on production server
2. **Repository Update**: Updated `infrastructure/examples/backup-env.example` to include:
   - `RCLONE_CONFIG` environment variable definition
   - Detailed setup instructions for creating `/etc/soar/rclone.conf`
   - Updated verification commands to use the config path variable

## Testing

- ✅ Manually tested on production server - backup now runs successfully
- ✅ Current backup in progress: backing up 139 GiB database to Wasabi S3
- ✅ Pre-commit hooks passed

## Impact

- **Immediate**: Production backups are now working (verified via `journalctl`)
- **Future**: New deployments will have correct configuration from the start