### PR TITLE
Fix flight profile graph: handle null values and time gaps

### DIFF
--- a/web/src/lib/components/FlightProfile.svelte
+++ b/web/src/lib/components/FlightProfile.svelte
@@ -87,9 +87,40 @@
 			}
 
 			const fixesInOrder = [...fixes].reverse();
-			const timestamps = fixesInOrder.map((fix) => new Date(fix.timestamp));
-			const altitudesMsl = fixesInOrder.map((fix) => fix.altitude_msl_feet || 0);
-			const groundSpeeds = fixesInOrder.map((fix) => fix.ground_speed_knots || 0);
+
+			// Define large gap threshold (5 minutes in milliseconds)
+			const LARGE_GAP_THRESHOLD_MS = 5 * 60 * 1000;
+
+			// Process fixes to insert nulls for large time gaps and null values
+			const timestamps: (Date | null)[] = [];
+			const altitudesMsl: (number | null)[] = [];
+			const altitudesAgl: (number | null)[] = [];
+			const groundSpeeds: (number | null)[] = [];
+
+			for (let i = 0; i < fixesInOrder.length; i++) {
+				const fix = fixesInOrder[i];
+				const timestamp = new Date(fix.timestamp);
+
+				// Check for large time gap (except for first fix)
+				if (i > 0) {
+					const prevTimestamp = new Date(fixesInOrder[i - 1].timestamp);
+					const timeDiff = timestamp.getTime() - prevTimestamp.getTime();
+
+					if (timeDiff > LARGE_GAP_THRESHOLD_MS) {
+						// Insert null point to create gap in the line
+						timestamps.push(null);
+						altitudesMsl.push(null);
+						altitudesAgl.push(null);
+						groundSpeeds.push(null);
+					}
+				}
+
+				// Add current fix data - use null instead of 0 for missing values
+				timestamps.push(timestamp);
+				altitudesMsl.push(fix.altitude_msl_feet ?? null);
+				altitudesAgl.push(fix.altitude_agl_feet ?? null);
+				groundSpeeds.push(fix.ground_speed_knots ?? null);
+			}
 
 			const traces = [
 				{
@@ -99,12 +130,12 @@
 					mode: 'lines' as const,
 					name: 'MSL Altitude (ft)',
 					line: { color: '#3b82f6', width: 2 },
+					connectgaps: false,
 					hovertemplate: '<b>MSL:</b> %{y:.0f} ft<br>%{x}<extra></extra>'
 				}
 			];
 
 			if (hasAglData) {
-				const altitudesAgl = fixesInOrder.map((fix) => fix.altitude_agl_feet || 0);
 				traces.push({
 					x: timestamps,
 					y: altitudesAgl,
@@ -112,6 +143,7 @@
 					mode: 'lines' as const,
 					name: 'AGL Altitude (ft)',
 					line: { color: '#10b981', width: 2 },
+					connectgaps: false,
 					hovertemplate: '<b>AGL:</b> %{y:.0f} ft<br>%{x}<extra></extra>'
 				});
 			}
@@ -125,6 +157,7 @@
 				mode: 'lines' as const,
 				name: 'Ground Speed (kt, Right Y Axis)',
 				line: { color: '#f59e0b', width: 2 },
+				connectgaps: false,
 				yaxis: 'y2',
 				hovertemplate: '<b>GS:</b> %{y:.0f} kt<br>%{x}<extra></extra>'
 			};


### PR DESCRIPTION
## Summary

Fixed two issues with the flight profile graph on the flight details page and full-screen map:

### Problem 1: Null Values Displayed as Zero
- **Issue**: When speed data was not transmitted (null), the graph displayed it as zero, creating a sawtooth wave pattern
- **Fix**: Changed data processing to preserve null values instead of converting them to 0 with `|| 0`
- **Result**: Missing speed data now shows as gaps in the line instead of false zero values

### Problem 2: Large Time Gaps Shown as Solid Lines  
- **Issue**: Multi-hour gaps in data (e.g., aircraft out of range) were rendered as straight lines connecting distant points
- **Fix**: Added detection for time gaps >5 minutes between consecutive fixes and insert null data points
- **Result**: Large data gaps now appear as actual gaps in the graph instead of misleading straight lines

## Technical Changes

- Use nullish coalescing (`??`) instead of logical OR (`||`) to preserve null values
- Detect gaps >5 minutes between consecutive fixes
- Insert null data points for large time gaps
- Set `connectgaps: false` on all Plotly traces to prevent line drawing over gaps

## Testing

- TypeScript check passes (`npm run check`)
- Pre-commit hooks pass (formatting, linting, type checking)

This makes the graph more accurately represent actual aircraft telemetry, clearly distinguishing between:
- Missing data (gaps in the line)
- Zero values (line at zero)
- Normal fluctuations