### PR TITLE
fix: correct OGN ingest Grafana dashboard naming and metrics

### DIFF
--- a/infrastructure/grafana-dashboard-ingest-ogn.json
+++ b/infrastructure/grafana-dashboard-ingest-ogn.json
@@ -31,7 +31,7 @@
       },
       "id": 50,
       "panels": [],
-      "title": "SOAR OGN Ingest - Process Metrics",
+      "title": "SOAR Ingest OGN - Process Metrics",
       "type": "row"
     },
     {
@@ -184,7 +184,7 @@
           },
           "editorMode": "code",
           "expr": "process_is_up{component=\"ingest-ogn\"}",
-          "legendFormat": "SOAR OGN Ingest",
+          "legendFormat": "SOAR Ingest OGN",
           "range": true,
           "refId": "A"
         }
@@ -257,7 +257,7 @@
           },
           "editorMode": "code",
           "expr": "process_memory_bytes{component=\"ingest-ogn\"}",
-          "legendFormat": "SOAR OGN Ingest",
+          "legendFormat": "SOAR Ingest OGN",
           "range": true,
           "refId": "A"
         }
@@ -275,7 +275,7 @@
       },
       "id": 100,
       "panels": [],
-      "title": "SOAR OGN Ingest - APRS Connection",
+      "title": "SOAR Ingest OGN - APRS Connection",
       "type": "row"
     },
     {
@@ -570,13 +570,143 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "aprs_keepalive_sent{component=\"ingest-ogn\"}",
-          "legendFormat": "Keepalive Messages",
+          "expr": "rate(aprs_keepalive_sent{component=\"ingest-ogn\"}[1m]) * 60",
+          "legendFormat": "Keepalive Messages/min",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Keepalive Messages Sent",
+      "title": "Keepalive Messages per Minute",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 104,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "aprs_connection_operation_failed{component=\"ingest-ogn\"}",
+          "legendFormat": "Operation Failed",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "aprs_connection_timeout{component=\"ingest-ogn\"}",
+          "legendFormat": "Timeouts",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "aprs_nats_connection_failed{component=\"ingest-ogn\"}",
+          "legendFormat": "NATS Connection Failed",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "aprs_ingest_failed{component=\"ingest-ogn\"}",
+          "legendFormat": "Ingest Failed",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Connection & Ingestion Errors",
       "type": "timeseries"
     },
     {
@@ -587,9 +717,514 @@
         "x": 0,
         "y": 26
       },
+      "id": 120,
+      "panels": [],
+      "title": "SOAR Ingest OGN - Message Processing",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 121,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_raw_message_received_server{component=\"ingest-ogn\"}[1m]) * 60",
+          "legendFormat": "Server Messages/min",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_raw_message_received_aprs{component=\"ingest-ogn\"}[1m]) * 60",
+          "legendFormat": "APRS Messages/min",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Messages Received per Minute",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 122,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_raw_message_queued_server{component=\"ingest-ogn\"}[1m]) * 60",
+          "legendFormat": "Server Messages/min",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_raw_message_queued_aprs{component=\"ingest-ogn\"}[1m]) * 60",
+          "legendFormat": "APRS Messages/min",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Messages Queued per Minute",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 123,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(aprs_raw_message_processed{component=\"ingest-ogn\"}[1m]) * 60",
+          "legendFormat": "Processed Messages/min",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Messages Processed per Minute",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 124,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "aprs_raw_message_queue_depth{component=\"ingest-ogn\"}",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Raw Message Queue Depth",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 125,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "aprs_raw_message_queue_full{component=\"ingest-ogn\"}",
+          "legendFormat": "Queue Full Events",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "aprs_queue_send_timeout{component=\"ingest-ogn\"}",
+          "legendFormat": "Queue Send Timeouts",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Queue Issues",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
       "id": 110,
       "panels": [],
-      "title": "SOAR OGN Ingest - JetStream Publishing",
+      "title": "SOAR Ingest OGN - NATS Publishing",
       "type": "row"
     },
     {
@@ -680,7 +1315,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_jetstream_published{component=\"ingest-ogn\"}[1m]) * 60",
+          "expr": "rate(aprs_nats_published{component=\"ingest-ogn\"}[1m]) * 60",
           "legendFormat": "Messages/min",
           "range": true,
           "refId": "A"
@@ -751,13 +1386,13 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "aprs_jetstream_queue_depth{component=\"ingest-ogn\"}",
+          "expr": "aprs_nats_queue_depth{component=\"ingest-ogn\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "JetStream Queue Depth",
+      "title": "NATS Queue Depth",
       "type": "gauge"
     },
     {
@@ -848,7 +1483,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "aprs_jetstream_publish_error{component=\"ingest-ogn\"}",
+          "expr": "aprs_nats_publish_error{component=\"ingest-ogn\"}",
           "legendFormat": "Publish Errors",
           "range": true,
           "refId": "A"
@@ -862,7 +1497,7 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
-      "description": "Tracks slow JetStream publish operations and timeouts",
+      "description": "Tracks slow NATS publish operations and timeouts",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -977,7 +1612,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_jetstream_slow_publish{component=\"ingest-ogn\"}[5m])",
+          "expr": "rate(aprs_nats_slow_publish{component=\"ingest-ogn\"}[5m])",
           "legendFormat": "Slow Publishes/sec",
           "range": true,
           "refId": "A"
@@ -988,13 +1623,13 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_jetstream_publish_timeout{component=\"ingest-ogn\"}[5m])",
+          "expr": "rate(aprs_nats_publish_timeout{component=\"ingest-ogn\"}[5m])",
           "legendFormat": "Publish Timeouts/sec",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "JetStream Publish Timeouts & Slow Publishes",
+      "title": "NATS Publish Timeouts & Slow Publishes",
       "type": "timeseries"
     },
     {
@@ -1002,7 +1637,7 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
-      "description": "Number of messages currently being published to JetStream",
+      "description": "Number of messages currently being published to NATS",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1086,13 +1721,13 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "aprs_jetstream_in_flight{component=\"ingest-ogn\"}",
+          "expr": "aprs_nats_in_flight{component=\"ingest-ogn\"}",
           "legendFormat": "Messages In-Flight",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "JetStream In-Flight Messages",
+      "title": "NATS In-Flight Messages",
       "type": "timeseries"
     },
     {
@@ -1181,7 +1816,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(aprs_jetstream_publish_duration_ms_bucket{component=\"ingest-ogn\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.50, sum(rate(aprs_nats_publish_duration_ms_bucket{component=\"ingest-ogn\"}[5m])) by (le))",
           "legendFormat": "p50",
           "range": true,
           "refId": "A"
@@ -1192,7 +1827,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(aprs_jetstream_publish_duration_ms_bucket{component=\"ingest-ogn\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(aprs_nats_publish_duration_ms_bucket{component=\"ingest-ogn\"}[5m])) by (le))",
           "hide": false,
           "legendFormat": "p95",
           "range": true,
@@ -1204,14 +1839,347 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(aprs_jetstream_publish_duration_ms_bucket{component=\"ingest-ogn\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(aprs_nats_publish_duration_ms_bucket{component=\"ingest-ogn\"}[5m])) by (le))",
           "hide": false,
           "legendFormat": "p99",
           "range": true,
           "refId": "C"
         }
       ],
-      "title": "JetStream Publish Duration",
+      "title": "NATS Publish Duration",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 75
+      },
+      "id": 130,
+      "panels": [],
+      "title": "SOAR Ingest OGN - Shutdown Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Queue depth at the moment shutdown was initiated",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 76
+      },
+      "id": 131,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "aprs_shutdown_queue_depth_at_shutdown{component=\"ingest-ogn\"}",
+          "legendFormat": "Queue Depth at Shutdown",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Shutdown Queue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Number of messages successfully flushed during graceful shutdown",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 76
+      },
+      "id": 132,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "aprs_shutdown_messages_flushed{component=\"ingest-ogn\"}",
+          "legendFormat": "Messages Flushed",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Shutdown Messages Flushed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Time taken to flush messages during graceful shutdown",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 84
+      },
+      "id": 133,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(aprs_shutdown_flush_duration_seconds_bucket{component=\"ingest-ogn\"}[5m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(aprs_shutdown_flush_duration_seconds_bucket{component=\"ingest-ogn\"}[5m])) by (le))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(aprs_shutdown_flush_duration_seconds_bucket{component=\"ingest-ogn\"}[5m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Shutdown Flush Duration",
       "type": "timeseries"
     }
   ],
@@ -1263,7 +2231,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "SOAR OGN Ingest",
+  "title": "SOAR Ingest OGN",
   "uid": "soar-ingest-ogn",
   "version": 1
 }


### PR DESCRIPTION
## Summary
Fixes multiple issues with the SOAR Ingest OGN Grafana dashboard:
- Corrects dashboard naming convention
- Fixes keepalive metric to show rate instead of cumulative counter
- Renames JetStream to NATS (correct terminology)
- Adds all missing metrics defined in `soar ingest-ogn` subcommand

## Changes

### Dashboard Naming
- Renamed: "SOAR OGN Ingest" → "SOAR Ingest OGN"
- Updated all section headers to match new naming convention

### Metric Fixes
- **Keepalive panel**: Changed from cumulative counter to rate in messages/minute
  - Query: `rate(aprs_keepalive_sent[1m]) * 60`
- **NATS Publishing**: Renamed from "JetStream Publishing" and updated all metric names
  - `aprs_jetstream_*` → `aprs_nats_*`

### New Panels Added

#### Connection Errors (added to APRS Connection section)
- Connection & ingestion errors panel showing:
  - Operation failures (`aprs.connection.operation_failed`)
  - Connection timeouts (`aprs.connection.timeout`)
  - NATS connection failures (`aprs.nats.connection_failed`)
  - Ingestion failures (`aprs.ingest_failed`)

#### Message Processing Section (entirely new)
- Messages received per minute (server vs APRS breakdown)
- Messages queued per minute (server vs APRS breakdown)
- Messages processed per minute
- Raw message queue depth gauge
- Queue issues (queue full events, send timeouts)

#### Shutdown Metrics Section (entirely new)
- Shutdown queue depth
- Shutdown messages flushed
- Shutdown flush duration (p50, p95, p99)

## Dashboard Organization
1. **Process Metrics** - Uptime, status, memory
2. **APRS Connection** - Connection status, events, keepalives, errors
3. **Message Processing** - Message flow, queuing, processing rates
4. **NATS Publishing** - Publishing rates, errors, performance
5. **Shutdown Metrics** - Graceful shutdown behavior

## Testing
- ✅ JSON validated
- ✅ All metrics defined in `src/metrics.rs::initialize_aprs_ingest_metrics()` now displayed

All metrics from the `soar ingest-ogn` subcommand are now properly displayed in the dashboard.