### PR TITLE
perf: use rsync with compression for faster deployment uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -722,7 +722,7 @@ jobs:
           ssh soar@staging.glider.flights "mkdir -p $DEPLOY_DIR"
 
           echo "Uploading deployment package..."
-          scp -r deploy-pkg/* soar@staging.glider.flights:$DEPLOY_DIR/
+          rsync -az --info=progress2 deploy-pkg/ soar@staging.glider.flights:$DEPLOY_DIR/
 
           echo "Deployment package uploaded successfully"
 
@@ -875,7 +875,7 @@ jobs:
           ssh soar@glider.flights "mkdir -p $DEPLOY_DIR"
 
           echo "Uploading deployment package..."
-          scp -r deploy-pkg/* soar@glider.flights:$DEPLOY_DIR/
+          rsync -az --info=progress2 deploy-pkg/ soar@glider.flights:$DEPLOY_DIR/
 
           echo "Deployment package uploaded successfully"
 


### PR DESCRIPTION
## Summary
- Replace `scp -r` with `rsync -az` for deployment package uploads
- Applies to both staging and production deployments
- Uses compression (`-z`) for significant speedup over network
- More efficient directory transfer handling

## Performance Impact
- Expected 2-5x speedup for deployment uploads depending on file types
- Reduces CI pipeline time for deployment steps
- Better progress reporting with `--info=progress2`

## Changes
- `.github/workflows/ci.yml`: Updated both staging and production upload commands

## Test Plan
- [x] Pre-commit hooks passed
- [ ] CI pipeline will validate on merge
- [ ] Monitor deployment time improvements in next release