### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/hut8/soar/security/code-scanning/1](https://github.com/hut8/soar/security/code-scanning/1)

To fix the problem, explicitly define `permissions` so the `GITHUB_TOKEN` is constrained instead of inheriting potentially broad repository defaults. The most straightforward and non-invasive approach is to add a workflow-level `permissions:` block that applies to all jobs, granting only read access to repository contents, which is sufficient for `actions/checkout` and typical CI tasks that do not modify the repo.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Add a `permissions:` section near the top of the workflow (after `name:` and before `on:`) with:
  - `contents: read`
- This will apply to all jobs (`test-sveltekit`, `test-e2e`, `test-rust`, `build-release`, etc.) unless a specific job declares its own `permissions:`. Based on the shown snippet, `test-sveltekit` and `test-e2e` only read code and use artifacts, so `contents: read` is adequate and does not alter their intended functionality.

No new methods, imports, or definitions are needed: this is purely a YAML configuration change to the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
