### PR TITLE
fix: correct OGN ingest disconnection alert query structure

### DIFF
--- a/infrastructure/grafana-provisioning/alerting/alert-rules-production.yml
+++ b/infrastructure/grafana-provisioning/alerting/alert-rules-production.yml
@@ -105,7 +105,7 @@ groups:
       # Alert when production OGN ingest service is disconnected
       - uid: ogn_service_disconnected_production
         title: "[Production] OGN Ingest Service Disconnected"
-        condition: C
+        condition: B
         data:
           # Query A: Check if APRS connection is established (production only)
           - refId: A
@@ -119,23 +119,8 @@ groups:
               maxDataPoints: 43200
               refId: A
 
-          # Reduce B: Convert time series to single value using last()
+          # Condition B: Alert if connection gauge is 0 (disconnected)
           - refId: B
-            relativeTimeRange:
-              from: 300
-              to: 0
-            datasourceUid: __expr__
-            model:
-              datasource:
-                type: __expr__
-                uid: __expr__
-              expression: A
-              reducer: last
-              type: reduce
-              refId: B
-
-          # Condition C: Alert if connection gauge is 0 (disconnected)
-          - refId: C
             relativeTimeRange:
               from: 300
               to: 0
@@ -150,7 +135,7 @@ groups:
                     type: and
                   query:
                     params:
-                      - B
+                      - A
                   reducer:
                     params: []
                     type: last
@@ -158,11 +143,11 @@ groups:
               datasource:
                 type: __expr__
                 uid: __expr__
-              expression: B
+              expression: A
               hide: false
               intervalMs: 1000
               maxDataPoints: 43200
-              refId: C
+              refId: B
               type: threshold
 
         for: 1m

--- a/infrastructure/grafana-provisioning/alerting/alert-rules-staging.yml
+++ b/infrastructure/grafana-provisioning/alerting/alert-rules-staging.yml
@@ -105,7 +105,7 @@ groups:
       # Alert when staging OGN ingest service is disconnected
       - uid: ogn_service_disconnected_staging
         title: "[Staging] OGN Ingest Service Disconnected"
-        condition: C
+        condition: B
         data:
           # Query A: Check if APRS connection is established (staging only)
           - refId: A
@@ -119,23 +119,8 @@ groups:
               maxDataPoints: 43200
               refId: A
 
-          # Reduce B: Convert time series to single value using last()
+          # Condition B: Alert if connection gauge is 0 (disconnected)
           - refId: B
-            relativeTimeRange:
-              from: 300
-              to: 0
-            datasourceUid: __expr__
-            model:
-              datasource:
-                type: __expr__
-                uid: __expr__
-              expression: A
-              reducer: last
-              type: reduce
-              refId: B
-
-          # Condition C: Alert if connection gauge is 0 (disconnected)
-          - refId: C
             relativeTimeRange:
               from: 300
               to: 0
@@ -150,7 +135,7 @@ groups:
                     type: and
                   query:
                     params:
-                      - B
+                      - A
                   reducer:
                     params: []
                     type: last
@@ -158,11 +143,11 @@ groups:
               datasource:
                 type: __expr__
                 uid: __expr__
-              expression: B
+              expression: A
               hide: false
               intervalMs: 1000
               maxDataPoints: 43200
-              refId: C
+              refId: B
               type: threshold
 
         for: 1m


### PR DESCRIPTION
## Summary

Fixes the **OGN ingest disconnection alert** that has been falsely triggering despite the service running normally.

## The Real Problem

**The service is NOT disconnected** - it's receiving and processing 80-150 messages/second. The **Grafana alert configuration is broken** and can't evaluate the metric properly.

### Evidence the Service is Fine

```bash
$ systemctl status soar-ingest-ogn-staging.service
Active: active (running) since Sat 2025-12-27 21:50:07 UTC

$ curl http://localhost:9090/api/v1/query?query=aprs_connection_connected
{
  "value": [1766880906.585, "1"]  # ← Connected!
}

$ journalctl -u soar-ingest-ogn-staging | tail -5
NATS stats: 106.6 msg/s attempted (queue: 0, last receive: 0.1s ago)
NATS stats: 98.2 msg/s attempted (queue: 0, last receive: 0.0s ago)
```

## Root Cause

The alert used an incorrect 3-query Grafana alert pattern that doesn't work:

```yaml
condition: C  # ← Wrong
data:
  - refId: A  # Prometheus query
  - refId: B  # Reduce step
  - refId: C  # Threshold referencing B ← Error here!
```

This caused Grafana to error:
```
Error: invalid format of evaluation results for the alert definition B: 
looks like time series data, only reduced data can be alerted on.
```

**Why it fails:**
- Grafana alerting requires `condition` to reference a `threshold` type query
- The threshold must directly reference the Prometheus query (A), not a reduce step (B)
- The broken config had C reference B, which Grafana can't evaluate correctly

## The Fix

Changed to the correct 2-query threshold pattern that Grafana expects:

```yaml
condition: B  # ← Correct
data:
  - refId: A  # Prometheus query: aprs_connection_connected{environment="staging"}
  - refId: B  # Threshold directly evaluating A ← Works!
    type: threshold
    conditions:
      - query: {params: [A]}  # ← Direct reference to A
        evaluator: {type: lt, params: [0.5]}
```

## Changes

**Modified alert files:**
- `infrastructure/grafana-provisioning/alerting/alert-rules-staging.yml`
- `infrastructure/grafana-provisioning/alerting/alert-rules-production.yml`

**For both staging and production OGN disconnect alerts:**
- Changed `condition: C` → `condition: B`
- Removed the Reduce step (refId B)  
- Made threshold query B directly evaluate Prometheus query A
- Changed threshold query params from `[B]` → `[A]`

## Impact

✅ **Alert will now work correctly:**
- Properly evaluates the `aprs_connection_connected` metric
- No more false "disconnected" alerts when service is running
- Will correctly trigger if service actually disconnects (when metric < 0.5)

✅ **Matches the working pattern:**
- This is the same pattern already used in `alert-rules.yml` (lines 95-120)
- Confirmed working structure for Grafana alerts

## Testing

- ✅ Pre-commit hooks passed (YAML validation)
- ✅ Current metric value is 1 (connected), alert should be clear after deployment
- ✅ Pattern matches known-working alert configuration

## Related

This is why the alert kept "breaking" - it was never fixed correctly. The alert configuration itself was fundamentally broken, not the service.