### PR TITLE
feat: add area tracker limit config and improve API parameter names

### DIFF
--- a/src/actions/fixes.rs
+++ b/src/actions/fixes.rs
@@ -20,6 +20,9 @@ use crate::web::AppState;
 use super::devices::enrich_aircraft_with_registration_data;
 use super::json_error;
 
+/// Area tracker configuration
+const AREA_TRACKER_LIMIT_ENABLED: bool = false;
+
 #[derive(Debug, Deserialize)]
 pub struct FixesQueryParams {
     pub aircraft_id: Option<uuid::Uuid>,
@@ -67,6 +70,11 @@ fn validate_bounds(bounds: &GeoBounds) -> anyhow::Result<()> {
             bounds.south,
             bounds.north
         ));
+    }
+
+    // When limit is disabled, skip size validation
+    if !AREA_TRACKER_LIMIT_ENABLED {
+        return Ok(());
     }
 
     // Calculate number of squares (accounting for date line crossing)

--- a/web/src/lib/services/FixFeed.ts
+++ b/web/src/lib/services/FixFeed.ts
@@ -418,10 +418,10 @@ export class FixFeed {
 
 	// Fetch aircraft in bounding box via REST API
 	public async fetchAircraftInBoundingBox(
-		latMin: number,
-		latMax: number,
-		lonMin: number,
-		lonMax: number,
+		south: number,
+		north: number,
+		west: number,
+		east: number,
 		afterTimestamp?: string // Expected in ISO 8601 format
 	): Promise<Aircraft[]> {
 		if (!browser) return [];
@@ -430,10 +430,10 @@ export class FixFeed {
 			const { serverCall } = await import('$lib/api/server');
 			const response = await serverCall('/aircraft', {
 				params: {
-					latitude_min: latMin,
-					latitude_max: latMax,
-					longitude_min: lonMin,
-					longitude_max: lonMax,
+					south,
+					north,
+					west,
+					east,
 					...(afterTimestamp && { after: afterTimestamp })
 				}
 			});

--- a/web/src/routes/operations/+page.svelte
+++ b/web/src/routes/operations/+page.svelte
@@ -26,6 +26,9 @@
 	// Extend dayjs with relative time plugin
 	dayjs.extend(relativeTime);
 
+	// Area tracker configuration
+	const AREA_TRACKER_LIMIT_ENABLED = false;
+
 	// TypeScript interfaces for airport data
 	interface RunwayEndView {
 		ident: string | null;
@@ -336,6 +339,12 @@
 	// Load area tracker state from localStorage
 	function loadAreaTrackerState(): boolean {
 		if (!browser) return true;
+
+		// When limit is disabled, area tracker is always on
+		if (!AREA_TRACKER_LIMIT_ENABLED) {
+			console.log('[AREA TRACKER] Limit disabled, area tracker always on');
+			return true;
+		}
 
 		try {
 			const saved = localStorage.getItem(AREA_TRACKER_KEY);
@@ -1762,6 +1771,12 @@
 	function updateAreaTrackerAvailability(): void {
 		if (!map) return;
 
+		// When limit is disabled, area tracker is always available
+		if (!AREA_TRACKER_LIMIT_ENABLED) {
+			areaTrackerAvailable = true;
+			return;
+		}
+
 		const area = calculateViewportArea();
 		const wasAvailable = areaTrackerAvailable;
 		areaTrackerAvailable = area <= 4000000; // 4,000,000 square miles limit (fits continental US)
@@ -1899,10 +1914,10 @@
 			// Fetch aircraft with their latest position only (no fix history)
 			// Fixes will accumulate from WebSocket after this
 			const aircraft = await fixFeed.fetchAircraftInBoundingBox(
-				sw.lat(), // latMin
-				ne.lat(), // latMax
-				sw.lng(), // lonMin
-				ne.lng() // lonMax
+				sw.lat(), // south
+				ne.lat(), // north
+				sw.lng(), // west
+				ne.lng() // east
 				// No 'after' parameter - backend doesn't fetch fixes anymore
 			);
 
@@ -1955,24 +1970,26 @@
 			<ListChecks size={20} />
 		</button>
 
-		<!-- Area Tracker Button -->
-		<button
-			class="location-btn"
-			class:area-tracker-active={areaTrackerActive}
-			class:area-tracker-unavailable={!areaTrackerAvailable}
-			onclick={toggleAreaTracker}
-			title={areaTrackerAvailable
-				? areaTrackerActive
-					? 'Disable Area Tracker'
-					: 'Enable Area Tracker'
-				: 'Area Tracker unavailable (map too zoomed out)'}
-		>
-			{#if areaTrackerActive}
-				<MapPlus size={20} />
-			{:else}
-				<MapMinus size={20} />
-			{/if}
-		</button>
+		<!-- Area Tracker Button (only show when limit is enabled) -->
+		{#if AREA_TRACKER_LIMIT_ENABLED}
+			<button
+				class="location-btn"
+				class:area-tracker-active={areaTrackerActive}
+				class:area-tracker-unavailable={!areaTrackerAvailable}
+				onclick={toggleAreaTracker}
+				title={areaTrackerAvailable
+					? areaTrackerActive
+						? 'Disable Area Tracker'
+						: 'Enable Area Tracker'
+					: 'Area Tracker unavailable (map too zoomed out)'}
+			>
+				{#if areaTrackerActive}
+					<MapPlus size={20} />
+				{:else}
+					<MapMinus size={20} />
+				{/if}
+			</button>
+		{/if}
 
 		<!-- Settings Button -->
 		<button class="location-btn" onclick={() => (showSettingsModal = true)} title="Settings">


### PR DESCRIPTION
## Summary
- Add `AREA_TRACKER_LIMIT_ENABLED` constant (set to `false`) to disable area tracker size limits
  - Frontend: Skip 4,000,000 sq miles viewport check
  - Backend: Skip 1,000 squares per subscription validation
  - When disabled, area tracker is always on and the toggle button is hidden
- Improve `/data/aircraft` API parameter names for better clarity
  - Changed from `latitude_min`, `latitude_max`, `longitude_min`, `longitude_max`
  - Changed to `south`, `north`, `west`, `east`
  - Updated all frontend calls and backend handlers

## Test plan
- [ ] Build frontend and backend successfully
- [ ] Verify area tracker is automatically enabled on operations page load
- [ ] Verify area tracker button is hidden
- [ ] Verify area tracker works with very large viewport (zoomed out globally)
- [ ] Verify `/data/aircraft` API accepts new parameter names
- [ ] Verify aircraft loading works correctly with new parameter names