### PR TITLE
fix: serialize raw_messages_repo tests to prevent parallel execution conflicts

### DIFF
--- a/src/raw_messages_repo.rs
+++ b/src/raw_messages_repo.rs
@@ -412,6 +412,7 @@ mod tests {
     use chrono::Utc;
     use diesel::connection::SimpleConnection;
     use diesel::r2d2::{ConnectionManager, Pool};
+    use serial_test::serial;
 
     /// Helper to create a test database pool
     /// Uses TEST_DATABASE_URL environment variable or defaults to local test database
@@ -446,6 +447,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_insert_and_get_by_id() {
         let pool = create_test_pool();
         cleanup_test_data(&pool);
@@ -509,6 +511,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_get_by_ids_multiple() {
         let pool = create_test_pool();
         cleanup_test_data(&pool);
@@ -558,6 +561,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_get_by_ids_partial_match() {
         let pool = create_test_pool();
         cleanup_test_data(&pool);


### PR DESCRIPTION
## Summary

Fixes the test failure introduced after PR #647 merged to main. The raw_messages_repo unit tests were failing due to parallel execution conflicts.

## Problem

After PR #644 enabled parallel test execution, the unit tests in `src/raw_messages_repo.rs` started failing with:

```
insert or update on table "raw_messages_p20251227" violates foreign key 
constraint "aprs_messages_receiver_id_fkey"
```

## Root Cause

Three tests share a common database (`soar_test`) and insert into the `receivers` table before inserting messages:
- `test_insert_and_get_by_id`
- `test_get_by_ids_multiple`  
- `test_get_by_ids_partial_match`

When run in parallel, receiver inserts could conflict with foreign key constraints on the partitioned `raw_messages` table.

## Changes

- Add `#[serial]` attribute to the three affected tests
- Add `use serial_test::serial;` to test module

This ensures these tests run sequentially, preventing database contention while maintaining parallel execution for other tests.

## Test Plan

- [x] CI tests should pass with the `#[serial]` attributes
- [x] Verify no regression in other tests

## Related

- Fixes test failure from PR #647 (Grafana alerts fix)
- Related to PR #644 (parallel test execution)