### PR TITLE
fix(grafana): add missing reduce step to OGN disconnect alert

### DIFF
--- a/infrastructure/grafana-provisioning/alerting/alert-rules-production.yml
+++ b/infrastructure/grafana-provisioning/alerting/alert-rules-production.yml
@@ -105,7 +105,7 @@ groups:
       # Alert when production OGN ingest service is disconnected
       - uid: ogn_service_disconnected_production
         title: "[Production] OGN Ingest Service Disconnected"
-        condition: B
+        condition: C
         data:
           # Query A: Check if APRS connection is established (production only)
           - refId: A
@@ -119,8 +119,23 @@ groups:
               maxDataPoints: 43200
               refId: A
 
-          # Condition B: Alert if connection gauge is 0 (disconnected)
+          # Reduce B: Convert time series to single value using last()
           - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              reducer: last
+              type: reduce
+              refId: B
+
+          # Condition C: Alert if connection gauge is 0 (disconnected)
+          - refId: C
             relativeTimeRange:
               from: 300
               to: 0
@@ -135,7 +150,7 @@ groups:
                     type: and
                   query:
                     params:
-                      - A
+                      - B
                   reducer:
                     params: []
                     type: last
@@ -143,11 +158,11 @@ groups:
               datasource:
                 type: __expr__
                 uid: __expr__
-              expression: A
+              expression: B
               hide: false
               intervalMs: 1000
               maxDataPoints: 43200
-              refId: B
+              refId: C
               type: threshold
 
         for: 1m

--- a/infrastructure/grafana-provisioning/alerting/alert-rules-staging.yml
+++ b/infrastructure/grafana-provisioning/alerting/alert-rules-staging.yml
@@ -105,7 +105,7 @@ groups:
       # Alert when staging OGN ingest service is disconnected
       - uid: ogn_service_disconnected_staging
         title: "[Staging] OGN Ingest Service Disconnected"
-        condition: B
+        condition: C
         data:
           # Query A: Check if APRS connection is established (staging only)
           - refId: A
@@ -119,8 +119,23 @@ groups:
               maxDataPoints: 43200
               refId: A
 
-          # Condition B: Alert if connection gauge is 0 (disconnected)
+          # Reduce B: Convert time series to single value using last()
           - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              reducer: last
+              type: reduce
+              refId: B
+
+          # Condition C: Alert if connection gauge is 0 (disconnected)
+          - refId: C
             relativeTimeRange:
               from: 300
               to: 0
@@ -135,7 +150,7 @@ groups:
                     type: and
                   query:
                     params:
-                      - A
+                      - B
                   reducer:
                     params: []
                     type: last
@@ -143,11 +158,11 @@ groups:
               datasource:
                 type: __expr__
                 uid: __expr__
-              expression: A
+              expression: B
               hide: false
               intervalMs: 1000
               maxDataPoints: 43200
-              refId: B
+              refId: C
               type: threshold
 
         for: 1m


### PR DESCRIPTION
## Summary
- Fixed Grafana alert error: "invalid format of evaluation results for the alert definition B: looks like time series data, only reduced data can be alerted on"
- Added missing Reduce step to convert time series to single value before applying threshold
- Applied fix to both staging and production alert configurations

## Root Cause
The "OGN Ingest Service Disconnected" alert was applying a threshold directly to Prometheus time series data without first reducing it to a single value, which is required by Grafana's alerting engine.

## Changes
- Added Reduce step (refId B) using `last()` reducer
- Changed threshold condition from refId B to refId C
- Updated condition field from `condition: B` to `condition: C`
- Updated threshold to reference reduced value instead of raw time series

## Files Changed
- `infrastructure/grafana-provisioning/alerting/alert-rules-staging.yml`
- `infrastructure/grafana-provisioning/alerting/alert-rules-production.yml`

## Test Plan
After deployment:
- [ ] Verify alert appears in Grafana UI without errors
- [ ] Check alert evaluation is running (no "invalid format" errors in logs)
- [ ] Test alert triggering by stopping OGN ingest service
- [ ] Verify email notification is sent when alert fires

## Deployment
Run `soar-deploy` on staging first to verify, then production:
```bash
sudo /usr/local/bin/soar-deploy staging /tmp/soar/deploy/$(date +%Y%m%d%H%M%S)
sudo /usr/local/bin/soar-deploy production /tmp/soar/deploy/$(date +%Y%m%d%H%M%S)
```