### PR TITLE
feat: add PostgreSQL application_name to identify connections by service

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -401,13 +401,32 @@ fn dump_schema_if_non_production(database_url: &str) -> Result<()> {
 }
 
 #[tracing::instrument]
-async fn setup_diesel_database() -> Result<Pool<ConnectionManager<PgConnection>>> {
+async fn setup_diesel_database(
+    app_name_prefix: &str,
+) -> Result<Pool<ConnectionManager<PgConnection>>> {
     // Load environment variables from .env file
     dotenvy::dotenv().ok();
 
     // Get the database URL from environment variables
-    let database_url =
+    let mut database_url =
         env::var("DATABASE_URL").expect("DATABASE_URL must be set in environment variables");
+
+    // Construct application_name from command and environment
+    let soar_env = env::var("SOAR_ENV").unwrap_or_default();
+    let app_name = match soar_env.as_str() {
+        "staging" => format!("{}-staging", app_name_prefix),
+        "" => format!("{}-dev", app_name_prefix),
+        _ => app_name_prefix.to_string(), // production or other
+    };
+
+    // Append application_name to DATABASE_URL for PostgreSQL connection tracking
+    let separator = if database_url.contains('?') { '&' } else { '?' };
+    database_url = format!("{}{}application_name={}", database_url, separator, app_name);
+
+    info!(
+        "Connecting to PostgreSQL with application_name: {}",
+        app_name
+    );
 
     // Clone for schema dump later (database_url will be moved into ConnectionManager)
     let database_url_for_dump = database_url.clone();
@@ -977,7 +996,26 @@ async fn main() -> Result<()> {
 
     // Set up database connection for commands that need it
     // This also runs migrations automatically
-    let diesel_pool = setup_diesel_database().await?;
+    // Determine application name prefix based on command
+    let app_name_prefix = match &cli.command {
+        Commands::Run { .. } => "soar-run",
+        Commands::Web { .. } => "soar-web",
+        Commands::Archive { .. } => "soar-archive",
+        Commands::Resurrect { .. } => "soar-resurrect",
+        Commands::LoadData { .. } => "soar-load-data",
+        Commands::PullData {} => "soar-pull-data",
+        Commands::PullAirspaces { .. } => "soar-pull-airspaces",
+        Commands::Sitemap { .. } => "soar-sitemap",
+        Commands::Migrate {} => "soar-migrate",
+        Commands::SeedTestData {} => "soar-seed-test-data",
+        // These should not reach here due to early returns
+        Commands::IngestOgn { .. } => unreachable!(),
+        Commands::IngestAdsb { .. } => unreachable!(),
+        Commands::VerifyRuntime { .. } => unreachable!(),
+        Commands::DumpUnifiedDdb { .. } => unreachable!(),
+    };
+
+    let diesel_pool = setup_diesel_database(app_name_prefix).await?;
 
     match cli.command {
         Commands::Sitemap { static_root } => {


### PR DESCRIPTION
## Summary
- Configure database connections to include `application_name` parameter for PostgreSQL connection tracking
- Application names follow systemd service naming pattern (e.g., `soar-run`, `soar-run-staging`, `soar-web-staging`)
- Enables identification of which service owns each database connection in `pg_stat_activity`

## Implementation
- Modified `setup_diesel_database()` to accept `app_name_prefix` parameter
- Dynamically constructs application name based on command and `SOAR_ENV`:
  - `"staging"` → appends `-staging` (e.g., `soar-run-staging`)
  - `""` (unset) → appends `-dev` (e.g., `soar-run-dev`)
  - Other values (like `"production"`) → uses base name (e.g., `soar-run`)
- Appends `application_name` parameter to `DATABASE_URL` connection string
- Logs the application name on connection for visibility

## Benefits
- Easy identification of connections by service when querying `pg_stat_activity`
- Simpler diagnosis of connection issues and resource usage per service
- Aligns with systemd service naming convention for consistency

## Verification
Query PostgreSQL to see application names:
```sql
SELECT application_name, state, query, pid 
FROM pg_stat_activity 
WHERE application_name LIKE 'soar-%'
ORDER BY application_name;
```

## Test Plan
- [x] Code compiles successfully
- [x] Pre-commit hooks pass
- [ ] Deploy to staging and verify application names appear in `pg_stat_activity`
- [ ] Confirm production deployment shows correct application names