### PR TITLE
fix: prevent position fixes from overwriting ICAO model code and emitter category

### DIFF
--- a/src/aircraft_repo.rs
+++ b/src/aircraft_repo.rs
@@ -298,8 +298,10 @@ impl AircraftRepository {
                 .set((
                     aircraft::last_fix_at.eq(fix_timestamp),
                     aircraft::aircraft_type_ogn.eq(packet_fields.aircraft_type),
-                    aircraft::icao_model_code.eq(packet_fields.icao_model_code),
-                    aircraft::adsb_emitter_category.eq(packet_fields.adsb_emitter_category),
+                    // Only update icao_model_code if current value is NULL (preserve data from authoritative sources)
+                    aircraft::icao_model_code.eq(diesel::dsl::sql("COALESCE(aircraft.icao_model_code, excluded.icao_model_code)")),
+                    // Only update adsb_emitter_category if current value is NULL (preserve data from authoritative sources)
+                    aircraft::adsb_emitter_category.eq(diesel::dsl::sql("COALESCE(aircraft.adsb_emitter_category, excluded.adsb_emitter_category)")),
                     aircraft::tracker_device_type.eq(packet_fields.tracker_device_type),
                     // Only update aircraft_model if current value is NULL or empty string
                     aircraft::aircraft_model.eq(diesel::dsl::sql(


### PR DESCRIPTION
## Summary
- Fixed bug where position fixes unconditionally overwrote `icao_model_code` and `adsb_emitter_category` fields with NULL values
- Changed `aircraft_repo.rs` to use `COALESCE()` pattern to preserve existing values from authoritative data sources
- Matches the approach already used in `load_data/adsb_exchange.rs` for consistency

## Root Cause
Aircraft C-GWUX (ICAO address c080e0) had `icao_model_code = "B738"` loaded from `basic-ac-db.json`, but position fixes were unconditionally overwriting this field. When a position packet arrived with no model code (or invalid format), the database value was replaced with NULL.

The issue was in `src/aircraft_repo.rs:301-302`:
```rust
// OLD - unconditionally overwrites
aircraft::icao_model_code.eq(packet_fields.icao_model_code),
aircraft::adsb_emitter_category.eq(packet_fields.adsb_emitter_category),
```

## Changes
- Updated `aircraft_repo.rs` to use `COALESCE(aircraft.field, excluded.field)` pattern
- Added comments explaining the preservation logic
- Applied same fix to both `icao_model_code` and `adsb_emitter_category` fields

## Test Plan
- [ ] Deploy to staging
- [ ] Verify C-GWUX (c080e0) retains icao_model_code "B738" after receiving position fixes
- [ ] Check other aircraft with ICAO model codes are preserved
- [ ] Monitor for any regressions in aircraft metadata updates