### PR TITLE
feat: add Google Analytics tracking to frontend

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -127,6 +127,17 @@
 	<meta name="apple-mobile-web-app-status-bar-style" content="default" />
 	<meta name="apple-mobile-web-app-title" content="SOAR" />
 	<meta name="theme-color" content="#0ea5e9" />
+
+	<!-- Google Analytics -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-DW6KXT6VG1"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag() {
+			dataLayer.push(arguments);
+		}
+		gtag('js', new Date());
+		gtag('config', 'G-DW6KXT6VG1');
+	</script>
 </svelte:head>
 
 <div class="flex h-full min-h-screen flex-col">


### PR DESCRIPTION
## Summary
Added Google Analytics tracking to the SOAR frontend application.

- Added gtag.js script to root layout file (`web/src/routes/+layout.svelte`)
- Tracking code is placed in `<svelte:head>` to ensure it loads on all pages
- Tracking ID: `G-DW6KXT6VG1`

## Test plan
- [x] Frontend builds successfully
- [x] All pre-commit hooks passed
- [ ] Verify tracking in Google Analytics dashboard after deployment

## Changes
- Modified `web/src/routes/+layout.svelte` to include Google Analytics scripts