### PR TITLE
fix: add Grafana datasource provisioning to soar-deploy

### DIFF
--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -431,6 +431,33 @@ GRAFANA_NEEDS_RESTART=false
 
 if [ -d "$DEPLOY_DIR/grafana-provisioning" ]; then
     log_info "Installing Grafana provisioning configuration..."
+
+    # Install datasource provisioning
+    if [ -d "$DEPLOY_DIR/grafana-provisioning/datasources" ]; then
+        log_info "Installing Grafana datasource configuration..."
+        mkdir -p /etc/grafana/provisioning/datasources
+        for datasource_file in "$DEPLOY_DIR/grafana-provisioning/datasources"/*.yml; do
+            if [ -f "$datasource_file" ]; then
+                filename=$(basename "$datasource_file")
+                cp "$datasource_file" /etc/grafana/provisioning/datasources/
+                chmod 640 "/etc/grafana/provisioning/datasources/$filename"
+                log_info "Installed datasource config: $filename"
+            fi
+        done
+
+        # Set ownership to grafana user
+        if id "grafana" &>/dev/null; then
+            chown -R grafana:grafana /etc/grafana/provisioning/datasources
+            log_info "Grafana datasource configuration installed successfully"
+            GRAFANA_NEEDS_RESTART=true
+        else
+            log_warn "grafana user not found, skipping ownership change"
+        fi
+    else
+        log_info "No datasource configuration found in deployment, skipping"
+    fi
+
+    # Install dashboard provisioning
     mkdir -p /etc/grafana/provisioning/dashboards
     cp -r "$DEPLOY_DIR/grafana-provisioning/dashboards"/*.yml /etc/grafana/provisioning/dashboards/
     chmod 644 /etc/grafana/provisioning/dashboards/*.yml


### PR DESCRIPTION
## Summary
Fixes the `[ERROR] Required datasource 'prometheus' not found in Grafana` error that appeared in soar-deploy logs.

## Problem
The `soar-deploy` script was not installing datasource provisioning files from the repository, causing Grafana alerts to reference non-existent datasources. This resulted in:
- Grafana failing to start properly on deployments
- Alert rules unable to query metrics
- Corrupted Grafana database state

## Solution
Updated `infrastructure/soar-deploy` to install datasource provisioning files alongside dashboard and alerting configurations.

### Changes
- Added datasource provisioning installation in soar-deploy (lines 435-458)
- Install configs from `infrastructure/grafana-provisioning/datasources/`
- Set proper ownership (`grafana:grafana`) and permissions (`640`)
- Follows existing pattern for dashboard/alerting provisioning

### Production Fix Applied
- Reset Grafana database to clear corrupted state
- Restarted Grafana to provision datasources from scratch
- Verified Prometheus datasource (uid: `prometheus`) created successfully
- Confirmed alerts now provision correctly without errors

## Testing
- ✅ Grafana running without errors on production
- ✅ Prometheus datasource configured correctly
- ✅ Alert rules successfully reference datasource
- ✅ No datasource-related errors in logs

## Impact
Future deployments will automatically install datasource configurations, preventing this error from occurring again.