### PR TITLE
fix: use ST_MakePoint for h3_lat_lng_to_cell function

### DIFF
--- a/src/commands/aggregate_coverage.rs
+++ b/src/commands/aggregate_coverage.rs
@@ -180,10 +180,11 @@ async fn fetch_and_aggregate_fixes(
 
         // Use h3_lat_lng_to_cell() PostgreSQL function for efficient H3 conversion
         // All aggregation happens in the database - WAY faster than fetching + processing in Rust
+        // Note: ST_MakePoint takes (longitude, latitude) in PostGIS (x, y order)
         let coverage_data: Vec<AggregatedCoverage> = diesel::sql_query(
             r#"
             SELECT
-                h3_lat_lng_to_cell(latitude, longitude, $3)::bigint AS h3_index,
+                h3_lat_lng_to_cell(ST_MakePoint(longitude, latitude)::geography, $3)::bigint AS h3_index,
                 receiver_id,
                 DATE(received_at) AS date,
                 COUNT(*)::integer AS fix_count,


### PR DESCRIPTION
## Summary
Fixes the `h3_lat_lng_to_cell` function call to use the correct signature expected by the h3 PostgreSQL extension.

## Problem
The aggregate-coverage command was failing with:
```
function h3_lat_lng_to_cell(double precision, double precision, smallint) does not exist
```

## Root Cause
The h3 extension expects `h3_lat_lng_to_cell(geography/geometry, resolution)`, not `h3_lat_lng_to_cell(lat, lng, resolution)`.

## Solution
Changed the SQL query to construct a PostGIS point:
```sql
-- Before:
h3_lat_lng_to_cell(latitude, longitude, resolution)

-- After:
h3_lat_lng_to_cell(ST_MakePoint(longitude, latitude)::geography, resolution)
```

**Note:** ST_MakePoint takes (longitude, latitude) in PostGIS (x, y order), not (lat, lng).

## Testing
- [x] Verified h3 extension is installed (v4.2.3)
- [x] Tested query with ST_MakePoint successfully
- [x] Build passes

## Impact
This fixes coverage aggregation on staging (and production) where the h3 extension is installed.