### PR TITLE
fix: correct Prometheus datasource UID capitalization for public dashboards

### DIFF
--- a/infrastructure/grafana-provisioning/alerting/alert-rules-production.yml
+++ b/infrastructure/grafana-provisioning/alerting/alert-rules-production.yml
@@ -25,7 +25,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: rate(aprs_raw_message_processed_total{environment="production"}[1m]) * 60
               intervalMs: 1000
@@ -37,7 +37,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: rate(aprs_nats_published_total{environment="production"}[1m]) * 60
               intervalMs: 1000
@@ -112,7 +112,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: aprs_connection_connected{environment="production"}
               intervalMs: 1000
@@ -187,7 +187,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: rate(aprs_nats_publish_error_total{environment="production"}[5m]) * 60
               intervalMs: 1000

--- a/infrastructure/grafana-provisioning/alerting/alert-rules-staging.yml
+++ b/infrastructure/grafana-provisioning/alerting/alert-rules-staging.yml
@@ -25,7 +25,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: rate(aprs_raw_message_processed_total{environment="staging"}[1m]) * 60
               intervalMs: 1000
@@ -37,7 +37,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: rate(aprs_nats_published_total{environment="staging"}[1m]) * 60
               intervalMs: 1000
@@ -112,7 +112,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: aprs_connection_connected{environment="staging"}
               intervalMs: 1000
@@ -187,7 +187,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: rate(aprs_nats_publish_error_total{environment="staging"}[5m]) * 60
               intervalMs: 1000

--- a/infrastructure/grafana-provisioning/alerting/alert-rules.yml
+++ b/infrastructure/grafana-provisioning/alerting/alert-rules.yml
@@ -29,7 +29,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: rate(aprs_raw_message_processed_total{environment="production"}[1m]) * 60
               intervalMs: 1000
@@ -41,7 +41,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: rate(aprs_nats_published_total{environment="production"}[1m]) * 60
               intervalMs: 1000
@@ -101,7 +101,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: aprs_connection_connected{environment="production"}
               intervalMs: 1000
@@ -161,7 +161,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: rate(aprs_nats_publish_error_total{environment="production"}[5m]) * 60
               intervalMs: 1000
@@ -229,7 +229,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: rate(aprs_raw_message_processed_total{environment="staging"}[1m]) * 60
               intervalMs: 1000
@@ -241,7 +241,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: rate(aprs_nats_published_total{environment="staging"}[1m]) * 60
               intervalMs: 1000
@@ -301,7 +301,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: aprs_connection_connected{environment="staging"}
               intervalMs: 1000
@@ -361,7 +361,7 @@ groups:
             relativeTimeRange:
               from: 300
               to: 0
-            datasourceUid: prometheus
+            datasourceUid: Prometheus
             model:
               expr: rate(aprs_nats_publish_error_total{environment="staging"}[5m]) * 60
               intervalMs: 1000

--- a/infrastructure/grafana-provisioning/datasources/prometheus.yaml
+++ b/infrastructure/grafana-provisioning/datasources/prometheus.yaml
@@ -3,7 +3,7 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
-    uid: prometheus
+    uid: Prometheus
     access: proxy
     url: http://localhost:9090
     isDefault: true


### PR DESCRIPTION
## Summary
Fixes public dashboard "data source not found" errors by correcting the Prometheus datasource UID capitalization to match dashboard references.

## Problem
Public dashboards were failing with:
```
logger=publicdashboards.service error="data source not found" datasources=[prometheus]
```

This was caused by a case sensitivity mismatch:
- Provisioned datasource UID: `prometheus` (lowercase)
- Dashboard JSON references: `Prometheus` (capital P)

While regular dashboards work fine with this mismatch, **public dashboards require exact UID matches**.

## Root Cause
Public dashboards use a stricter datasource resolution that requires exact string matches. The provisioned datasource had UID `prometheus` but all dashboards reference `Prometheus`.

## Changes
- ✅ Updated datasource UID: `prometheus` → `Prometheus`
- ✅ Updated all alert rule `datasourceUid` references to match

## Files Changed
- `infrastructure/grafana-provisioning/datasources/prometheus.yaml`
- `infrastructure/grafana-provisioning/alerting/alert-rules-production.yml`
- `infrastructure/grafana-provisioning/alerting/alert-rules-staging.yml`
- `infrastructure/grafana-provisioning/alerting/alert-rules.yml`

## Test Plan
- [x] Pre-commit hooks passed (YAML validation)
- [ ] Deploy to staging and verify public dashboard loads without errors
- [ ] Verify alerts continue to function correctly

## Impact
- Fixes "Internal Server Error" on public dashboards (e.g., SOAR Run Performance Dashboard)
- No functional changes to metrics or queries
- Alerts will continue to work with updated UID references