### PR TITLE
feat: add aircraft display limit and total count to operations page

### DIFF
--- a/src/actions/fixes.rs
+++ b/src/actions/fixes.rs
@@ -17,7 +17,7 @@ use crate::fixes_repo::FixesRepository;
 use crate::live_fixes::WebSocketMessage;
 use crate::web::AppState;
 
-use super::devices::enrich_aircraft_with_registration_data;
+use super::aircraft_search::enrich_aircraft_with_registration_data;
 use super::json_error;
 
 /// Area tracker configuration

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,4 +1,5 @@
 pub mod aircraft;
+pub mod aircraft_search;
 pub mod airports;
 pub mod airspaces;
 pub mod analytics;
@@ -6,7 +7,6 @@ pub mod aprs_messages;
 pub mod auth;
 pub mod clubs;
 pub mod coverage;
-pub mod devices;
 pub mod fixes;
 pub mod flights;
 pub mod pilots;
@@ -18,13 +18,13 @@ pub mod views;
 pub mod watchlist;
 
 pub use aircraft::*;
+pub use aircraft_search::*;
 pub use airports::*;
 pub use airspaces::*;
 pub use analytics::*;
 pub use aprs_messages::*;
 pub use auth::*;
 pub use clubs::*;
-pub use devices::*;
 pub use fixes::*;
 pub use flights::*;
 pub use receivers::*;
@@ -52,6 +52,14 @@ pub struct DataResponse<T> {
 #[serde(rename_all = "camelCase")]
 pub struct DataListResponse<T> {
     pub data: Vec<T>,
+}
+
+/// Standard wrapper for list responses with total count
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DataListResponseWithTotal<T> {
+    pub data: Vec<T>,
+    pub total: i64,
 }
 
 /// Pagination metadata (nested in paginated responses)

--- a/web/src/lib/services/FixFeed.ts
+++ b/web/src/lib/services/FixFeed.ts
@@ -422,9 +422,10 @@ export class FixFeed {
 		north: number,
 		west: number,
 		east: number,
-		afterTimestamp?: string // Expected in ISO 8601 format
-	): Promise<Aircraft[]> {
-		if (!browser) return [];
+		afterTimestamp?: string, // Expected in ISO 8601 format
+		limit?: number
+	): Promise<{ data: Aircraft[]; total: number }> {
+		if (!browser) return { data: [], total: 0 };
 
 		try {
 			const { serverCall } = await import('$lib/api/server');
@@ -434,13 +435,14 @@ export class FixFeed {
 					north,
 					west,
 					east,
-					...(afterTimestamp && { after: afterTimestamp })
+					...(afterTimestamp && { after: afterTimestamp }),
+					...(limit && { limit })
 				}
 			});
-			return response as Aircraft[];
+			return response as { data: Aircraft[]; total: number };
 		} catch (error) {
 			console.error('Failed to fetch aircraft in bounding box:', error);
-			return [];
+			return { data: [], total: 0 };
 		}
 	}
 }

--- a/web/src/routes/operations/+page.svelte
+++ b/web/src/routes/operations/+page.svelte
@@ -1879,23 +1879,28 @@
 
 			// Fetch aircraft with their latest position only (no fix history)
 			// Fixes will accumulate from WebSocket after this
-			const aircraft = await fixFeed.fetchAircraftInBoundingBox(
+			const response = await fixFeed.fetchAircraftInBoundingBox(
 				sw.lat(), // south
 				ne.lat(), // north
 				sw.lng(), // west
-				ne.lng() // east
-				// No 'after' parameter - backend doesn't fetch fixes anymore
+				ne.lng(), // east
+				undefined, // No 'after' parameter - backend doesn't fetch fixes anymore
+				MAX_AIRCRAFT_DISPLAY // Backend returns 'total' field to detect if there are more
 			);
 
-			console.log(`[REST] Received ${aircraft.length} aircraft with latest positions`);
+			const { data: aircraft, total } = response;
 
-			// Store total aircraft count
-			totalAircraftInViewport = aircraft.length;
+			console.log(
+				`[REST] Received ${aircraft.length} aircraft with latest positions (total: ${total})`
+			);
+
+			// Store total aircraft count from the backend
+			totalAircraftInViewport = total;
 
 			// Check if we've exceeded the display limit
-			if (aircraft.length > MAX_AIRCRAFT_DISPLAY) {
+			if (total > MAX_AIRCRAFT_DISPLAY) {
 				console.warn(
-					`[REST] Aircraft count (${aircraft.length}) exceeds display limit (${MAX_AIRCRAFT_DISPLAY}). Not rendering aircraft.`
+					`[REST] Aircraft count (${total}) exceeds display limit (${MAX_AIRCRAFT_DISPLAY}). Not rendering aircraft.`
 				);
 				aircraftLimitExceeded = true;
 				// Clear any existing aircraft markers


### PR DESCRIPTION
## Summary

This PR adds a safety mechanism to prevent browser crashes when the operations page tries to render too many aircraft markers. It introduces a 50-aircraft display limit with a backend limit parameter and total count.

## Changes

### Backend
- ✅ Add `DataListResponseWithTotal` response type with `total` field
- ✅ Add optional `limit` parameter to `AircraftSearchQuery` (hard cap at 1000)
- ✅ Add `count_aircraft_in_bounding_box()` function for efficient counting
- ✅ Update `search_aircraft_by_bbox` to return both limited data and total count
- ✅ Rename `devices.rs` → `aircraft_search.rs` for clarity

### Frontend
- ✅ Add `MAX_AIRCRAFT_DISPLAY = 50` constant
- ✅ Update `fetchAircraftInBoundingBox` to accept `limit` parameter
- ✅ Change return type to `{ data: Aircraft[], total: number }`
- ✅ Display warning overlay when total exceeds limit
- ✅ Show accurate count in warning message

## How It Works

When there are 900 aircraft in the viewport:
1. Frontend requests: `limit=50`
2. Backend counts all aircraft: `total=900`
3. Backend fetches & truncates to limit: returns 50 aircraft
4. Backend response: `{ data: [50 aircraft], total: 900 }`
5. Frontend sees `total > 50`, displays warning overlay with accurate count
6. No markers rendered, browser doesn't crash

When there are 40 aircraft:
1. Backend response: `{ data: [40 aircraft], total: 40 }`
2. Frontend sees `total <= 50`, renders all aircraft normally

## Testing

- [x] Backend compiles without errors
- [x] Frontend compiles without errors
- [x] Clippy passes
- [x] Pre-commit hooks pass

## Related Issues

Fixes the browser crash issue when loading operations page with large numbers of aircraft in view.