### PR TITLE
fix: add datasource object to Grafana alert reduce operations

### DIFF
--- a/infrastructure/grafana-provisioning/alerting/alert-rules-production.yml
+++ b/infrastructure/grafana-provisioning/alerting/alert-rules-production.yml
@@ -51,6 +51,9 @@ groups:
               to: 0
             datasourceUid: __expr__
             model:
+              datasource:
+                type: __expr__
+                uid: __expr__
               expression: A
               reducer: last
               type: reduce
@@ -123,6 +126,9 @@ groups:
               to: 0
             datasourceUid: __expr__
             model:
+              datasource:
+                type: __expr__
+                uid: __expr__
               expression: A
               reducer: last
               type: reduce
@@ -195,6 +201,9 @@ groups:
               to: 0
             datasourceUid: __expr__
             model:
+              datasource:
+                type: __expr__
+                uid: __expr__
               expression: A
               reducer: last
               type: reduce

--- a/infrastructure/grafana-provisioning/alerting/alert-rules-staging.yml
+++ b/infrastructure/grafana-provisioning/alerting/alert-rules-staging.yml
@@ -51,6 +51,9 @@ groups:
               to: 0
             datasourceUid: __expr__
             model:
+              datasource:
+                type: __expr__
+                uid: __expr__
               expression: A
               reducer: last
               type: reduce
@@ -123,6 +126,9 @@ groups:
               to: 0
             datasourceUid: __expr__
             model:
+              datasource:
+                type: __expr__
+                uid: __expr__
               expression: A
               reducer: last
               type: reduce
@@ -195,6 +201,9 @@ groups:
               to: 0
             datasourceUid: __expr__
             model:
+              datasource:
+                type: __expr__
+                uid: __expr__
               expression: A
               reducer: last
               type: reduce


### PR DESCRIPTION
## Summary
Fixes Grafana alert evaluation errors by adding required `datasource` object to reduce operations in alert rules.

## Problem
Production was receiving alert emails with this error:
```
Error: invalid format of evaluation results for the alert definition B: 
looks like time series data, only reduced data can be alerted on.
```

This was caused by Grafana's unified alerting engine requiring reduce operations to have the datasource specified as a nested object within the model, not just `datasourceUid` at the top level.

## Changes
- ✅ Updated all 6 reduce operations across production and staging alert files:
  - OGN Message Ingestion Rate alerts (Reduce C)
  - OGN Service Disconnected alerts (Reduce B) ← **Was failing**
  - OGN NATS Publishing Errors alerts (Reduce B)

**Before:**
```yaml
model:
  expression: A
  reducer: last
  type: reduce
```

**After:**
```yaml
model:
  datasource:
    type: __expr__
    uid: __expr__
  expression: A
  reducer: last
  type: reduce
```

## Test Plan
- [x] Pre-commit hooks passed (YAML validation)
- [ ] Deploy to staging Grafana and verify alerts evaluate without errors
- [ ] Deploy to production Grafana and verify alert emails stop showing errors

## Impact
- Fixes alert evaluation errors in production
- No functional changes to alert logic or thresholds
- Alerts will now properly evaluate connection status and send accurate notifications