### PR TITLE
fix: correct circular references in Grafana alert rules

### DIFF
--- a/infrastructure/grafana-provisioning/alerting/alert-rules-production.yml
+++ b/infrastructure/grafana-provisioning/alerting/alert-rules-production.yml
@@ -75,7 +75,7 @@ groups:
                     type: and
                   query:
                     params:
-                      - D
+                      - C
                   reducer:
                     params: []
                     type: last
@@ -150,7 +150,7 @@ groups:
                     type: and
                   query:
                     params:
-                      - C
+                      - B
                   reducer:
                     params: []
                     type: last
@@ -225,7 +225,7 @@ groups:
                     type: and
                   query:
                     params:
-                      - C
+                      - B
                   reducer:
                     params: []
                     type: last

--- a/infrastructure/grafana-provisioning/alerting/alert-rules-staging.yml
+++ b/infrastructure/grafana-provisioning/alerting/alert-rules-staging.yml
@@ -75,7 +75,7 @@ groups:
                     type: and
                   query:
                     params:
-                      - D
+                      - C
                   reducer:
                     params: []
                     type: last
@@ -150,7 +150,7 @@ groups:
                     type: and
                   query:
                     params:
-                      - C
+                      - B
                   reducer:
                     params: []
                     type: last
@@ -225,7 +225,7 @@ groups:
                     type: and
                   query:
                     params:
-                      - C
+                      - B
                   reducer:
                     params: []
                     type: last


### PR DESCRIPTION
## Summary

Fixes Grafana alert evaluation errors caused by circular references in alert rule configurations.

## Problem

All Grafana alerts were failing with this error:
```
Error: invalid format of evaluation results for the alert definition B: 
looks like time series data, only reduced data can be alerted on.
```

## Root Cause

All three alert rules in both `alert-rules-staging.yml` and `alert-rules-production.yml` had circular references where threshold conditions were referencing themselves instead of the reduced query values they depend on.

**Example of the bug:**
```yaml
# Reduce B: Convert time series to single value
- refId: B
  expression: A
  reducer: last
  type: reduce

# Condition C: Should reference B, but was referencing C (itself!)
- refId: C
  conditions:
    query:
      params: [C]  # ❌ WRONG - circular reference
  expression: B
  type: threshold
```

## Changes

Fixed 6 circular references across both environment files:

### Staging (`alert-rules-staging.yml`)
1. **Alert 1 (Message Rate)**: Line 78 - Changed `query.params: [D]` → `[C]`
2. **Alert 2 (Service Disconnected)**: Line 153 - Changed `query.params: [C]` → `[B]` ⚠️ This was the one triggering emails
3. **Alert 3 (NATS Errors)**: Line 228 - Changed `query.params: [C]` → `[B]`

### Production (`alert-rules-production.yml`)
4. **Alert 1 (Message Rate)**: Line 78 - Changed `query.params: [D]` → `[C]`
5. **Alert 2 (Service Disconnected)**: Line 153 - Changed `query.params: [C]` → `[B]`
6. **Alert 3 (NATS Errors)**: Line 228 - Changed `query.params: [C]` → `[B]`

## Test Plan

- [ ] Merge and deploy to staging via CI/CD
- [ ] Monitor Grafana for alert evaluation errors
- [ ] Verify alerts can evaluate successfully without "invalid format" errors
- [ ] If staging OGN service goes down, verify alert fires correctly with proper message

## Notes

- The old `alert-rules.yml` file uses a simpler structure without the reduce step and doesn't have this issue
- The production/staging split files were refactored to use a reduce step but introduced these circular references