### PR TITLE
fix: resolve localStorage quota error from undefined aircraftId

### DIFF
--- a/src/fixes.rs
+++ b/src/fixes.rs
@@ -41,6 +41,7 @@ where
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Insertable)]
 #[diesel(table_name = crate::schema::fixes)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
+#[serde(rename_all = "camelCase")]
 pub struct Fix {
     /// Unique identifier for this fix
     pub id: Uuid,
@@ -58,9 +59,7 @@ pub struct Fix {
     pub latitude: f64,
     pub longitude: f64,
     // Note: location and geom fields are skipped as they're computed from lat/lng
-    #[serde(rename = "altitude_msl_feet")]
     pub altitude_msl_feet: Option<i32>,
-    #[serde(rename = "altitude_agl_feet")]
     pub altitude_agl_feet: Option<i32>,
 
     /// Flight information
@@ -131,6 +130,7 @@ pub struct FixWithAircraftInfo {
 /// Extended Fix struct that includes flight metadata for WebSocket streaming
 /// Used when streaming fixes to include current flight information
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FixWithFlightInfo {
     #[serde(flatten)]
     pub fix: Fix,

--- a/web/src/lib/services/FixFeed.ts
+++ b/web/src/lib/services/FixFeed.ts
@@ -181,6 +181,14 @@ export class FixFeed {
 						const aircraftFixes = aircraft.fixes || [];
 						if (aircraftFixes.length > 0) {
 							for (const fix of aircraftFixes) {
+								// Ensure fix has aircraftId set (should come from backend, but validate)
+								if (!fix.aircraftId && aircraft.id) {
+									console.warn(
+										'[FIXFEED] Fix missing aircraftId, setting from parent aircraft:',
+										aircraft.id
+									);
+									fix.aircraftId = aircraft.id;
+								}
 								this.aircraftRegistry.addFixToAircraft(fix, false).catch((error) => {
 									console.warn('Failed to add aircraft fix to registry:', error);
 								});


### PR DESCRIPTION
## Problem
Users were seeing this error in the browser console:
```
Failed to save aircraft to localStorage: QuotaExceededError: Failed to execute 'setItem' on 'Storage': Setting the value of 'aircraft.undefined' exceeded the quota.
```

The localStorage wasn't actually full - the issue was that a malformed key `'aircraft.undefined'` was being created repeatedly.

## Root Cause
The backend was serializing `Fix` objects with **snake_case** field names (e.g., `aircraft_id`) but the frontend expected **camelCase** (e.g., `aircraftId`). This caused:
1. WebSocket messages to have `rawMessage.aircraft_id` instead of `rawMessage.aircraftId`
2. Frontend to read `undefined` when accessing `rawMessage.aircraftId`
3. Aircraft to be created with `id: undefined`
4. localStorage key to become `'aircraft.undefined'`

## Changes

### Backend (`src/fixes.rs`)
- ✅ Added `#[serde(rename_all = "camelCase")]` to `Fix` struct
- ✅ Added `#[serde(rename_all = "camelCase")]` to `FixWithFlightInfo` struct
- ✅ Removed explicit snake_case renames for altitude fields (now correctly serialize as `altitudeMslFeet`, `altitudeAglFeet`)
- ✅ Kept explicit rename for `is_active` → `active` (as expected by frontend)

### Frontend (`web/src/lib/services/`)
- ✅ **AircraftRegistry.ts**: Added validation to prevent saving aircraft with undefined IDs
- ✅ **AircraftRegistry.ts**: Added cleanup function to remove malformed localStorage keys on startup
- ✅ **FixFeed.ts**: Added defensive check to set `aircraftId` from parent aircraft if missing in embedded fixes

## Testing
- ✅ TypeScript type checks pass
- ✅ Rust builds without errors
- ✅ Clippy passes with no warnings
- ✅ All pre-commit hooks pass

## Result
- Backend now correctly serializes all Fix fields in camelCase
- Frontend properly receives `aircraftId` instead of `undefined`
- Malformed localStorage keys are prevented and automatically cleaned up
- The localStorage quota error will no longer occur