### PR TITLE
Fix: Restrict Google Analytics and Sentry to production/staging only

### DIFF
--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -8,6 +8,10 @@ declare global {
 		// interface PageState {}
 		// interface Platform {}
 	}
+
+	interface Window {
+		dataLayer: unknown[];
+	}
 }
 
 export {};

--- a/web/src/hooks.client.ts
+++ b/web/src/hooks.client.ts
@@ -2,11 +2,24 @@ import * as Sentry from '@sentry/sveltekit';
 import { replayIntegration } from '@sentry/sveltekit';
 import type { HandleClientError } from '@sveltejs/kit';
 
-// Only initialize Sentry in production
-if (import.meta.env.MODE !== 'development') {
+// Determine if we should enable Sentry
+// Only enable on staging (staging.glider.flights) and production (glider.flights)
+// Exclude localhost, 127.0.0.1, and test environments
+const shouldEnableSentry = () => {
+	if (typeof window === 'undefined') return false;
+	const hostname = window.location.hostname;
+
+	// Enable on production and staging only
+	return hostname === 'glider.flights' || hostname === 'staging.glider.flights';
+};
+
+// Only initialize Sentry on staging/production
+if (shouldEnableSentry()) {
+	const environment = window.location.hostname === 'glider.flights' ? 'production' : 'staging';
+
 	Sentry.init({
 		dsn: 'https://5d2b053d9c52b539568f9bb038cfae06@o4510021799706624.ingest.us.sentry.io/4510173675520000',
-		environment: import.meta.env.MODE || 'production',
+		environment,
 
 		// Adjust trace sample rate for production
 		tracesSampleRate: 0.1,
@@ -20,11 +33,11 @@ if (import.meta.env.MODE !== 'development') {
 }
 
 export const handleError: HandleClientError = ({ error, event }) => {
-	// Only send to Sentry in production
-	if (import.meta.env.MODE !== 'development') {
+	// Only send to Sentry on staging/production
+	if (shouldEnableSentry()) {
 		Sentry.captureException(error, { contexts: { sveltekit: { event } } });
 	} else {
-		// Log to console in development
+		// Log to console in development/test
 		console.error('Client error:', error, event);
 	}
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -12,7 +12,7 @@
 	import { websocketStatus, debugStatus } from '$lib/stores/websocket-status';
 	import { onMount, onDestroy } from 'svelte';
 	import { startTracking, stopTracking } from '$lib/services/locationTracker';
-	import { dev } from '$app/environment';
+	import { dev, browser } from '$app/environment';
 	import RadarLoader from '$lib/components/RadarLoader.svelte';
 	import LoadingBar from '$lib/components/LoadingBar.svelte';
 	import BottomLoadingBar from '$lib/components/BottomLoadingBar.svelte';
@@ -68,6 +68,21 @@
 		auth.initFromStorage();
 		theme.init();
 		backendMode.init();
+
+		// Load Google Analytics only on production domain
+		if (browser && window.location.hostname === 'glider.flights') {
+			const script = document.createElement('script');
+			script.async = true;
+			script.src = 'https://www.googletagmanager.com/gtag/js?id=G-DW6KXT6VG1';
+			document.head.appendChild(script);
+
+			window.dataLayer = window.dataLayer || [];
+			function gtag(...args: unknown[]) {
+				window.dataLayer.push(args);
+			}
+			gtag('js', new Date());
+			gtag('config', 'G-DW6KXT6VG1');
+		}
 
 		// Add click outside listener
 		document.addEventListener('click', handleClickOutside);
@@ -128,16 +143,7 @@
 	<meta name="apple-mobile-web-app-title" content="SOAR" />
 	<meta name="theme-color" content="#0ea5e9" />
 
-	<!-- Google Analytics -->
-	<script async src="https://www.googletagmanager.com/gtag/js?id=G-DW6KXT6VG1"></script>
-	<script>
-		window.dataLayer = window.dataLayer || [];
-		function gtag() {
-			dataLayer.push(arguments);
-		}
-		gtag('js', new Date());
-		gtag('config', 'G-DW6KXT6VG1');
-	</script>
+	<!-- Google Analytics is loaded dynamically in onMount for production only -->
 </svelte:head>
 
 <div class="flex h-full min-h-screen flex-col">


### PR DESCRIPTION
## Summary
Restricts Google Analytics and Sentry to only load in production and staging environments, preventing pollution of analytics and error tracking with local development and E2E test data.

## Changes

### Google Analytics
- **Production only** (glider.flights)
- Moved from static `<script>` tags to dynamic loading in `onMount()`
- Checks `window.location.hostname === 'glider.flights'`
- Does NOT load on localhost, 127.0.0.1, or during E2E tests

### Sentry
- **Staging + Production** (staging.glider.flights and glider.flights)
- Changed from build mode check to hostname check
- Automatically sets correct environment tag ("production" vs "staging")
- Does NOT load on localhost, 127.0.0.1, or during E2E tests

### TypeScript
- Added `window.dataLayer` type declaration

## Testing
- ✅ TypeScript check passes
- ✅ ESLint passes
- ✅ Production build completes successfully
- ✅ All pre-commit hooks pass

## Environment Loading Matrix

| Environment | Google Analytics | Sentry |
|-------------|-----------------|--------|
| **Production** (glider.flights) | ✅ Loads | ✅ Loads (env: production) |
| **Staging** (staging.glider.flights) | ❌ Does NOT load | ✅ Loads (env: staging) |
| **Local Dev** (localhost:*) | ❌ Does NOT load | ❌ Does NOT load |
| **E2E Tests** (localhost:4173) | ❌ Does NOT load | ❌ Does NOT load |