### PR TITLE
fix: remove redundant /data prefix in coverage hexes API call

### DIFF
--- a/web/src/routes/receivers/coverage/+page.svelte
+++ b/web/src/routes/receivers/coverage/+page.svelte
@@ -130,7 +130,7 @@
 			}
 
 			const response = await serverCall<CoverageGeoJsonResponse>(
-				`/data/coverage/hexes?${params.toString()}`
+				`/coverage/hexes?${params.toString()}`
 			);
 
 			hexCount = response.features?.length || 0;


### PR DESCRIPTION
## Summary
- Fixed duplicate `/data/data/` path in coverage hexes API endpoint
- `serverCall()` automatically prepends `/data/`, so passing `/data/coverage/hexes` resulted in `/data/data/coverage/hexes`
- Changed to `/coverage/hexes` for correct URL construction

## Test plan
- [ ] Load coverage map page and verify API calls use correct `/data/coverage/hexes` path
- [ ] Verify hexagons load properly on map
- [ ] Test with different filters (resolution, date range, receiver, altitude)