### PR TITLE
Potential fix for code scanning alert no. 11: Use of externally-controlled format string

### DIFF
--- a/web/src/lib/services/AircraftRegistry.ts
+++ b/web/src/lib/services/AircraftRegistry.ts
@@ -404,7 +404,7 @@ export class AircraftRegistry {
 				}
 				return data;
 			} catch (e) {
-				console.warn(`Failed to parse stored aircraft ${aircraftId}:`, e);
+				console.warn('Failed to parse stored aircraft %s:', aircraftId, e);
 				// Remove corrupted data
 				localStorage.removeItem(key);
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/hut8/soar/security/code-scanning/11](https://github.com/hut8/soar/security/code-scanning/11)

General fix approach: Avoid constructing the first argument to `console.warn` (the format string) from untrusted data. Instead, use a constant format string that contains `%s` and pass the untrusted value (`aircraftId`) as a separate argument. This prevents any `%` sequences within `aircraftId` from being interpreted as format specifiers.

Best concrete fix here: In `AircraftRegistry.loadAircraftFromStorage`, replace the template literal

```ts
console.warn(`Failed to parse stored aircraft ${aircraftId}:`, e);
```

with a constant format string and explicit arguments:

```ts
console.warn('Failed to parse stored aircraft %s:', aircraftId, e);
```

This keeps the log content effectively the same (a message mentioning the aircraft ID plus the error object), but ensures that only our fixed string is treated as the format string. No other behavior of the method changes, and no new imports or helpers are required.

Only `web/src/lib/services/AircraftRegistry.ts` needs to be edited, in the `catch` block inside `loadAircraftFromStorage`. No changes are needed in `FixFeed.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
