### PR TITLE
perf(run): fix NATS slow consumer warnings during high load

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -748,13 +748,14 @@ async fn main() -> Result<()> {
 
     // Create separate filter for fmt_layer (console output)
     // Use RUST_LOG if set, otherwise default based on environment
+    // Note: async_nats is set to warn to suppress "slow consumers" INFO logs during high load
     let fmt_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         if is_production {
-            EnvFilter::new("warn,hyper_util=info,rustls=info")
+            EnvFilter::new("warn,hyper_util=info,rustls=info,async_nats=warn")
         } else if is_staging {
-            EnvFilter::new("info,hyper_util=info,rustls=info")
+            EnvFilter::new("info,hyper_util=info,rustls=info,async_nats=warn")
         } else {
-            EnvFilter::new("debug,hyper_util=info,rustls=info")
+            EnvFilter::new("debug,hyper_util=info,rustls=info,async_nats=warn")
         }
     });
 


### PR DESCRIPTION
## Summary

Fixes the "slow consumers for subscription 1" log flooding issue that occurs during high system load.

- Increases NATS subscription capacity from default ~512 to **10,000 messages** to handle traffic bursts
- Suppresses async_nats INFO-level log spam by setting `async_nats=warn` in tracing filters
- Reduces journald CPU overhead from excessive logging

## Changes

- `src/commands/run.rs`: Set `subscription_capacity(10_000)` on NATS ConnectOptions for both Beast and APRS subscribers
- `src/main.rs`: Add `async_nats=warn` to all tracing filter levels

## Impact

- ✅ No more "slow consumers" log spam flooding journald
- ✅ Better handling of message bursts (20x larger buffer)
- ✅ Reduced system load from journald logging
- ✅ Still get WARN/ERROR logs if NATS actually fails

## Test Plan

- [x] Code compiles successfully
- [x] Pre-commit hooks pass
- [ ] Deploy to staging and verify no slow consumer warnings under load
- [ ] Monitor Grafana for NATS metrics during peak traffic