### PR TITLE
refactor: switch Pelias provisioning from OpenSearch to Elasticsearch 8

### DIFF
--- a/scripts/provision-pelias
+++ b/scripts/provision-pelias
@@ -2,7 +2,7 @@
 # SOAR Pelias Geocoding Service Provisioning Script
 #
 # This script provisions a Pelias geocoding server for SOAR by:
-# - Installing OpenSearch 2.x with required plugins
+# - Installing Elasticsearch 8 with required plugins
 # - Downloading and importing Who's on First data (city-level)
 # - Setting up Pelias API and PIP services (systemd, not Docker)
 # - Installing and configuring Caddy reverse proxy
@@ -35,27 +35,7 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
-# Generate or load OpenSearch admin password
-OPENSEARCH_PASSWORD_FILE="/etc/opensearch/.admin_password"
-PASSWORD_NEEDS_SAVING=false
-
-if [ -f "$OPENSEARCH_PASSWORD_FILE" ]; then
-    echo -e "${BLUE}Using existing OpenSearch admin password from $OPENSEARCH_PASSWORD_FILE${NC}"
-    OPENSEARCH_INITIAL_ADMIN_PASSWORD=$(cat "$OPENSEARCH_PASSWORD_FILE")
-else
-    echo -e "${BLUE}Generating secure password for OpenSearch admin user...${NC}"
-    # Temporarily disable pipefail to avoid SIGPIPE error from tr | head
-    set +o pipefail
-    OPENSEARCH_INITIAL_ADMIN_PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9!@#$%^&*()_+=-' < /dev/urandom | head -c 32)
-    set -o pipefail
-    # Ensure password meets complexity requirements by adding one of each required character
-    OPENSEARCH_INITIAL_ADMIN_PASSWORD="Aa1!${OPENSEARCH_INITIAL_ADMIN_PASSWORD}"
-    PASSWORD_NEEDS_SAVING=true
-    echo -e "${BLUE}Password will be saved after OpenSearch installation${NC}"
-fi
-export OPENSEARCH_INITIAL_ADMIN_PASSWORD
-
-echo -e "${GREEN}Provisioning Pelias geocoding server with OpenSearch...${NC}"
+echo -e "${GREEN}Provisioning Pelias geocoding server with Elasticsearch 8...${NC}"
 
 # Detect OS
 if [ -f /etc/os-release ]; then
@@ -79,117 +59,108 @@ echo -e "${BLUE}Installing prerequisites...${NC}"
 apt-get update
 apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release gpg jq debian-keyring debian-archive-keyring
 
-# Install OpenSearch
-echo -e "${BLUE}Installing OpenSearch...${NC}"
+# Install Elasticsearch 8
+echo -e "${BLUE}Installing Elasticsearch 8...${NC}"
 
-# Add OpenSearch GPG key and repository
-if [ ! -f /usr/share/keyrings/opensearch-keyring ]; then
-    curl -o- https://artifacts.opensearch.org/publickeys/opensearch.pgp | \
-        gpg --dearmor --batch --yes -o /usr/share/keyrings/opensearch-keyring
+# Add Elasticsearch GPG key and repository
+if [ ! -f /usr/share/keyrings/elasticsearch-keyring.gpg ]; then
+    curl -fsSL https://artifacts.elastic.co/GPG-KEY-elasticsearch | \
+        gpg --dearmor --batch --yes -o /usr/share/keyrings/elasticsearch-keyring.gpg
 fi
 
-if [ ! -f /etc/apt/sources.list.d/opensearch-2.x.list ]; then
-    echo "deb [signed-by=/usr/share/keyrings/opensearch-keyring] https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/apt stable main" | \
-        tee /etc/apt/sources.list.d/opensearch-2.x.list
+if [ ! -f /etc/apt/sources.list.d/elastic-8.x.list ]; then
+    echo "deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/8.x/apt stable main" | \
+        tee /etc/apt/sources.list.d/elastic-8.x.list
 fi
 
 apt-get update
-apt-get install -y opensearch
-
-# Save the admin password file if it was newly generated
-if [ "$PASSWORD_NEEDS_SAVING" = true ]; then
-    echo -e "${BLUE}Saving OpenSearch admin password to: $OPENSEARCH_PASSWORD_FILE${NC}"
-    mkdir -p /etc/opensearch
-    echo "$OPENSEARCH_INITIAL_ADMIN_PASSWORD" > "$OPENSEARCH_PASSWORD_FILE"
-    chmod 600 "$OPENSEARCH_PASSWORD_FILE"
-    echo -e "${GREEN}OpenSearch admin password saved${NC}"
-fi
+apt-get install -y elasticsearch
 
 # Install ICU plugin if not already installed
-if /usr/share/opensearch/bin/opensearch-plugin list | grep -q analysis-icu; then
+if /usr/share/elasticsearch/bin/elasticsearch-plugin list | grep -q analysis-icu; then
     echo -e "${BLUE}ICU analysis plugin already installed${NC}"
 else
     echo -e "${BLUE}Installing ICU analysis plugin...${NC}"
-    /usr/share/opensearch/bin/opensearch-plugin install analysis-icu --batch
+    /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu --batch
 fi
 
-# Add current user and soar user to opensearch group for access to logs and config
-echo -e "${BLUE}Adding users to opensearch group...${NC}"
+# Add current user and soar user to elasticsearch group for access to logs and config
+echo -e "${BLUE}Adding users to elasticsearch group...${NC}"
 CURRENT_USER="${SUDO_USER:-$USER}"
 if id "$CURRENT_USER" &>/dev/null; then
-    usermod -a -G opensearch "$CURRENT_USER"
-    echo -e "${GREEN}Added $CURRENT_USER to opensearch group${NC}"
+    usermod -a -G elasticsearch "$CURRENT_USER"
+    echo -e "${GREEN}Added $CURRENT_USER to elasticsearch group${NC}"
 fi
 if id soar &>/dev/null; then
-    usermod -a -G opensearch soar
-    echo -e "${GREEN}Added soar user to opensearch group${NC}"
+    usermod -a -G elasticsearch soar
+    echo -e "${GREEN}Added soar user to elasticsearch group${NC}"
 fi
 
 # Configure for Pelias
-OPENSEARCH_CONFIG_CHANGED=false
+ELASTICSEARCH_CONFIG_CHANGED=false
 
-if ! grep -q "# Pelias configuration" /etc/opensearch/opensearch.yml 2>/dev/null; then
-    echo -e "${BLUE}Adding Pelias configuration to opensearch.yml...${NC}"
-    cat >> /etc/opensearch/opensearch.yml <<EOF
+if ! grep -q "# Pelias configuration" /etc/elasticsearch/elasticsearch.yml 2>/dev/null; then
+    echo -e "${BLUE}Adding Pelias configuration to elasticsearch.yml...${NC}"
+    cat >> /etc/elasticsearch/elasticsearch.yml <<EOF
 
 # Pelias configuration
 discovery.type: single-node
 indices.query.bool.max_clause_count: 4096
 
-# Network configuration - HTTP only on localhost (Docker uses host networking)
+# Network configuration - HTTP only on localhost
 network.host: 127.0.0.1
 http.port: 9200
 
-# Disable security plugin completely (no HTTPS, no authentication)
-plugins.security.disabled: true
-plugins.security.ssl.http.enabled: false
-plugins.security.ssl.transport.enabled: false
+# Disable security features (no HTTPS, no authentication for localhost access)
+xpack.security.enabled: false
+xpack.security.http.ssl.enabled: false
+xpack.security.transport.ssl.enabled: false
 EOF
-    OPENSEARCH_CONFIG_CHANGED=true
+    ELASTICSEARCH_CONFIG_CHANGED=true
 else
-    echo -e "${BLUE}Pelias configuration section found in opensearch.yml${NC}"
+    echo -e "${BLUE}Pelias configuration section found in elasticsearch.yml${NC}"
     # Ensure network.host is set to 127.0.0.1 (localhost only - not exposed to internet)
-    if ! grep -q "^network.host: 127.0.0.1" /etc/opensearch/opensearch.yml; then
+    if ! grep -q "^network.host: 127.0.0.1" /etc/elasticsearch/elasticsearch.yml; then
         echo -e "${YELLOW}Updating network.host to 127.0.0.1 (localhost only)...${NC}"
-        if grep -q "^network.host:" /etc/opensearch/opensearch.yml; then
-            sed -i 's/^network.host:.*/network.host: 127.0.0.1/' /etc/opensearch/opensearch.yml
+        if grep -q "^network.host:" /etc/elasticsearch/elasticsearch.yml; then
+            sed -i 's/^network.host:.*/network.host: 127.0.0.1/' /etc/elasticsearch/elasticsearch.yml
         else
-            sed -i '/# Pelias configuration/a network.host: 127.0.0.1' /etc/opensearch/opensearch.yml
+            sed -i '/# Pelias configuration/a network.host: 127.0.0.1' /etc/elasticsearch/elasticsearch.yml
         fi
-        OPENSEARCH_CONFIG_CHANGED=true
+        ELASTICSEARCH_CONFIG_CHANGED=true
     fi
 fi
 
 # Set JVM heap size (8GB - adjust based on RAM)
-mkdir -p /etc/opensearch/jvm.options.d
-cat > /etc/opensearch/jvm.options.d/heap.options <<EOF
+mkdir -p /etc/elasticsearch/jvm.options.d
+cat > /etc/elasticsearch/jvm.options.d/heap.options <<EOF
 -Xms8g
 -Xmx8g
 EOF
 
-# Enable and start/restart OpenSearch
+# Enable and start/restart Elasticsearch
 systemctl daemon-reload
-systemctl enable opensearch
+systemctl enable elasticsearch
 
-if [ "$OPENSEARCH_CONFIG_CHANGED" = true ]; then
-    echo -e "${BLUE}Restarting OpenSearch to apply configuration changes...${NC}"
-    systemctl restart opensearch
+if [ "$ELASTICSEARCH_CONFIG_CHANGED" = true ]; then
+    echo -e "${BLUE}Restarting Elasticsearch to apply configuration changes...${NC}"
+    systemctl restart elasticsearch
 else
-    systemctl start opensearch 2>/dev/null || true
+    systemctl start elasticsearch 2>/dev/null || true
 fi
 
-echo -e "${GREEN}OpenSearch configured and running${NC}"
+echo -e "${GREEN}Elasticsearch configured and running${NC}"
 
 # Wait for search engine to be ready
-echo -e "${BLUE}Waiting for OpenSearch to be ready...${NC}"
+echo -e "${BLUE}Waiting for Elasticsearch to be ready...${NC}"
 for i in {1..30}; do
     if curl -s http://localhost:9200 > /dev/null 2>&1; then
-        echo -e "${GREEN}OpenSearch is ready on localhost${NC}"
+        echo -e "${GREEN}Elasticsearch is ready on localhost${NC}"
         break
     fi
     if [ $i -eq 30 ]; then
-        echo -e "${RED}Error: OpenSearch failed to start${NC}"
-        echo -e "${YELLOW}Check logs: journalctl -u opensearch -n 50${NC}"
+        echo -e "${RED}Error: Elasticsearch failed to start${NC}"
+        echo -e "${YELLOW}Check logs: journalctl -u elasticsearch -n 50${NC}"
         exit 1
     fi
     sleep 2
@@ -380,7 +351,7 @@ fi
 if curl -s -o /dev/null -w "%{http_code}" "http://localhost:9200/pelias" | grep -q "200"; then
     echo -e "${BLUE}Pelias index already exists (skipping creation)${NC}"
 else
-    echo -e "${BLUE}Creating Pelias index in OpenSearch...${NC}"
+    echo -e "${BLUE}Creating Pelias index in Elasticsearch...${NC}"
     su - pelias -c "cd /opt/pelias/docker && ./pelias elastic create"
 
     # Verify index was created successfully
@@ -441,8 +412,8 @@ cat > /etc/systemd/system/pelias-pip.service <<EOF
 [Unit]
 Description=Pelias PIP (Point in Polygon) Service
 Documentation=https://github.com/pelias/pip-service
-After=network.target opensearch.service
-Requires=opensearch.service
+After=network.target elasticsearch.service
+Requires=elasticsearch.service
 
 [Service]
 Type=simple
@@ -627,7 +598,7 @@ echo -e "${GREEN}Pelias geocoding server setup complete!${NC}"
 echo -e "${GREEN}======================================${NC}"
 echo ""
 echo -e "${BLUE}Services:${NC}"
-echo -e "  - OpenSearch: http://localhost:9200"
+echo -e "  - Elasticsearch: http://localhost:9200"
 echo -e "  - Pelias API: http://localhost:4000"
 echo -e "  - Pelias PIP: http://localhost:4200"
 echo -e "  - Caddy reverse proxy: http://localhost (configured)"
@@ -639,7 +610,7 @@ echo ""
 echo -e "${BLUE}Service management:${NC}"
 echo -e "  sudo systemctl status pelias-api"
 echo -e "  sudo systemctl status pelias-pip"
-echo -e "  sudo systemctl status opensearch"
+echo -e "  sudo systemctl status elasticsearch"
 echo -e "  sudo systemctl status caddy"
 echo ""
 echo -e "${BLUE}View logs:${NC}"


### PR DESCRIPTION
## Summary

This PR migrates the Pelias geocoding server provisioning from OpenSearch 2.x to Elasticsearch 8.

- Replace OpenSearch 2.x repository with Elasticsearch 8.x repository
- Update all configuration paths and service names throughout the provisioning script
- Update security settings to use Elasticsearch 8's xpack.security.* instead of OpenSearch's plugins.security.*
- Remove password generation logic (not needed with xpack.security.enabled=false for localhost)
- Update systemd service dependencies for pelias-pip and pelias-api
- Update all user-facing messages and documentation

**Note:** The main `scripts/provision` script is unchanged as it uses Photon's embedded OpenSearch, which is a separate geocoding service unrelated to Pelias.

## Test plan

- [ ] Verify script syntax and structure changes are correct
- [ ] Test provisioning on a clean server (staging or test environment)
- [ ] Confirm Elasticsearch 8 installs correctly with the new repository
- [ ] Verify ICU analysis plugin installs successfully
- [ ] Confirm Pelias index creation works with Elasticsearch 8
- [ ] Verify data import completes successfully
- [ ] Test Pelias API and PIP services start correctly
- [ ] Verify geocoding queries return expected results
- [ ] Confirm systemd service dependencies work correctly
- [ ] Check that no OpenSearch references remain in the Pelias provisioning path