### PR TITLE
Potential fix for code scanning alert no. 9: Use of externally-controlled format string

### DIFF
--- a/web/src/lib/services/AircraftRegistry.ts
+++ b/web/src/lib/services/AircraftRegistry.ts
@@ -212,7 +212,7 @@ export class AircraftRegistry {
 			this.setAircraft(apiAircraft);
 			return this.getAircraft(aircraftId);
 		} catch (error) {
-			console.warn(`Failed to fetch aircraft ${aircraftId} from API:`, error);
+			console.warn('Failed to fetch aircraft from API:', aircraftId, error);
 			return null;
 		}
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/hut8/soar/security/code-scanning/9](https://github.com/hut8/soar/security/code-scanning/9)

General approach: Avoid using untrusted data inside a string that might be interpreted as a format string by `console.warn` (or similar APIs). Instead, keep the format string constant and pass untrusted data as subsequent arguments, or sanitize the untrusted data before interpolation.

Best targeted fix here: Change the `console.warn` call in `updateAircraftFromAPI` so that the first argument is a constant string, and `aircraftId` is passed as an additional argument. This preserves all existing logging behavior while eliminating any chance that an attacker‑controlled `aircraftId` is interpreted as part of the format pattern.

Concretely, in `web/src/lib/services/AircraftRegistry.ts`, around line 215, replace:

```ts
console.warn(`Failed to fetch aircraft ${aircraftId} from API:`, error);
```

with:

```ts
console.warn('Failed to fetch aircraft from API:', aircraftId, error);
```

This keeps the same information (message, aircraftId, error) in the log and ensures the first argument is not influenced by user input. No new imports, helper methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
