### PR TITLE
fix: install migration service template before running migrations

### DIFF
--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -188,6 +188,22 @@ log_info "Deploying new binary to temporary location: $TEMP_BIN_PATH"
 install -m 755 -o soar -g soar "$DEPLOY_DIR/soar" "$TEMP_BIN_PATH"
 log_info "Binary deployed to temporary location"
 
+# Install migration service template early (needed before running migrations)
+log_info "Installing migration service template..."
+for service in "${TEMPLATE_SERVICES[@]}"; do
+    if [ -f "$DEPLOY_DIR/$service" ]; then
+        log_info "Installing $service..."
+        cp "$DEPLOY_DIR/$service" /etc/systemd/system/
+        chmod 644 "/etc/systemd/system/$service"
+    else
+        log_warn "$service not found in deployment directory, skipping"
+    fi
+done
+
+# Reload systemd daemon to pick up new migration service
+log_info "Reloading systemd daemon..."
+systemctl daemon-reload
+
 # Stop soar-run service only (for migrations, keep others running)
 log_info "Stopping soar-run${SERVICE_SUFFIX} service for migrations..."
 if systemctl is-active --quiet "soar-run${SERVICE_SUFFIX}.service"; then
@@ -396,9 +412,23 @@ else
     log_info "No obsolete systemd files found"
 fi
 
-# Install service files
+# Install service files (skip template services, they were installed earlier)
 log_info "Installing service files..."
 for service in "${ALL_SERVICES[@]}"; do
+    # Skip template services (already installed before migrations)
+    skip=false
+    for template_service in "${TEMPLATE_SERVICES[@]}"; do
+        if [ "$service" = "$template_service" ]; then
+            skip=true
+            break
+        fi
+    done
+
+    if [ "$skip" = true ]; then
+        log_info "$service already installed (template service)"
+        continue
+    fi
+
     if [ -f "$DEPLOY_DIR/$service" ]; then
         log_info "Installing $service..."
         cp "$DEPLOY_DIR/$service" /etc/systemd/system/


### PR DESCRIPTION
## Summary

Fixes deployment failures on staging where `soar-migrate@staging.service` was not found.

## Problem

The deployment script (`infrastructure/soar-deploy`) was attempting to **start** the migration service at line 215, but didn't **install** the service template file (`soar-migrate@.service`) until line 401. This caused the error:

```
Failed to start soar-migrate@staging.service: Unit soar-migrate@staging.service not found.
```

## Solution

This PR restructures the deployment flow to:

1. **Install template services early** - Copies `soar-migrate@.service` from the deployment package to `/etc/systemd/system/` immediately after deploying the binary
2. **Reload systemd** - Runs `systemctl daemon-reload` to pick up the new service template  
3. **Run migrations** - Now the migration service exists and can be started successfully
4. **Skip duplicate installation** - The later service installation loop skips template services since they're already installed

## Changes

- Modified `infrastructure/soar-deploy`:
  - Added early installation of `TEMPLATE_SERVICES` (lines 191-205)
  - Updated service installation loop to skip template services (lines 415-439)

## Testing

- Verified bash syntax with `bash -n`
- Pre-commit hooks passed
- This fixes the deployment failure seen in https://github.com/hut8/soar/actions/runs/20539310517/job/59001732728

## Related

- Fixes the staging deployment pipeline
- No impact on existing deployments (the provision script already installs this service, so running deployments already have it)