### PR TITLE
feat: add pagination to receiver list and aircraft detail improvements

### DIFF
--- a/src/airports_repo.rs
+++ b/src/airports_repo.rs
@@ -532,7 +532,7 @@ impl AirportsRepository {
                 SELECT id, ident, type as airport_type, name, latitude_deg, longitude_deg, elevation_ft,
                        continent, iso_country, iso_region, municipality, scheduled_service,
                        icao_code, iata_code, gps_code, local_code, home_link, wikipedia_link, keywords,
-                       NULL::float8 as distance_meters
+                       location_id, NULL::float8 as distance_meters
                 FROM airports
                 WHERE latitude_deg IS NOT NULL
                   AND longitude_deg IS NOT NULL
@@ -617,5 +617,43 @@ mod tests {
         assert_eq!(airport.elevation_ft, Some(11));
         assert_eq!(airport.iso_country, Some("US".to_string()));
         assert!(!airport.scheduled_service);
+    }
+
+    #[test]
+    fn test_airport_with_distance_has_location_id() {
+        // This test ensures AirportWithDistance struct has all required fields
+        // including location_id which was previously missing from SQL queries.
+        // This is a compile-time check - if any field is missing, this won't compile.
+
+        use super::AirportWithDistance;
+        use uuid::Uuid;
+
+        let test_uuid = Uuid::new_v4();
+        let _test_struct = AirportWithDistance {
+            id: 1,
+            ident: "TEST".to_string(),
+            airport_type: "small_airport".to_string(),
+            name: "Test Airport".to_string(),
+            latitude_deg: Some(BigDecimal::from_str("40.0").unwrap()),
+            longitude_deg: Some(BigDecimal::from_str("-74.0").unwrap()),
+            elevation_ft: Some(100),
+            continent: Some("NA".to_string()),
+            iso_country: Some("US".to_string()),
+            iso_region: Some("US-PA".to_string()),
+            municipality: Some("Test City".to_string()),
+            scheduled_service: false,
+            icao_code: Some("KTEST".to_string()),
+            iata_code: None,
+            gps_code: Some("TEST".to_string()),
+            local_code: Some("TEST".to_string()),
+            home_link: None,
+            wikipedia_link: None,
+            keywords: None,
+            location_id: Some(test_uuid), // This field must be present
+            distance_meters: Some(1000.0),
+        };
+
+        // If this compiles, all fields are present including location_id
+        // No assertion needed - this is a compile-time check
     }
 }

--- a/web/src/routes/aircraft/[id]/+page.svelte
+++ b/web/src/routes/aircraft/[id]/+page.svelte
@@ -167,7 +167,7 @@
 			const response = await serverCall<FixesResponse>(`/aircraft/${aircraftId}/fixes`, {
 				params: {
 					page,
-					perPage: 50,
+					perPage: 10,
 					after,
 					...(hideInactiveFixes && { active: true })
 				}
@@ -528,251 +528,6 @@
 					</div>
 				{/if}
 
-				<!-- Aircraft Registration -->
-				<div class="space-y-4 card p-6">
-					<h2 class="flex items-center gap-2 h2">
-						<Plane class="h-6 w-6" />
-						Aircraft Registration
-					</h2>
-
-					{#if aircraftRegistration}
-						<div class="space-y-3">
-							<!-- Registration Number -->
-							<div class="flex items-start gap-3">
-								<Info class="mt-1 h-4 w-4 text-surface-500" />
-								<div>
-									<p class="text-surface-600-300-token mb-1 text-sm">Registration Number</p>
-									<p class="font-mono font-semibold">
-										{aircraft.registration || aircraftRegistration.registrationNumber || 'Unknown'}
-									</p>
-								</div>
-							</div>
-
-							<!-- Serial Number -->
-							<div class="flex items-start gap-3">
-								<Info class="mt-1 h-4 w-4 text-surface-500" />
-								<div>
-									<p class="text-surface-600-300-token mb-1 text-sm">Serial Number</p>
-									<p class="font-mono">{aircraftRegistration.serialNumber}</p>
-								</div>
-							</div>
-
-							<!-- Manufacturer/Model/Series Codes -->
-							{#if aircraftRegistration.manufacturerCode || aircraftRegistration.modelCode || aircraftRegistration.seriesCode}
-								<div class="flex items-start gap-3">
-									<Info class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Manufacturer/Model/Series</p>
-										<p class="font-mono">
-											{[
-												aircraftRegistration.manufacturerCode,
-												aircraftRegistration.modelCode,
-												aircraftRegistration.seriesCode
-											]
-												.filter(Boolean)
-												.join('-')}
-										</p>
-									</div>
-								</div>
-							{/if}
-
-							<!-- Engine Codes -->
-							{#if aircraftRegistration.engineManufacturerCode || aircraftRegistration.engineModelCode}
-								<div class="flex items-start gap-3">
-									<Info class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Engine Manufacturer/Model</p>
-										<p class="font-mono">
-											{[
-												aircraftRegistration.engineManufacturerCode,
-												aircraftRegistration.engineModelCode
-											]
-												.filter(Boolean)
-												.join('-')}
-										</p>
-									</div>
-								</div>
-							{/if}
-
-							<!-- Year Manufactured -->
-							{#if aircraftRegistration.yearManufactured}
-								<div class="flex items-start gap-3">
-									<Calendar class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Year Manufactured</p>
-										<p>{aircraftRegistration.yearManufactured}</p>
-									</div>
-								</div>
-							{/if}
-
-							<!-- Aircraft Type -->
-							{#if aircraftRegistration.aircraftType}
-								<div class="flex items-start gap-3">
-									<Info class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Aircraft Type</p>
-										<p>{aircraftRegistration.aircraftType}</p>
-									</div>
-								</div>
-							{/if}
-
-							<!-- Engine Type -->
-							{#if aircraftRegistration.engineType}
-								<div class="flex items-start gap-3">
-									<Info class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Engine Type</p>
-										<p>{aircraftRegistration.engineType}</p>
-									</div>
-								</div>
-							{/if}
-
-							<!-- Registrant Name -->
-							{#if aircraftRegistration.registrantName}
-								<div class="flex items-start gap-3">
-									<User class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Owner</p>
-										<p>{aircraftRegistration.registrantName}</p>
-									</div>
-								</div>
-							{/if}
-
-							<!-- Registrant Type -->
-							{#if aircraftRegistration.registrantType}
-								<div class="flex items-start gap-3">
-									<Info class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Registrant Type</p>
-										<p>{aircraftRegistration.registrantType}</p>
-									</div>
-								</div>
-							{/if}
-
-							<!-- Status Code -->
-							{#if aircraftRegistration.statusCode}
-								<div class="flex items-start gap-3">
-									<Info class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Status</p>
-										<p>
-											{getStatusCodeDescription(aircraftRegistration.statusCode)}
-											<span class="ml-1 text-xs text-surface-500"
-												>({aircraftRegistration.statusCode})</span
-											>
-										</p>
-									</div>
-								</div>
-							{/if}
-
-							<!-- Transponder Code -->
-							{#if aircraftRegistration.transponderCode}
-								<div class="flex items-start gap-3">
-									<Info class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Transponder Code</p>
-										<p class="font-mono">
-											{formatTransponderCode(aircraftRegistration.transponderCode)}
-										</p>
-									</div>
-								</div>
-							{/if}
-
-							<!-- Airworthiness Class -->
-							{#if aircraftRegistration.airworthinessClass}
-								<div class="flex items-start gap-3">
-									<Info class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Airworthiness Class</p>
-										<p>{aircraftRegistration.airworthinessClass}</p>
-									</div>
-								</div>
-							{/if}
-
-							<!-- Airworthiness Date -->
-							{#if aircraftRegistration.airworthinessDate}
-								<div class="flex items-start gap-3">
-									<Calendar class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Airworthiness Date</p>
-										<p>{dayjs(aircraftRegistration.airworthinessDate).format('YYYY-MM-DD')}</p>
-									</div>
-								</div>
-							{/if}
-
-							<!-- Certificate Issue Date -->
-							{#if aircraftRegistration.certificateIssueDate}
-								<div class="flex items-start gap-3">
-									<Calendar class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Certificate Issue Date</p>
-										<p>
-											{dayjs(aircraftRegistration.certificateIssueDate).format('YYYY-MM-DD')}
-										</p>
-									</div>
-								</div>
-							{/if}
-
-							<!-- Expiration Date -->
-							{#if aircraftRegistration.expirationDate}
-								<div class="flex items-start gap-3">
-									<Calendar class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Expiration Date</p>
-										<p>{dayjs(aircraftRegistration.expirationDate).format('YYYY-MM-DD')}</p>
-									</div>
-								</div>
-							{/if}
-
-							<!-- Kit Manufacturer/Model -->
-							{#if aircraftRegistration.kitManufacturerName || aircraftRegistration.kitModelName}
-								<div class="flex items-start gap-3">
-									<Info class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Kit</p>
-										<p>
-											{[aircraftRegistration.kitManufacturerName, aircraftRegistration.kitModelName]
-												.filter(Boolean)
-												.join(' ')}
-										</p>
-									</div>
-								</div>
-							{/if}
-
-							<!-- Light Sport Type -->
-							{#if aircraftRegistration.lightSportType}
-								<div class="flex items-start gap-3">
-									<Info class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Light Sport Type</p>
-										<p>{aircraftRegistration.lightSportType}</p>
-									</div>
-								</div>
-							{/if}
-
-							<!-- Other Names -->
-							{#if aircraftRegistration.otherNames && aircraftRegistration.otherNames.length > 0}
-								<div class="flex items-start gap-3">
-									<Info class="mt-1 h-4 w-4 text-surface-500" />
-									<div>
-										<p class="text-surface-600-300-token mb-1 text-sm">Other Names</p>
-										<p>{aircraftRegistration.otherNames.join(', ')}</p>
-									</div>
-								</div>
-							{/if}
-						</div>
-					{:else}
-						<div class="text-surface-600-300-token py-8 text-center text-sm">
-							<Plane class="mx-auto mb-4 h-12 w-12 text-surface-400" />
-							<p>
-								No aircraft registration found for {aircraft.registration || 'Unknown'}
-								<br />
-								<i>Data is currently only available for aircraft registered in the USA</i>
-							</p>
-						</div>
-					{/if}
-				</div>
-
 				<!-- Aircraft Model Details -->
 				{#if aircraftModel}
 					<div class="space-y-4 card p-6">
@@ -960,6 +715,251 @@
 					{/if}
 				{/if}
 			</div>
+
+			<!-- Aircraft Registration -->
+			<div class="space-y-4 card p-6">
+				<h2 class="flex items-center gap-2 h2">
+					<Plane class="h-6 w-6" />
+					Aircraft Registration
+				</h2>
+
+				{#if aircraftRegistration}
+					<div class="space-y-3">
+						<!-- Registration Number -->
+						<div class="flex items-start gap-3">
+							<Info class="mt-1 h-4 w-4 text-surface-500" />
+							<div>
+								<p class="text-surface-600-300-token mb-1 text-sm">Registration Number</p>
+								<p class="font-mono font-semibold">
+									{aircraft.registration || aircraftRegistration.registrationNumber || 'Unknown'}
+								</p>
+							</div>
+						</div>
+
+						<!-- Serial Number -->
+						<div class="flex items-start gap-3">
+							<Info class="mt-1 h-4 w-4 text-surface-500" />
+							<div>
+								<p class="text-surface-600-300-token mb-1 text-sm">Serial Number</p>
+								<p class="font-mono">{aircraftRegistration.serialNumber}</p>
+							</div>
+						</div>
+
+						<!-- Manufacturer/Model/Series Codes -->
+						{#if aircraftRegistration.manufacturerCode || aircraftRegistration.modelCode || aircraftRegistration.seriesCode}
+							<div class="flex items-start gap-3">
+								<Info class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Manufacturer/Model/Series</p>
+									<p class="font-mono">
+										{[
+											aircraftRegistration.manufacturerCode,
+											aircraftRegistration.modelCode,
+											aircraftRegistration.seriesCode
+										]
+											.filter(Boolean)
+											.join('-')}
+									</p>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Engine Codes -->
+						{#if aircraftRegistration.engineManufacturerCode || aircraftRegistration.engineModelCode}
+							<div class="flex items-start gap-3">
+								<Info class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Engine Manufacturer/Model</p>
+									<p class="font-mono">
+										{[
+											aircraftRegistration.engineManufacturerCode,
+											aircraftRegistration.engineModelCode
+										]
+											.filter(Boolean)
+											.join('-')}
+									</p>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Year Manufactured -->
+						{#if aircraftRegistration.yearManufactured}
+							<div class="flex items-start gap-3">
+								<Calendar class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Year Manufactured</p>
+									<p>{aircraftRegistration.yearManufactured}</p>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Aircraft Type -->
+						{#if aircraftRegistration.aircraftType}
+							<div class="flex items-start gap-3">
+								<Info class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Aircraft Type</p>
+									<p>{aircraftRegistration.aircraftType}</p>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Engine Type -->
+						{#if aircraftRegistration.engineType}
+							<div class="flex items-start gap-3">
+								<Info class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Engine Type</p>
+									<p>{aircraftRegistration.engineType}</p>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Registrant Name -->
+						{#if aircraftRegistration.registrantName}
+							<div class="flex items-start gap-3">
+								<User class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Owner</p>
+									<p>{aircraftRegistration.registrantName}</p>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Registrant Type -->
+						{#if aircraftRegistration.registrantType}
+							<div class="flex items-start gap-3">
+								<Info class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Registrant Type</p>
+									<p>{aircraftRegistration.registrantType}</p>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Status Code -->
+						{#if aircraftRegistration.statusCode}
+							<div class="flex items-start gap-3">
+								<Info class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Status</p>
+									<p>
+										{getStatusCodeDescription(aircraftRegistration.statusCode)}
+										<span class="ml-1 text-xs text-surface-500"
+											>({aircraftRegistration.statusCode})</span
+										>
+									</p>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Transponder Code -->
+						{#if aircraftRegistration.transponderCode}
+							<div class="flex items-start gap-3">
+								<Info class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Transponder Code</p>
+									<p class="font-mono">
+										{formatTransponderCode(aircraftRegistration.transponderCode)}
+									</p>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Airworthiness Class -->
+						{#if aircraftRegistration.airworthinessClass}
+							<div class="flex items-start gap-3">
+								<Info class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Airworthiness Class</p>
+									<p>{aircraftRegistration.airworthinessClass}</p>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Airworthiness Date -->
+						{#if aircraftRegistration.airworthinessDate}
+							<div class="flex items-start gap-3">
+								<Calendar class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Airworthiness Date</p>
+									<p>{dayjs(aircraftRegistration.airworthinessDate).format('YYYY-MM-DD')}</p>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Certificate Issue Date -->
+						{#if aircraftRegistration.certificateIssueDate}
+							<div class="flex items-start gap-3">
+								<Calendar class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Certificate Issue Date</p>
+									<p>
+										{dayjs(aircraftRegistration.certificateIssueDate).format('YYYY-MM-DD')}
+									</p>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Expiration Date -->
+						{#if aircraftRegistration.expirationDate}
+							<div class="flex items-start gap-3">
+								<Calendar class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Expiration Date</p>
+									<p>{dayjs(aircraftRegistration.expirationDate).format('YYYY-MM-DD')}</p>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Kit Manufacturer/Model -->
+						{#if aircraftRegistration.kitManufacturerName || aircraftRegistration.kitModelName}
+							<div class="flex items-start gap-3">
+								<Info class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Kit</p>
+									<p>
+										{[aircraftRegistration.kitManufacturerName, aircraftRegistration.kitModelName]
+											.filter(Boolean)
+											.join(' ')}
+									</p>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Light Sport Type -->
+						{#if aircraftRegistration.lightSportType}
+							<div class="flex items-start gap-3">
+								<Info class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Light Sport Type</p>
+									<p>{aircraftRegistration.lightSportType}</p>
+								</div>
+							</div>
+						{/if}
+
+						<!-- Other Names -->
+						{#if aircraftRegistration.otherNames && aircraftRegistration.otherNames.length > 0}
+							<div class="flex items-start gap-3">
+								<Info class="mt-1 h-4 w-4 text-surface-500" />
+								<div>
+									<p class="text-surface-600-300-token mb-1 text-sm">Other Names</p>
+									<p>{aircraftRegistration.otherNames.join(', ')}</p>
+								</div>
+							</div>
+						{/if}
+					</div>
+				{:else}
+					<div class="text-surface-600-300-token py-4 text-center text-xs">
+						<p>
+							No registration data found
+							<br />
+							<i>(Data currently only available for USA-registered aircraft)</i>
+						</p>
+					</div>
+				{/if}
+			</div>
+
 			<!-- Position Fixes Section -->
 			<div class="space-y-4 card p-6">
 				<h2 class="flex items-center gap-2 h2">


### PR DESCRIPTION
## Summary
This PR adds pagination to the receiver list page and makes several improvements to the aircraft detail page layout and functionality.

## Changes

### Receiver List Pagination
- **Backend**: Added pagination parameters (`page`, `per_page`) to all receiver search endpoints
- **Backend**: Implemented paginated repository methods for all search types:
  - `search_by_query_paginated`
  - `get_receivers_within_radius_paginated`
  - `get_receivers_in_bounding_box_paginated`
  - `search_by_callsign_paginated`
  - `get_receivers_with_coordinates_paginated`
- **Backend**: All endpoints now return `PaginatedDataResponse` with metadata (page, totalPages, totalCount)
- **Backend**: Default 100 items per page, clamped between 1-100
- **Frontend**: Added pagination state and UI controls (50 items per page)
- **Frontend**: Pagination controls at top and bottom of results list
- **Frontend**: Display total count in results header

### Aircraft Detail Page Improvements
- **Position Fixes**: Reduced default per page from 50 to 10 for better performance
- **Registration Section**: 
  - Shrunk "no data" message (removed large icon, smaller text)
  - Moved entire section to appear after Flight History and before Position Fixes
  - Better page flow and organization

### Bug Fixes
- **Airports**: Fixed missing `location_id` column in `get_airports_in_bounding_box` SQL query
- **Testing**: Added compile-time test `test_airport_with_distance_has_location_id()` to prevent future column omissions

## Test Plan
- [x] Backend builds successfully
- [x] All clippy checks pass
- [x] All pre-commit hooks pass
- [x] Pagination controls work on receiver list page
- [x] Search functionality maintains pagination state
- [x] Aircraft detail page shows 10 fixes by default
- [x] Registration section appears in correct position
- [x] Airport bounding box query includes location_id