### PR TITLE
Potential fix for code scanning alert no. 13: Failure to use HTTPS URLs

### DIFF
--- a/src/commands/pull_data.rs
+++ b/src/commands/pull_data.rs
@@ -233,7 +233,7 @@ pub async fn handle_pull_data(diesel_pool: Pool<ConnectionManager<PgConnection>>
     download_text_file_atomically(&client, flarmnet_url, &flarmnet_path, max_retries).await?;
 
     // Download ADS-B Exchange basic aircraft database
-    let adsb_url = "http://downloads.adsbexchange.com/downloads/basic-ac-db.json.gz";
+    let adsb_url = "https://downloads.adsbexchange.com/downloads/basic-ac-db.json.gz";
     let adsb_gz_path = format!("{}/basic-ac-db.json.gz", temp_dir);
     let adsb_json_path = format!("{}/basic-ac-db.json", temp_dir);
 


### PR DESCRIPTION
Potential fix for [https://github.com/hut8/soar/security/code-scanning/13](https://github.com/hut8/soar/security/code-scanning/13)

In general, to fix this kind of issue you should ensure that any URLs used for network requests use `https://` instead of `http://`, so that the connection is encrypted and protected against interception or tampering. That usually means updating hard-coded URL strings or URL-building logic to specify HTTPS.

For this specific code, the problematic URL is the ADS-B Exchange download URL on line 236:  
`"http://downloads.adsbexchange.com/downloads/basic-ac-db.json.gz"`.  
This value is passed through `adsb_url` into `download_file_atomically`, and then into `download_with_retry`, where `client.get(url)` is invoked. The minimal change that preserves existing behavior while securing the connection is to change the protocol of this literal from `http://` to `https://`. No other logic, function signatures, or imports need to be changed, and the retry and decompression logic remain exactly the same.

Concretely:

- In `src/commands/pull_data.rs`, locate the line defining `adsb_url`.
- Replace the string so that it reads `"https://downloads.adsbexchange.com/downloads/basic-ac-db.json.gz"`.
- No additional methods, imports, or configurations are required for `reqwest` to use HTTPS; it supports HTTPS out of the box.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
