### PR TITLE
fix: Fix tow detection by searching active_flights instead of aircraft_trackers

### DIFF
--- a/src/flight_tracker/state_transitions.rs
+++ b/src/flight_tracker/state_transitions.rs
@@ -549,6 +549,7 @@ pub(crate) async fn process_state_transition(
                                 ctx.fixes_repo.clone(),
                                 ctx.flights_repo.clone(),
                                 ctx.aircraft_repo.clone(),
+                                Arc::clone(ctx.active_flights),
                                 Arc::clone(ctx.aircraft_trackers),
                             );
                         }


### PR DESCRIPTION
## Summary
Fixes the broken tow detection system that was resulting in 0 glider flights being linked to tow tugs despite 895 tow tug flights and 1,957 glider flights occurring in the last 48 hours.

## Root Cause
The tow detection code in `find_nearby_gliders()` was searching the `aircraft_trackers` map, which **only contains tow tugs** (used for climb rate tracking to detect tow release). Gliders are never added to this map, so the search always returned zero results.

## Changes
- Added `active_flights` parameter to `spawn_towing_detection_task()` and `find_towed_glider()`
- Updated `find_nearby_gliders()` to search `active_flights` (which contains ALL active aircraft including gliders) instead of `aircraft_trackers`
- Updated call site in `state_transitions.rs` to pass `Arc::clone(ctx.active_flights)`

## Testing
- ✅ Code compiles with no errors
- ✅ Passes clippy with no warnings
- ✅ All flight_tracker tests pass
- ✅ Pre-commit hooks pass

## Expected Result
Tow detection should now correctly identify and link gliders to tow tugs when:
1. A tow tug takes off (triggers the detection task)
2. After 10 seconds, exactly one glider is found within 500m of the tow tug
3. The database is updated with `towed_by_aircraft_id` and `towed_by_flight_id`

Ready for staging deployment to verify tow detection is working.