### PR TITLE
fix: rename counter metrics to follow Prometheus conventions and fix Grafana dashboards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,12 @@ SOAR is a comprehensive aircraft tracking and club management system built with:
 - Always prefer Diesel's query builder and type-safe methods over raw SQL
 - **NEVER use CREATE INDEX CONCURRENTLY in Diesel migrations** - Diesel migrations run in transactions, which don't support CONCURRENTLY. Use regular CREATE INDEX instead
 
-### SERVER ACCESS
+### SERVER ACCESS AND DEPLOYMENT
 - You are running on the staging server. The staging server is named "supervillain". You can always run commands that do not modify anything. Ask before running commands that modify something.
 - You have access to the production server by running "ssh glider.flights". The user you are running as already has "sudo" access. Ask before connecting or using sudo unless I give you permission in advance.
+- **NEVER attempt to deploy or restart services without explicit instructions** - Only build/check code, do not deploy
+- **Use `cargo check` for validation** - Do not run deployment scripts or restart systemd services unless instructed
+- **Ask before any service modifications** - This includes systemctl restart, deployment scripts, or copying binaries to production locations
 
 ### DATABASE SAFETY RULES (CRITICAL)
 - **Development Database**: `soar_dev` - This is where you work

--- a/infrastructure/grafana-dashboard-analytics.json
+++ b/infrastructure/grafana-dashboard-analytics.json
@@ -370,7 +370,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT\n  hour as time,\n  flight_count as \"Flights\",\n  active_devices as \"Active Devices\",\n  active_clubs as \"Active Clubs\"\nFROM flight_analytics_hourly\nWHERE hour >= NOW() - INTERVAL '48 hours'\nORDER BY hour ASC",
+          "rawSql": "SELECT\n  hour as time,\n  flight_count as \"Flights\",\n  active_devices as \"Active Devices\",\n  active_clubs as \"Active Clubs\"\nFROM flight_analytics_hourly\nWHERE hour >= NOW() - INTERVAL '30 days'\nORDER BY hour ASC",
           "refId": "A",
           "sql": {
             "columns": [],
@@ -379,7 +379,7 @@
           }
         }
       ],
-      "title": "Hourly Flight Activity (Last 48 Hours)",
+      "title": "Hourly Flight Activity (Last 30 Days)",
       "type": "timeseries"
     },
     {

--- a/infrastructure/grafana-dashboard-coverage.json
+++ b/infrastructure/grafana-dashboard-coverage.json
@@ -106,7 +106,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(coverage_api_hexes_requests_total[5m])",
+          "expr": "rate(coverage_api_hexes_requests_total_total[5m])",
           "refId": "A",
           "legendFormat": "API Requests"
         },
@@ -115,7 +115,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(coverage_api_hexes_success_total[5m])",
+          "expr": "rate(coverage_api_hexes_success_total_total[5m])",
           "refId": "B",
           "legendFormat": "Successful Requests"
         },
@@ -124,7 +124,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(coverage_api_errors_total[5m])",
+          "expr": "rate(coverage_api_errors_total_total[5m])",
           "refId": "C",
           "legendFormat": "Errors"
         }
@@ -247,7 +247,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(coverage_cache_hit_total[5m])",
+          "expr": "rate(coverage_cache_hit_total_total[5m])",
           "refId": "A",
           "legendFormat": "Cache Hits"
         },
@@ -256,7 +256,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(coverage_cache_miss_total[5m])",
+          "expr": "rate(coverage_cache_miss_total_total[5m])",
           "refId": "B",
           "legendFormat": "Cache Misses"
         }
@@ -555,7 +555,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "100 * rate(coverage_cache_hit_total[5m]) / (rate(coverage_cache_hit_total[5m]) + rate(coverage_cache_miss_total[5m]))",
+          "expr": "100 * rate(coverage_cache_hit_total_total[5m]) / (rate(coverage_cache_hit_total_total[5m]) + rate(coverage_cache_miss_total_total[5m]))",
           "refId": "A"
         }
       ],
@@ -623,7 +623,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(coverage_api_errors_total[5m])",
+          "expr": "rate(coverage_api_errors_total_total[5m])",
           "refId": "A"
         }
       ],

--- a/infrastructure/grafana-dashboard-ingest-adsb.json
+++ b/infrastructure/grafana-dashboard-ingest-adsb.json
@@ -451,7 +451,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "beast_connection_established{component=\"ingest-adsb\"}",
+          "expr": "beast_connection_established_total{component=\"ingest-adsb\"}",
           "legendFormat": "Established",
           "range": true,
           "refId": "A"
@@ -462,7 +462,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "beast_connection_failed{component=\"ingest-adsb\"}",
+          "expr": "beast_connection_failed_total{component=\"ingest-adsb\"}",
           "legendFormat": "Failed",
           "range": true,
           "refId": "B"
@@ -473,7 +473,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "beast_timeout{component=\"ingest-adsb\"}",
+          "expr": "beast_timeout_total{component=\"ingest-adsb\"}",
           "legendFormat": "Timeout",
           "range": true,
           "refId": "C"
@@ -571,7 +571,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(beast_bytes_received{component=\"ingest-adsb\"}[1m])",
+          "expr": "rate(beast_bytes_received_total{component=\"ingest-adsb\"}[1m])",
           "legendFormat": "Bytes/sec",
           "range": true,
           "refId": "A"
@@ -765,7 +765,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "beast_frames_published{component=\"ingest-adsb\"}",
+          "expr": "beast_frames_published_total{component=\"ingest-adsb\"}",
           "legendFormat": "Published",
           "range": true,
           "refId": "A"
@@ -776,7 +776,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "beast_frames_dropped{component=\"ingest-adsb\"}",
+          "expr": "beast_frames_dropped_total{component=\"ingest-adsb\"}",
           "legendFormat": "Dropped",
           "range": true,
           "refId": "B"

--- a/infrastructure/grafana-dashboard-ingest-ogn.json
+++ b/infrastructure/grafana-dashboard-ingest-ogn.json
@@ -451,7 +451,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "aprs_connection_established{component=\"ingest-ogn\"}",
+          "expr": "aprs_connection_established_total{component=\"ingest-ogn\"}",
           "legendFormat": "Established",
           "range": true,
           "refId": "A"
@@ -462,7 +462,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "aprs_connection_failed{component=\"ingest-ogn\"}",
+          "expr": "aprs_connection_failed_total{component=\"ingest-ogn\"}",
           "legendFormat": "Failed",
           "range": true,
           "refId": "B"
@@ -473,7 +473,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "aprs_connection_ended{component=\"ingest-ogn\"}",
+          "expr": "aprs_connection_ended_total{component=\"ingest-ogn\"}",
           "legendFormat": "Ended",
           "range": true,
           "refId": "C"
@@ -570,7 +570,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_keepalive_sent{component=\"ingest-ogn\"}[1m]) * 60",
+          "expr": "rate(aprs_keepalive_sent_total{component=\"ingest-ogn\"}[1m]) * 60",
           "legendFormat": "Keepalive Messages/min",
           "range": true,
           "refId": "A"
@@ -667,8 +667,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(rate(aprs_connection_operation_failed{component=\"ingest-ogn\",environment=~\"$environment\"}[1m]) or vector(0))",
-          "legendFormat": "Connection Operation Failed",
+          "expr": "(rate(aprs_connection_failed_total{component=\"ingest-ogn\",environment=~\"$environment\"}[1m]) or vector(0)) * 60",
+          "legendFormat": "Connection Failed/min",
           "range": true,
           "refId": "A"
         },
@@ -678,8 +678,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(rate(aprs_connection_operation_failed{component=\"ingest-ogn\",environment=~\"$environment\"}[1m]) or vector(0))",
-          "legendFormat": "Connection Operation Failed",
+          "expr": "(rate(aprs_connection_operation_failed_total{component=\"ingest-ogn\",environment=~\"$environment\"}[1m]) or vector(0)) * 60",
+          "legendFormat": "Connection Operation Failed/min",
           "range": true,
           "refId": "B"
         },
@@ -689,8 +689,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(rate(aprs_connection_operation_failed{component=\"ingest-ogn\",environment=~\"$environment\"}[1m]) or vector(0))",
-          "legendFormat": "Connection Operation Failed",
+          "expr": "(rate(aprs_nats_publish_error_total{component=\"ingest-ogn\",environment=~\"$environment\"}[1m]) or vector(0)) * 60",
+          "legendFormat": "NATS Publish Errors/min",
           "range": true,
           "refId": "C"
         },
@@ -700,8 +700,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(rate(aprs_connection_operation_failed{component=\"ingest-ogn\",environment=~\"$environment\"}[1m]) or vector(0))",
-          "legendFormat": "Connection Operation Failed",
+          "expr": "(rate(aprs_nats_connection_failed_total{component=\"ingest-ogn\",environment=~\"$environment\"}[1m]) or vector(0)) * 60",
+          "legendFormat": "NATS Connection Failed/min",
           "range": true,
           "refId": "D"
         }
@@ -810,7 +810,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_raw_message_received_server{component=\"ingest-ogn\"}[1m]) * 60",
+          "expr": "rate(aprs_raw_message_received_server_total{component=\"ingest-ogn\"}[1m]) * 60",
           "legendFormat": "Server Messages/min",
           "range": true,
           "refId": "A"
@@ -821,7 +821,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_raw_message_received_aprs{component=\"ingest-ogn\"}[1m]) * 60",
+          "expr": "rate(aprs_raw_message_received_aprs_total{component=\"ingest-ogn\"}[1m]) * 60",
           "legendFormat": "APRS Messages/min",
           "range": true,
           "refId": "B"
@@ -918,7 +918,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_raw_message_queued_server{component=\"ingest-ogn\"}[1m]) * 60",
+          "expr": "rate(aprs_raw_message_queued_server_total{component=\"ingest-ogn\"}[1m]) * 60",
           "legendFormat": "Server Messages/min",
           "range": true,
           "refId": "A"
@@ -929,7 +929,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_raw_message_queued_aprs{component=\"ingest-ogn\"}[1m]) * 60",
+          "expr": "rate(aprs_raw_message_queued_aprs_total{component=\"ingest-ogn\"}[1m]) * 60",
           "legendFormat": "APRS Messages/min",
           "range": true,
           "refId": "B"
@@ -1039,7 +1039,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_nats_published{component=\"ingest-ogn\"}[1m]) * 60",
+          "expr": "rate(aprs_nats_published_total{component=\"ingest-ogn\"}[1m]) * 60",
           "legendFormat": "Messages/min",
           "range": true,
           "refId": "A"
@@ -1136,7 +1136,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(rate(aprs_nats_publish_error{component=\"ingest-ogn\",environment=~\"$environment\"}[1m]) or vector(0))",
+          "expr": "(rate(aprs_nats_publish_error_total{component=\"ingest-ogn\",environment=~\"$environment\"}[1m]) or vector(0))",
           "legendFormat": "Publish Errors",
           "range": true,
           "refId": "A"
@@ -1208,7 +1208,7 @@
         "x": 0,
         "y": 84
       },
-      "id": 100,
+      "id": 112,
       "options": {
         "legend": {
           "calcs": [
@@ -1344,7 +1344,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "(rate(aprs_nats_slow_publish{component=\"ingest-ogn\",environment=~\"$environment\"}[1m]) or vector(0)) * 60",
+          "expr": "(rate(aprs_nats_slow_publish_total{component=\"ingest-ogn\",environment=~\"$environment\"}[1m]) or vector(0)) * 60",
           "legendFormat": "Slow Publishes (>100ms)",
           "refId": "A"
         }

--- a/infrastructure/grafana-dashboard-nats.json
+++ b/infrastructure/grafana-dashboard-nats.json
@@ -118,7 +118,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_nats_published{component=\"ingest-ogn\",environment=\"$environment\"}[1m])",
+          "expr": "rate(aprs_nats_published_total{component=\"ingest-ogn\",environment=\"$environment\"}[1m])",
           "legendFormat": "Raw APRS Messages Published",
           "range": true,
           "refId": "A"
@@ -129,7 +129,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(nats_publisher_fixes_published{component=\"run\",environment=\"$environment\"}[1m])",
+          "expr": "rate(nats_publisher_fixes_published_total{component=\"run\",environment=\"$environment\"}[1m])",
           "legendFormat": "Processed Fixes Published",
           "range": true,
           "refId": "B"
@@ -226,7 +226,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_nats_publish_error{component=\"ingest-ogn\",environment=\"$environment\"}[1m])",
+          "expr": "rate(aprs_nats_publish_error_total{component=\"ingest-ogn\",environment=\"$environment\"}[1m])",
           "legendFormat": "Ingest-OGN Publish Errors",
           "range": true,
           "refId": "A"
@@ -237,7 +237,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(nats_publisher_errors{component=\"run\",environment=\"$environment\"}[1m])",
+          "expr": "rate(nats_publisher_errors_total{component=\"run\",environment=\"$environment\"}[1m])",
           "legendFormat": "Run Publisher Errors",
           "range": true,
           "refId": "B"
@@ -505,7 +505,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(increase(aprs_nats_published{component=\"ingest-ogn\",environment=\"$environment\"}[1h]))",
+          "expr": "sum(increase(aprs_nats_published_total{component=\"ingest-ogn\",environment=\"$environment\"}[1h]))",
           "legendFormat": "Last Hour",
           "range": true,
           "refId": "A"
@@ -568,7 +568,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(increase(nats_publisher_fixes_published{component=\"run\",environment=\"$environment\"}[1h]))",
+          "expr": "sum(increase(nats_publisher_fixes_published_total{component=\"run\",environment=\"$environment\"}[1h]))",
           "legendFormat": "Last Hour",
           "range": true,
           "refId": "A"
@@ -646,7 +646,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(increase(aprs_nats_publish_error{component=\"ingest-ogn\",environment=\"$environment\"}[1h])) + sum(increase(nats_publisher_errors{component=\"run\",environment=\"$environment\"}[1h]))",
+          "expr": "sum(increase(aprs_nats_publish_error_total{component=\"ingest-ogn\",environment=\"$environment\"}[1h])) + sum(increase(nats_publisher_errors_total{component=\"run\",environment=\"$environment\"}[1h]))",
           "legendFormat": "Total Errors",
           "range": true,
           "refId": "A"
@@ -723,7 +723,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "SOAR NATS Performance",
+  "title": "SOAR - NATS Infrastructure",
   "uid": "soar-nats",
   "version": 1
 }

--- a/infrastructure/grafana-dashboard-run-core.json
+++ b/infrastructure/grafana-dashboard-run-core.json
@@ -420,7 +420,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_aircraft_processed{component=\"run\",environment=\"$environment\"}[1m])",
+          "expr": "rate(aprs_aircraft_processed_total{component=\"run\",environment=\"$environment\"}[1m])",
           "legendFormat": "Aircraft Enqueued",
           "range": true,
           "refId": "A"
@@ -431,7 +431,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_receiver_status_processed{component=\"run\",environment=\"$environment\"}[1m])",
+          "expr": "rate(aprs_receiver_status_processed_total{component=\"run\",environment=\"$environment\"}[1m])",
           "legendFormat": "Receiver Status Enqueued",
           "range": true,
           "refId": "B"
@@ -442,7 +442,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_receiver_position_processed{component=\"run\",environment=\"$environment\"}[1m])",
+          "expr": "rate(aprs_receiver_position_processed_total{component=\"run\",environment=\"$environment\"}[1m])",
           "legendFormat": "Receiver Position Enqueued",
           "range": true,
           "refId": "C"
@@ -453,7 +453,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_server_status_processed{component=\"run\",environment=\"$environment\"}[1m])",
+          "expr": "rate(aprs_server_status_processed_total{component=\"run\",environment=\"$environment\"}[1m])",
           "legendFormat": "Server Status Enqueued",
           "range": true,
           "refId": "D"
@@ -464,7 +464,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_raw_message_queue_full{component=\"run\",environment=\"$environment\"}[1m]) + rate(aprs_aircraft_queue_full{component=\"run\",environment=\"$environment\"}[1m]) + rate(aprs_receiver_status_queue_full{component=\"run\",environment=\"$environment\"}[1m]) + rate(aprs_receiver_position_queue_full{component=\"run\",environment=\"$environment\"}[1m]) + rate(aprs_server_status_queue_full{component=\"run\",environment=\"$environment\"}[1m])",
+          "expr": "rate(aprs_raw_message_queue_full_total{component=\"run\",environment=\"$environment\"}[1m]) + rate(aprs_aircraft_queue_full_total{component=\"run\",environment=\"$environment\"}[1m]) + rate(aprs_receiver_status_queue_full_total{component=\"run\",environment=\"$environment\"}[1m]) + rate(aprs_receiver_position_queue_full_total{component=\"run\",environment=\"$environment\"}[1m]) + rate(aprs_server_status_queue_full_total{component=\"run\",environment=\"$environment\"}[1m])",
           "legendFormat": "Total Dropped",
           "range": true,
           "refId": "E"
@@ -475,7 +475,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_aircraft_queue_full{component=\"run\",environment=\"$environment\"}[1m])",
+          "expr": "rate(aprs_aircraft_queue_full_total{component=\"run\",environment=\"$environment\"}[1m])",
           "legendFormat": "Aircraft Dropped",
           "range": true,
           "refId": "F"
@@ -486,7 +486,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_receiver_status_queue_full{component=\"run\",environment=\"$environment\"}[1m])",
+          "expr": "rate(aprs_receiver_status_queue_full_total{component=\"run\",environment=\"$environment\"}[1m])",
           "legendFormat": "Receiver Status Dropped",
           "range": true,
           "refId": "G"
@@ -497,7 +497,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_receiver_position_queue_full{component=\"run\",environment=\"$environment\"}[1m])",
+          "expr": "rate(aprs_receiver_position_queue_full_total{component=\"run\",environment=\"$environment\"}[1m])",
           "legendFormat": "Receiver Position Dropped",
           "range": true,
           "refId": "H"
@@ -508,7 +508,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_server_status_queue_full{component=\"run\",environment=\"$environment\"}[1m])",
+          "expr": "rate(aprs_server_status_queue_full_total{component=\"run\",environment=\"$environment\"}[1m])",
           "legendFormat": "Server Status Dropped",
           "range": true,
           "refId": "I"
@@ -519,7 +519,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_raw_message_queue_full{component=\"run\",environment=\"$environment\"}[1m])",
+          "expr": "rate(aprs_raw_message_queue_full_total{component=\"run\",environment=\"$environment\"}[1m])",
           "legendFormat": "Raw Message Queue Dropped",
           "range": true,
           "refId": "J"
@@ -647,7 +647,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(nats_publisher_fixes_published{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(nats_publisher_fixes_published_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Published/sec",
           "range": true,
           "refId": "A"
@@ -658,7 +658,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(nats_publisher_errors{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "(rate(nats_publisher_errors_total{component=\"run\",environment=\"$environment\"}[5m]) or vector(0))",
           "legendFormat": "Errors/sec",
           "range": true,
           "refId": "C"
@@ -1405,7 +1405,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_aircraft_queue_closed{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_aircraft_queue_closed_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Aircraft Queue Closed",
           "range": true,
           "refId": "A"
@@ -1416,7 +1416,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_receiver_status_queue_closed{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_receiver_status_queue_closed_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Receiver Status Queue Closed",
           "range": true,
           "refId": "B"
@@ -1427,7 +1427,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_receiver_position_queue_closed{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_receiver_position_queue_closed_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Receiver Position Queue Closed",
           "range": true,
           "refId": "C"
@@ -1438,7 +1438,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_server_status_queue_closed{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_server_status_queue_closed_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Server Status Queue Closed",
           "range": true,
           "refId": "D"

--- a/infrastructure/grafana-dashboard-run-elevation.json
+++ b/infrastructure/grafana-dashboard-run-elevation.json
@@ -170,7 +170,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_elevation_sync_processed{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_elevation_sync_processed_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Sync Processed/sec",
           "range": true,
           "refId": "A"
@@ -181,7 +181,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(aprs_elevation_processed{component=\"run\",environment=\"$environment\"}[5m]))",
+          "expr": "sum(rate(aprs_elevation_processed_total{component=\"run\",environment=\"$environment\"}[5m]))",
           "legendFormat": "Async Processed/sec",
           "range": true,
           "refId": "B"
@@ -192,7 +192,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_elevation_queued{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_elevation_queued_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Async Queued/sec",
           "range": true,
           "refId": "C"
@@ -203,7 +203,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_elevation_channel_closed{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_elevation_channel_closed_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Async Channel Closed Errors/sec",
           "range": true,
           "refId": "E"
@@ -456,7 +456,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(elevation_cache_hits{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(elevation_cache_hits_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Hits/sec",
           "range": true,
           "refId": "A"
@@ -467,7 +467,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(elevation_cache_misses{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(elevation_cache_misses_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Misses/sec",
           "range": true,
           "refId": "B"
@@ -540,7 +540,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(elevation_cache_hits{component=\"run\",environment=\"$environment\"}[5m]) / (rate(elevation_cache_hits{component=\"run\",environment=\"$environment\"}[5m]) + rate(elevation_cache_misses{component=\"run\",environment=\"$environment\"}[5m]))",
+          "expr": "rate(elevation_cache_hits_total{component=\"run\",environment=\"$environment\"}[5m]) / (rate(elevation_cache_hits_total{component=\"run\",environment=\"$environment\"}[5m]) + rate(elevation_cache_misses_total{component=\"run\",environment=\"$environment\"}[5m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -712,7 +712,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(elevation_tile_cache_hits{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(elevation_tile_cache_hits_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Hits/sec",
           "range": true,
           "refId": "A"
@@ -723,7 +723,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(elevation_tile_cache_misses{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(elevation_tile_cache_misses_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Misses/sec",
           "range": true,
           "refId": "B"
@@ -796,7 +796,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(elevation_tile_cache_hits{component=\"run\",environment=\"$environment\"}[5m]) / (rate(elevation_tile_cache_hits{component=\"run\",environment=\"$environment\"}[5m]) + rate(elevation_tile_cache_misses{component=\"run\",environment=\"$environment\"}[5m]))",
+          "expr": "rate(elevation_tile_cache_hits_total{component=\"run\",environment=\"$environment\"}[5m]) / (rate(elevation_tile_cache_hits_total{component=\"run\",environment=\"$environment\"}[5m]) + rate(elevation_tile_cache_misses_total{component=\"run\",environment=\"$environment\"}[5m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -984,7 +984,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(receiver_repo_latest_packet_at_skipped{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(receiver_repo_latest_packet_at_skipped_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Updates Skipped (Cached)",
           "range": true,
           "refId": "A"
@@ -995,7 +995,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(receiver_repo_latest_packet_at_updated{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(receiver_repo_latest_packet_at_updated_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Database Updates",
           "range": true,
           "refId": "B"

--- a/infrastructure/grafana-dashboard-run-flights.json
+++ b/infrastructure/grafana-dashboard-run-flights.json
@@ -197,7 +197,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_timeouts_detected{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(flight_tracker_timeouts_detected_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Timeouts/sec",
           "range": true,
           "refId": "A"
@@ -296,7 +296,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_flight_ended_landed{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(flight_tracker_flight_ended_landed_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Landed",
           "range": true,
           "refId": "A"
@@ -307,7 +307,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_flight_ended_timed_out{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(flight_tracker_flight_ended_timed_out_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Timed Out",
           "range": true,
           "refId": "B"
@@ -410,7 +410,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_coalesce_resumed{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(flight_tracker_coalesce_resumed_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "Resumed",
           "range": true,
           "refId": "A"
@@ -421,7 +421,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_coalesce_callsign_mismatch{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(flight_tracker_coalesce_callsign_mismatch_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "Callsign Mismatch",
           "range": true,
           "refId": "B"
@@ -432,7 +432,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_coalesce_no_timeout_flight{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(flight_tracker_coalesce_no_timeout_flight_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "No Timeout Flight",
           "range": true,
           "refId": "C"
@@ -443,7 +443,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_coalesce_rejected_callsign{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(flight_tracker_coalesce_rejected_callsign_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "Rejected: Callsign",
           "range": true,
           "refId": "D"
@@ -454,7 +454,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_coalesce_rejected_probable_landing{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(flight_tracker_coalesce_rejected_probable_landing_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "Rejected: Probable Landing",
           "range": true,
           "refId": "E"
@@ -545,7 +545,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "flight_tracker_coalesce_resumed_distance_km{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
+          "expr": "flight_tracker_coalesce_resumed_total_distance_km{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "Resumed Distance (km)",
           "range": true,
           "refId": "A"
@@ -556,7 +556,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "flight_tracker_coalesce_resumed_distance_km{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
+          "expr": "flight_tracker_coalesce_resumed_total_distance_km{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "Rejected Distance (km)",
           "range": true,
           "refId": "B"
@@ -647,7 +647,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_timeout_phase{component=\"run\",environment=\"$environment\",phase=\"climbing\"}[$__rate_interval])",
+          "expr": "rate(flight_tracker_timeout_phase_total{component=\"run\",environment=\"$environment\",phase=\"climbing\"}[$__rate_interval])",
           "legendFormat": "Climbing",
           "range": true,
           "refId": "A"
@@ -658,7 +658,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_timeout_phase{component=\"run\",environment=\"$environment\",phase=\"cruising\"}[$__rate_interval])",
+          "expr": "rate(flight_tracker_timeout_phase_total{component=\"run\",environment=\"$environment\",phase=\"cruising\"}[$__rate_interval])",
           "legendFormat": "Cruising",
           "range": true,
           "refId": "B"
@@ -669,7 +669,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_timeout_phase{component=\"run\",environment=\"$environment\",phase=\"descending\"}[$__rate_interval])",
+          "expr": "rate(flight_tracker_timeout_phase_total{component=\"run\",environment=\"$environment\",phase=\"descending\"}[$__rate_interval])",
           "legendFormat": "Descending",
           "range": true,
           "refId": "C"
@@ -680,7 +680,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_timeout_phase{component=\"run\",environment=\"$environment\",phase=\"unknown\"}[$__rate_interval])",
+          "expr": "rate(flight_tracker_timeout_phase_total{component=\"run\",environment=\"$environment\",phase=\"unknown\"}[$__rate_interval])",
           "legendFormat": "Unknown",
           "range": true,
           "refId": "D"
@@ -689,118 +689,6 @@
       "title": "Flight Timeouts by Phase",
       "type": "timeseries",
       "id": 8
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "x": 0,
-        "y": 50,
-        "w": 24,
-        "h": 1
-      },
-      "id": 9,
-      "panels": [],
-      "title": "SOAR Run - Receiver Status",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 51,
-        "w": 24,
-        "h": 8
-      },
-      "id": 10,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "12.2.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(receiver_status_updates_total{component=\"run\",environment=\"$environment\"}[5m])",
-          "legendFormat": "Status Updates/sec",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Receiver Status Updates",
-      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/infrastructure/grafana-dashboard-run-geocoding.json
+++ b/infrastructure/grafana-dashboard-run-geocoding.json
@@ -100,7 +100,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_location_pelias_success_total{component=\"run\",environment=\"$environment\"}[5m]) / (rate(flight_tracker_location_pelias_success_total{component=\"run\",environment=\"$environment\"}[5m]) + rate(flight_tracker_location_pelias_failure_total{component=\"run\",environment=\"$environment\"}[5m]))",
+          "expr": "rate(flight_tracker_location_pelias_success_total_total{component=\"run\",environment=\"$environment\"}[5m]) / (rate(flight_tracker_location_pelias_success_total_total{component=\"run\",environment=\"$environment\"}[5m]) + rate(flight_tracker_location_pelias_failure_total_total{component=\"run\",environment=\"$environment\"}[5m]))",
           "legendFormat": "Success Rate",
           "range": true,
           "refId": "A"
@@ -175,7 +175,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_location_pelias_no_structured_data_total{component=\"run\",environment=\"$environment\"}[5m]) / rate(flight_tracker_location_pelias_success_total{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(flight_tracker_location_pelias_no_structured_data_total_total{component=\"run\",environment=\"$environment\"}[5m]) / rate(flight_tracker_location_pelias_success_total_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "No Structured Data Rate",
           "range": true,
           "refId": "A"
@@ -299,7 +299,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_location_pelias_success_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(flight_tracker_location_pelias_success_total_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "Success",
           "range": true,
           "refId": "A"
@@ -310,7 +310,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_location_pelias_failure_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(flight_tracker_location_pelias_failure_total_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "Failures",
           "range": true,
           "refId": "B"
@@ -523,7 +523,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_location_created_total{component=\"run\",environment=\"$environment\",type=\"start_takeoff\"}[$__rate_interval])",
+          "expr": "rate(flight_tracker_location_created_total_total{component=\"run\",environment=\"$environment\",type=\"start_takeoff\"}[$__rate_interval])",
           "legendFormat": "Start (Takeoff)",
           "range": true,
           "refId": "A"
@@ -534,7 +534,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_location_created_total{component=\"run\",environment=\"$environment\",type=\"start_airborne\"}[$__rate_interval])",
+          "expr": "rate(flight_tracker_location_created_total_total{component=\"run\",environment=\"$environment\",type=\"start_airborne\"}[$__rate_interval])",
           "legendFormat": "Start (Airborne)",
           "range": true,
           "refId": "B"
@@ -545,7 +545,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_location_created_total{component=\"run\",environment=\"$environment\",type=\"end_landing\"}[$__rate_interval])",
+          "expr": "rate(flight_tracker_location_created_total_total{component=\"run\",environment=\"$environment\",type=\"end_landing\"}[$__rate_interval])",
           "legendFormat": "End (Landing)",
           "range": true,
           "refId": "C"
@@ -556,7 +556,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_location_created_total{component=\"run\",environment=\"$environment\",type=\"end_timeout\"}[$__rate_interval])",
+          "expr": "rate(flight_tracker_location_created_total_total{component=\"run\",environment=\"$environment\",type=\"end_timeout\"}[$__rate_interval])",
           "legendFormat": "End (Timeout)",
           "range": true,
           "refId": "D"

--- a/infrastructure/grafana-dashboard-run-ingestion.json
+++ b/infrastructure/grafana-dashboard-run-ingestion.json
@@ -122,7 +122,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_type_received{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_type_received_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "{{type}}",
           "range": true,
           "refId": "A"
@@ -195,7 +195,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(generic_processor_receiver_cache_hit{component=\"run\",environment=\"$environment\"}[5m]) / (rate(generic_processor_receiver_cache_hit{component=\"run\",environment=\"$environment\"}[5m]) + rate(generic_processor_receiver_cache_miss{component=\"run\",environment=\"$environment\"}[5m]))",
+          "expr": "rate(generic_processor_receiver_cache_hit_total{component=\"run\",environment=\"$environment\"}[5m]) / (rate(generic_processor_receiver_cache_hit_total{component=\"run\",environment=\"$environment\"}[5m]) + rate(generic_processor_receiver_cache_miss_total{component=\"run\",environment=\"$environment\"}[5m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -294,7 +294,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(generic_processor_receiver_cache_hit{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(generic_processor_receiver_cache_hit_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Hits/sec",
           "range": true,
           "refId": "A"
@@ -305,7 +305,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(generic_processor_receiver_cache_miss{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(generic_processor_receiver_cache_miss_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Misses/sec",
           "range": true,
           "refId": "B"
@@ -417,7 +417,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(beast_run_nats_consumed{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(beast_run_nats_consumed_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Beast Messages Consumed/sec",
           "range": true,
           "refId": "A"
@@ -428,7 +428,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(beast_run_intake_processed{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(beast_run_intake_processed_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Beast Intake Processed/sec",
           "range": true,
           "refId": "B"
@@ -543,7 +543,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(beast_run_decode_success{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(beast_run_decode_success_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Decode Success/sec",
           "range": true,
           "refId": "A"
@@ -554,7 +554,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(beast_run_decode_failed{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(beast_run_decode_failed_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Decode Failed/sec",
           "range": true,
           "refId": "B"
@@ -653,7 +653,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(beast_run_fixes_processed{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(beast_run_fixes_processed_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Fixes Processed/sec",
           "range": true,
           "refId": "A"
@@ -664,7 +664,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(beast_run_no_fix_created{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(beast_run_no_fix_created_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "No Fix Created/sec",
           "range": true,
           "refId": "B"
@@ -675,7 +675,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(beast_run_raw_message_stored{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(beast_run_raw_message_stored_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Raw Messages Stored/sec",
           "range": true,
           "refId": "C"

--- a/infrastructure/grafana-dashboard-run-routing.json
+++ b/infrastructure/grafana-dashboard-run-routing.json
@@ -140,7 +140,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_parse_success{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_parse_success_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Parse Success/sec",
           "range": true,
           "refId": "A"
@@ -151,7 +151,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_parse_failed{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_parse_failed_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Parse Failed/sec",
           "range": true,
           "refId": "B"
@@ -297,7 +297,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_fixes_inserted{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_fixes_inserted_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Fixes Inserted/sec",
           "range": true,
           "refId": "A"
@@ -308,7 +308,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_fixes_duplicate_on_redelivery{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_fixes_duplicate_on_redelivery_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Duplicates Detected/sec",
           "range": true,
           "refId": "B"
@@ -319,7 +319,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_fixes_suppressed{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_fixes_suppressed_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Fixes Suppressed/sec",
           "range": true,
           "refId": "C"
@@ -446,7 +446,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_router_internal_queue_disconnected{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_router_internal_queue_disconnected_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Queue Disconnected/sec",
           "range": true,
           "refId": "B"
@@ -562,7 +562,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_router_process_packet_called{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_router_process_packet_called_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Process Packet Called/sec",
           "range": true,
           "refId": "A"
@@ -573,7 +573,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_router_process_packet_internal_called{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_router_process_packet_internal_called_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Internal Processing/sec",
           "range": true,
           "refId": "B"
@@ -584,7 +584,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_router_position_source_aircraft{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_router_position_source_aircraft_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Aircraft Position Source/sec",
           "range": true,
           "refId": "C"
@@ -595,7 +595,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_router_no_queue_aircraft{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_router_no_queue_aircraft_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "No Queue Available/sec",
           "range": true,
           "refId": "D"
@@ -869,7 +869,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_router_packet_type_position{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_router_packet_type_position_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Position Packets/sec",
           "range": true,
           "refId": "A"
@@ -880,7 +880,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_router_packet_type_status{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_router_packet_type_status_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Status Packets/sec",
           "range": true,
           "refId": "B"
@@ -995,7 +995,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_router_routed_aircraft{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_router_routed_aircraft_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Routed to Aircraft/sec",
           "range": true,
           "refId": "A"
@@ -1006,7 +1006,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_router_generic_processor_success{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_router_generic_processor_success_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Generic Success/sec",
           "range": true,
           "refId": "B"
@@ -1017,7 +1017,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_router_generic_processor_failed{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(aprs_router_generic_processor_failed_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Generic Failed/sec",
           "range": true,
           "refId": "C"
@@ -1116,7 +1116,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_flight_created_takeoff{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(flight_tracker_flight_created_takeoff_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Takeoff",
           "range": true,
           "refId": "A"
@@ -1127,7 +1127,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_flight_created_airborne{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "rate(flight_tracker_flight_created_airborne_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Airborne",
           "range": true,
           "refId": "B"
@@ -1217,7 +1217,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_nats_consumed_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_nats_consumed_total_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "OGN Messages/sec",
           "range": true,
           "refId": "A"
@@ -1308,7 +1308,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_nats_process_error_total{component=\"run\",environment=\"$environment\"}[$__rate_interval]) or\nrate(aprs_nats_decode_error_total{component=\"run\",environment=\"$environment\"}[$__rate_interval]) or\nrate(aprs_nats_receive_error_total{component=\"run\",environment=\"$environment\"}[$__rate_interval]) or\nrate(aprs_nats_ack_error_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_nats_process_error_total_total{component=\"run\",environment=\"$environment\"}[$__rate_interval]) or\nrate(aprs_nats_decode_error_total_total{component=\"run\",environment=\"$environment\"}[$__rate_interval]) or\nrate(aprs_nats_receive_error_total_total{component=\"run\",environment=\"$environment\"}[$__rate_interval]) or\nrate(aprs_nats_ack_error_total_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "{{__name__}}",
           "range": true,
           "refId": "A"
@@ -1490,7 +1490,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_messages_processed_aircraft{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_messages_processed_aircraft_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "Aircraft",
           "range": true,
           "refId": "A"
@@ -1501,7 +1501,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_messages_processed_receiver_status{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_messages_processed_receiver_status_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "Receiver Status",
           "range": true,
           "refId": "B"
@@ -1512,7 +1512,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_messages_processed_receiver_position{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_messages_processed_receiver_position_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "Receiver Position",
           "range": true,
           "refId": "C"
@@ -1523,7 +1523,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_messages_processed_server{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_messages_processed_server_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "Server",
           "range": true,
           "refId": "D"
@@ -1614,7 +1614,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_fixes_skipped_aircraft_type{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_fixes_skipped_aircraft_type_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "Skipped",
           "range": true,
           "refId": "A"
@@ -1705,7 +1705,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_router_process_packet_called{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_router_process_packet_called_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "process_packet called",
           "range": true,
           "refId": "A"
@@ -1716,7 +1716,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_router_process_packet_internal_called{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_router_process_packet_internal_called_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "process_packet_internal called",
           "range": true,
           "refId": "B"
@@ -1727,7 +1727,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_router_position_source_aircraft{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_router_position_source_aircraft_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "Position source: aircraft",
           "range": true,
           "refId": "C"
@@ -1738,7 +1738,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_router_no_queue_aircraft{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_router_no_queue_aircraft_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "No queue: aircraft",
           "range": true,
           "refId": "D"
@@ -1829,7 +1829,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_nats_acked_immediately{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_nats_acked_immediately_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "Acked Immediately",
           "range": true,
           "refId": "A"
@@ -1840,7 +1840,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_nats_intake_queue_full{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_nats_intake_queue_full_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "Intake Queue Full",
           "range": true,
           "refId": "B"
@@ -1931,7 +1931,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_router_internal_queue_disconnected{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_router_internal_queue_disconnected_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "Disconnections",
           "range": true,
           "refId": "A"
@@ -1940,6 +1940,118 @@
       "title": "Router Internal Queue Disconnections",
       "type": "timeseries",
       "id": 18
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 59,
+        "w": 24,
+        "h": 1
+      },
+      "id": 19,
+      "panels": [],
+      "title": "SOAR Run - Receiver Status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 60,
+        "w": 24,
+        "h": 8
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.2.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(receiver_status_updates_total{component=\"run\",environment=\"$environment\"}[5m])",
+          "legendFormat": "Status Updates/sec",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Receiver Status Updates",
+      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/infrastructure/grafana-dashboard-web.json
+++ b/infrastructure/grafana-dashboard-web.json
@@ -787,7 +787,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(websocket_messages_sent{component=\"web\",environment=\"$environment\"}[5m])",
+          "expr": "rate(websocket_messages_sent_total{component=\"web\",environment=\"$environment\"}[5m])",
           "legendFormat": "Messages Sent/sec",
           "range": true,
           "refId": "A"
@@ -798,7 +798,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(websocket_send_errors{component=\"web\",environment=\"$environment\"}[5m])",
+          "expr": "rate(websocket_send_errors_total{component=\"web\",environment=\"$environment\"}[5m])",
           "legendFormat": "Send Errors/sec",
           "range": true,
           "refId": "B"
@@ -809,7 +809,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(websocket_serialization_errors{component=\"web\",environment=\"$environment\"}[5m])",
+          "expr": "rate(websocket_serialization_errors_total{component=\"web\",environment=\"$environment\"}[5m])",
           "legendFormat": "Serialization Errors/sec",
           "range": true,
           "refId": "C"
@@ -902,7 +902,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(websocket_aircraft_subscribes{component=\"web\",environment=\"$environment\"}[5m])",
+          "expr": "rate(websocket_aircraft_subscribes_total{component=\"web\",environment=\"$environment\"}[5m])",
           "legendFormat": "Device Subscribes/sec",
           "range": true,
           "refId": "A"
@@ -913,7 +913,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(websocket_aircraft_unsubscribes{component=\"web\",environment=\"$environment\"}[5m])",
+          "expr": "rate(websocket_aircraft_unsubscribes_total{component=\"web\",environment=\"$environment\"}[5m])",
           "legendFormat": "Device Unsubscribes/sec",
           "range": true,
           "refId": "B"
@@ -1006,7 +1006,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(websocket_area_subscribes{component=\"web\",environment=\"$environment\"}[5m])",
+          "expr": "rate(websocket_area_subscribes_total{component=\"web\",environment=\"$environment\"}[5m])",
           "legendFormat": "Area Subscribes/sec",
           "range": true,
           "refId": "A"
@@ -1017,7 +1017,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(websocket_area_unsubscribes{component=\"web\",environment=\"$environment\"}[5m])",
+          "expr": "rate(websocket_area_unsubscribes_total{component=\"web\",environment=\"$environment\"}[5m])",
           "legendFormat": "Area Unsubscribes/sec",
           "range": true,
           "refId": "B"

--- a/src/actions/airspaces.rs
+++ b/src/actions/airspaces.rs
@@ -59,7 +59,7 @@ pub async fn get_airspaces(
     let repo = AirspacesRepository::new(state.pool.clone());
 
     // Record metrics
-    metrics::counter!("api.airspaces.requests").increment(1);
+    metrics::counter!("api.airspaces.requests_total").increment(1);
     let start = std::time::Instant::now();
 
     match repo
@@ -81,7 +81,7 @@ pub async fn get_airspaces(
         }
         Err(e) => {
             error!("Failed to fetch airspaces: {}", e);
-            metrics::counter!("api.airspaces.errors").increment(1);
+            metrics::counter!("api.airspaces.errors_total").increment(1);
             json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &format!("Failed to fetch airspaces: {}", e),

--- a/src/actions/analytics.rs
+++ b/src/actions/analytics.rs
@@ -62,7 +62,7 @@ pub async fn get_daily_flights(
     Query(params): Query<DateRangeParams>,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
-    metrics::counter!("analytics.api.daily_flights.requests").increment(1);
+    metrics::counter!("analytics.api.daily_flights.requests_total").increment(1);
 
     let end_date = params
         .end_date
@@ -76,7 +76,7 @@ pub async fn get_daily_flights(
     match cache.get_daily_flights(start_date, end_date).await {
         Ok(data) => (StatusCode::OK, Json(DataListResponse { data })).into_response(),
         Err(e) => {
-            metrics::counter!("analytics.api.errors").increment(1);
+            metrics::counter!("analytics.api.errors_total").increment(1);
             json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &format!("Failed to get daily flights: {}", e),
@@ -92,7 +92,7 @@ pub async fn get_hourly_flights(
     Query(params): Query<HoursParams>,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
-    metrics::counter!("analytics.api.hourly_flights.requests").increment(1);
+    metrics::counter!("analytics.api.hourly_flights.requests_total").increment(1);
 
     let hours = params.hours.unwrap_or(24);
 
@@ -101,7 +101,7 @@ pub async fn get_hourly_flights(
     match cache.get_hourly_flights(hours).await {
         Ok(data) => (StatusCode::OK, Json(DataListResponse { data })).into_response(),
         Err(e) => {
-            metrics::counter!("analytics.api.errors").increment(1);
+            metrics::counter!("analytics.api.errors_total").increment(1);
             json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &format!("Failed to get hourly flights: {}", e),
@@ -114,14 +114,14 @@ pub async fn get_hourly_flights(
 /// GET /data/analytics/flights/duration-distribution
 /// Get flight duration distribution buckets
 pub async fn get_duration_distribution(State(state): State<AppState>) -> impl IntoResponse {
-    metrics::counter!("analytics.api.duration_distribution.requests").increment(1);
+    metrics::counter!("analytics.api.duration_distribution.requests_total").increment(1);
 
     let cache = AnalyticsCache::new(AnalyticsRepository::new(state.pool.clone()));
 
     match cache.get_duration_distribution().await {
         Ok(data) => (StatusCode::OK, Json(DataListResponse { data })).into_response(),
         Err(e) => {
-            metrics::counter!("analytics.api.errors").increment(1);
+            metrics::counter!("analytics.api.errors_total").increment(1);
             json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &format!("Failed to get duration distribution: {}", e),
@@ -137,7 +137,7 @@ pub async fn get_aircraft_outliers(
     Query(params): Query<OutliersParams>,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
-    metrics::counter!("analytics.api.aircraft_outliers.requests").increment(1);
+    metrics::counter!("analytics.api.aircraft_outliers.requests_total").increment(1);
 
     let threshold = params.threshold.unwrap_or(3.0);
 
@@ -146,7 +146,7 @@ pub async fn get_aircraft_outliers(
     match cache.get_device_outliers(threshold).await {
         Ok(data) => (StatusCode::OK, Json(DataListResponse { data })).into_response(),
         Err(e) => {
-            metrics::counter!("analytics.api.errors").increment(1);
+            metrics::counter!("analytics.api.errors_total").increment(1);
             json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &format!("Failed to get device outliers: {}", e),
@@ -162,7 +162,7 @@ pub async fn get_top_aircraft(
     Query(params): Query<TopDevicesParams>,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
-    metrics::counter!("analytics.api.top_aircraft.requests").increment(1);
+    metrics::counter!("analytics.api.top_aircraft.requests_total").increment(1);
 
     let limit = params.limit.unwrap_or(10);
     let period_days = match params.period.as_deref() {
@@ -176,7 +176,7 @@ pub async fn get_top_aircraft(
     match cache.get_top_aircraft(limit, period_days).await {
         Ok(data) => (StatusCode::OK, Json(DataListResponse { data })).into_response(),
         Err(e) => {
-            metrics::counter!("analytics.api.errors").increment(1);
+            metrics::counter!("analytics.api.errors_total").increment(1);
             json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &format!("Failed to get top aircraft: {}", e),
@@ -192,7 +192,7 @@ pub async fn get_club_analytics(
     Query(params): Query<ClubAnalyticsParams>,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
-    metrics::counter!("analytics.api.club_analytics.requests").increment(1);
+    metrics::counter!("analytics.api.club_analytics.requests_total").increment(1);
 
     let end_date = params
         .end_date
@@ -209,7 +209,7 @@ pub async fn get_club_analytics(
     {
         Ok(data) => (StatusCode::OK, Json(DataListResponse { data })).into_response(),
         Err(e) => {
-            metrics::counter!("analytics.api.errors").increment(1);
+            metrics::counter!("analytics.api.errors_total").increment(1);
             json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &format!("Failed to get club analytics: {}", e),
@@ -225,7 +225,7 @@ pub async fn get_airport_activity(
     Query(params): Query<AirportActivityParams>,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
-    metrics::counter!("analytics.api.airport_activity.requests").increment(1);
+    metrics::counter!("analytics.api.airport_activity.requests_total").increment(1);
 
     let end_date = params
         .end_date
@@ -243,7 +243,7 @@ pub async fn get_airport_activity(
     {
         Ok(data) => (StatusCode::OK, Json(DataListResponse { data })).into_response(),
         Err(e) => {
-            metrics::counter!("analytics.api.errors").increment(1);
+            metrics::counter!("analytics.api.errors_total").increment(1);
             json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &format!("Failed to get airport activity: {}", e),
@@ -256,14 +256,14 @@ pub async fn get_airport_activity(
 /// GET /data/analytics/summary
 /// Get analytics summary for dashboard
 pub async fn get_summary(State(state): State<AppState>) -> impl IntoResponse {
-    metrics::counter!("analytics.api.summary.requests").increment(1);
+    metrics::counter!("analytics.api.summary.requests_total").increment(1);
 
     let cache = AnalyticsCache::new(AnalyticsRepository::new(state.pool.clone()));
 
     match cache.get_summary().await {
         Ok(data) => (StatusCode::OK, Json(DataResponse { data })).into_response(),
         Err(e) => {
-            metrics::counter!("analytics.api.errors").increment(1);
+            metrics::counter!("analytics.api.errors_total").increment(1);
             json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &format!("Failed to get analytics summary: {}", e),

--- a/src/actions/coverage.rs
+++ b/src/actions/coverage.rs
@@ -74,7 +74,7 @@ pub async fn get_coverage_hexes(
     Query(params): Query<CoverageQueryParams>,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
-    metrics::counter!("coverage.api.hexes.requests").increment(1);
+    metrics::counter!("coverage.api.hexes.requests_total").increment(1);
 
     // Validate and set defaults
     let resolution = params.resolution.unwrap_or(7);
@@ -123,7 +123,7 @@ pub async fn get_coverage_hexes(
         .await
     {
         Ok(features) => {
-            metrics::counter!("coverage.api.hexes.success").increment(1);
+            metrics::counter!("coverage.api.hexes.success_total").increment(1);
             metrics::histogram!("coverage.api.hexes.count").record(features.len() as f64);
 
             (
@@ -136,7 +136,7 @@ pub async fn get_coverage_hexes(
                 .into_response()
         }
         Err(e) => {
-            metrics::counter!("coverage.api.errors").increment(1);
+            metrics::counter!("coverage.api.errors_total").increment(1);
             json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 &format!("Failed to get coverage hexes: {}", e),

--- a/src/analytics_cache.rs
+++ b/src/analytics_cache.rs
@@ -71,13 +71,13 @@ impl AnalyticsCache {
         let key = CacheKey::DailyFlights(start_date, end_date);
 
         if let Some(cached) = self.daily_flights_cache.get(&key).await {
-            metrics::counter!("analytics.cache.hit").increment(1);
+            metrics::counter!("analytics.cache.hit_total").increment(1);
             let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
             metrics::histogram!("analytics.query.daily_flights_ms").record(duration_ms);
             return Ok(cached);
         }
 
-        metrics::counter!("analytics.cache.miss").increment(1);
+        metrics::counter!("analytics.cache.miss_total").increment(1);
         let result = self.repo.get_daily_flights(start_date, end_date).await?;
         self.daily_flights_cache.insert(key, result.clone()).await;
 
@@ -91,13 +91,13 @@ impl AnalyticsCache {
         let key = CacheKey::DurationDistribution;
 
         if let Some(cached) = self.duration_cache.get(&key).await {
-            metrics::counter!("analytics.cache.hit").increment(1);
+            metrics::counter!("analytics.cache.hit_total").increment(1);
             let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
             metrics::histogram!("analytics.query.duration_distribution_ms").record(duration_ms);
             return Ok(cached);
         }
 
-        metrics::counter!("analytics.cache.miss").increment(1);
+        metrics::counter!("analytics.cache.miss_total").increment(1);
         let result = self.repo.get_duration_distribution().await?;
         self.duration_cache.insert(key, result.clone()).await;
 
@@ -111,13 +111,13 @@ impl AnalyticsCache {
         let key = CacheKey::HourlyFlights(hours);
 
         if let Some(cached) = self.hourly_cache.get(&key).await {
-            metrics::counter!("analytics.cache.hit").increment(1);
+            metrics::counter!("analytics.cache.hit_total").increment(1);
             let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
             metrics::histogram!("analytics.query.hourly_flights_ms").record(duration_ms);
             return Ok(cached);
         }
 
-        metrics::counter!("analytics.cache.miss").increment(1);
+        metrics::counter!("analytics.cache.miss_total").increment(1);
         let result = self.repo.get_hourly_flights(hours).await?;
         self.hourly_cache.insert(key, result.clone()).await;
 
@@ -131,13 +131,13 @@ impl AnalyticsCache {
         let key = CacheKey::AircraftOutliers(format!("{:.2}", threshold));
 
         if let Some(cached) = self.outliers_cache.get(&key).await {
-            metrics::counter!("analytics.cache.hit").increment(1);
+            metrics::counter!("analytics.cache.hit_total").increment(1);
             let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
             metrics::histogram!("analytics.query.aircraft_outliers_ms").record(duration_ms);
             return Ok(cached);
         }
 
-        metrics::counter!("analytics.cache.miss").increment(1);
+        metrics::counter!("analytics.cache.miss_total").increment(1);
         let result = self.repo.get_device_outliers(threshold).await?;
         self.outliers_cache.insert(key, result.clone()).await;
 
@@ -151,13 +151,13 @@ impl AnalyticsCache {
         let key = CacheKey::TopAircraft(limit, period_days);
 
         if let Some(cached) = self.top_aircraft_cache.get(&key).await {
-            metrics::counter!("analytics.cache.hit").increment(1);
+            metrics::counter!("analytics.cache.hit_total").increment(1);
             let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
             metrics::histogram!("analytics.query.top_aircraft_ms").record(duration_ms);
             return Ok(cached);
         }
 
-        metrics::counter!("analytics.cache.miss").increment(1);
+        metrics::counter!("analytics.cache.miss_total").increment(1);
         let result = self.repo.get_top_aircraft(limit, period_days).await?;
         self.top_aircraft_cache.insert(key, result.clone()).await;
 
@@ -176,13 +176,13 @@ impl AnalyticsCache {
         let key = CacheKey::ClubAnalytics(start_date, end_date, club_id);
 
         if let Some(cached) = self.club_cache.get(&key).await {
-            metrics::counter!("analytics.cache.hit").increment(1);
+            metrics::counter!("analytics.cache.hit_total").increment(1);
             let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
             metrics::histogram!("analytics.query.club_analytics_ms").record(duration_ms);
             return Ok(cached);
         }
 
-        metrics::counter!("analytics.cache.miss").increment(1);
+        metrics::counter!("analytics.cache.miss_total").increment(1);
         let result = self
             .repo
             .get_club_analytics(start_date, end_date, club_id)
@@ -204,13 +204,13 @@ impl AnalyticsCache {
         let key = CacheKey::AirportActivity(start_date, end_date, limit);
 
         if let Some(cached) = self.airport_cache.get(&key).await {
-            metrics::counter!("analytics.cache.hit").increment(1);
+            metrics::counter!("analytics.cache.hit_total").increment(1);
             let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
             metrics::histogram!("analytics.query.airport_activity_ms").record(duration_ms);
             return Ok(cached);
         }
 
-        metrics::counter!("analytics.cache.miss").increment(1);
+        metrics::counter!("analytics.cache.miss_total").increment(1);
         let result = self
             .repo
             .get_airport_activity(start_date, end_date, limit)
@@ -227,13 +227,13 @@ impl AnalyticsCache {
         let key = CacheKey::Summary;
 
         if let Some(cached) = self.summary_cache.get(&key).await {
-            metrics::counter!("analytics.cache.hit").increment(1);
+            metrics::counter!("analytics.cache.hit_total").increment(1);
             let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
             metrics::histogram!("analytics.query.summary_ms").record(duration_ms);
             return Ok(cached);
         }
 
-        metrics::counter!("analytics.cache.miss").increment(1);
+        metrics::counter!("analytics.cache.miss_total").increment(1);
         let result = self.repo.get_summary().await?;
         self.summary_cache.insert(key, result.clone()).await;
 

--- a/src/aprs_nats_publisher.rs
+++ b/src/aprs_nats_publisher.rs
@@ -37,17 +37,17 @@ impl NatsPublisher {
                 Ok(()) => {
                     let duration_ms = start.elapsed().as_millis() as f64;
                     metrics::histogram!("aprs.nats.publish_duration_ms").record(duration_ms);
-                    metrics::counter!("aprs.nats.published").increment(1);
+                    metrics::counter!("aprs.nats.published_total").increment(1);
 
                     // Track slow publishes (>100ms is considered slow for fire-and-forget)
                     if duration_ms > 100.0 {
                         warn!("Slow NATS publish: {:.1}ms", duration_ms);
-                        metrics::counter!("aprs.nats.slow_publish").increment(1);
+                        metrics::counter!("aprs.nats.slow_publish_total").increment(1);
                     }
                 }
                 Err(e) => {
                     error!("Failed to publish message to NATS: {}", e);
-                    metrics::counter!("aprs.nats.publish_error").increment(1);
+                    metrics::counter!("aprs.nats.publish_error_total").increment(1);
                 }
             }
         });
@@ -62,7 +62,7 @@ impl NatsPublisher {
             .await
             .context("Failed to publish message to NATS")?;
 
-        metrics::counter!("aprs.nats.published").increment(1);
+        metrics::counter!("aprs.nats.published_total").increment(1);
 
         Ok(())
     }

--- a/src/beast_nats_publisher.rs
+++ b/src/beast_nats_publisher.rs
@@ -39,7 +39,7 @@ impl NatsPublisher {
                 Ok(()) => {
                     let duration_ms = start.elapsed().as_millis() as f64;
                     metrics::histogram!("beast.nats.publish_duration_ms").record(duration_ms);
-                    metrics::counter!("beast.nats.published").increment(1);
+                    metrics::counter!("beast.nats.published_total").increment(1);
 
                     // Log slow publishes
                     if duration_ms > 100.0 {
@@ -48,7 +48,7 @@ impl NatsPublisher {
                 }
                 Err(e) => {
                     error!("Failed to publish Beast message to NATS: {}", e);
-                    metrics::counter!("beast.nats.publish_error").increment(1);
+                    metrics::counter!("beast.nats.publish_error_total").increment(1);
                 }
             }
         });
@@ -61,7 +61,7 @@ impl NatsPublisher {
             .await
             .context("Failed to publish Beast message to NATS")?;
 
-        metrics::counter!("beast.nats.published").increment(1);
+        metrics::counter!("beast.nats.published_total").increment(1);
 
         Ok(())
     }

--- a/src/commands/ingest_adsb.rs
+++ b/src/commands/ingest_adsb.rs
@@ -151,7 +151,7 @@ pub async fn handle_ingest_adsb(
             }
             Err(e) => {
                 error!("Failed to connect to NATS: {} - retrying in 1s", e);
-                metrics::counter!("beast.nats.connection_failed").increment(1);
+                metrics::counter!("beast.nats.connection_failed_total").increment(1);
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
                 continue;
             }
@@ -187,7 +187,7 @@ pub async fn handle_ingest_adsb(
             }
             Err(e) => {
                 error!("ADS-B ingestion failed: {} - retrying in 1s", e);
-                metrics::counter!("beast.ingest_failed").increment(1);
+                metrics::counter!("beast.ingest_failed_total").increment(1);
 
                 // Mark NATS as disconnected
                 {

--- a/src/commands/ingest_ogn.rs
+++ b/src/commands/ingest_ogn.rs
@@ -163,7 +163,7 @@ pub async fn handle_ingest_ogn(
             }
             Err(e) => {
                 error!("Failed to connect to NATS: {} - retrying in 1s", e);
-                metrics::counter!("aprs.nats.connection_failed").increment(1);
+                metrics::counter!("aprs.nats.connection_failed_total").increment(1);
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
                 continue;
             }
@@ -196,7 +196,7 @@ pub async fn handle_ingest_ogn(
             }
             Err(e) => {
                 error!("OGN ingestion failed: {} - retrying in 1s", e);
-                metrics::counter!("aprs.ingest_failed").increment(1);
+                metrics::counter!("aprs.ingest_failed_total").increment(1);
 
                 // Mark NATS as disconnected
                 {

--- a/src/commands/load_data/mod.rs
+++ b/src/commands/load_data/mod.rs
@@ -30,7 +30,7 @@ fn record_stage_metrics(metrics: &EntityMetrics, stage_name: &str) {
     let stage_name = stage_name.to_string();
     metrics::histogram!("data_load.stage.duration_seconds", "stage" => stage_name.clone())
         .record(metrics.duration_secs);
-    metrics::counter!("data_load.stage.records_loaded", "stage" => stage_name.clone())
+    metrics::counter!("data_load.stage.records_loaded_total", "stage" => stage_name.clone())
         .increment(metrics.records_loaded as u64);
     metrics::gauge!("data_load.stage.success", "stage" => stage_name.clone())
         .set(if metrics.success { 1.0 } else { 0.0 });

--- a/src/commands/pull_airspaces.rs
+++ b/src/commands/pull_airspaces.rs
@@ -267,8 +267,8 @@ pub async fn handle_pull_airspaces(
     )?;
 
     // Record metrics
-    metrics::counter!("airspace_sync.total_fetched").increment(total_fetched as u64);
-    metrics::counter!("airspace_sync.total_inserted").increment(total_inserted as u64);
+    metrics::counter!("airspace_sync.total_fetched_total").increment(total_fetched as u64);
+    metrics::counter!("airspace_sync.total_inserted_total").increment(total_inserted as u64);
     metrics::gauge!("airspace_sync.last_run_timestamp").set(
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/src/coverage_cache.rs
+++ b/src/coverage_cache.rs
@@ -107,13 +107,13 @@ impl CoverageCache {
         );
 
         if let Some(cached) = self.cache.get(&key).await {
-            metrics::counter!("coverage.cache.hit").increment(1);
+            metrics::counter!("coverage.cache.hit_total").increment(1);
             let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
             metrics::histogram!("coverage.query.hexes_ms").record(duration_ms);
             return Ok(cached);
         }
 
-        metrics::counter!("coverage.cache.miss").increment(1);
+        metrics::counter!("coverage.cache.miss_total").increment(1);
         let result = self
             .repo
             .get_coverage_geojson(

--- a/src/fix_processor.rs
+++ b/src/fix_processor.rs
@@ -189,7 +189,7 @@ impl FixProcessor {
                 let tracker_device_type = packet.to.to_string();
 
                 // Track APRS type before filtering
-                metrics::counter!("aprs.type.received", "type" => tracker_device_type.clone())
+                metrics::counter!("aprs.type.received_total", "type" => tracker_device_type.clone())
                     .increment(1);
 
                 // Check if this APRS type is suppressed
@@ -199,7 +199,7 @@ impl FixProcessor {
                     .any(|t| t == &tracker_device_type)
                 {
                     trace!("Suppressing fix from APRS type: {}", tracker_device_type);
-                    metrics::counter!("aprs.fixes.suppressed").increment(1);
+                    metrics::counter!("aprs.fixes.suppressed_total").increment(1);
                     return;
                 }
 
@@ -211,7 +211,7 @@ impl FixProcessor {
                         .any(|t| t == ac_type)
                 {
                     trace!("Skipping fix from OGN aircraft type: {:?}", ac_type);
-                    metrics::counter!("aprs.fixes.skipped_aircraft_type", "aircraft_type" => ac_type.to_string())
+                    metrics::counter!("aprs.fixes.skipped_aircraft_type_total", "aircraft_type" => ac_type.to_string())
                         .increment(1);
                     return;
                 }
@@ -354,7 +354,7 @@ impl FixProcessor {
 
             metrics::histogram!("aprs.elevation.sync_duration_ms")
                 .record(elevation_start.elapsed().as_micros() as f64 / 1000.0);
-            metrics::counter!("aprs.elevation.sync_processed").increment(1);
+            metrics::counter!("aprs.elevation.sync_processed_total").increment(1);
         }
 
         // Step 1: Process through flight detection AND save to database

--- a/src/fixes_repo.rs
+++ b/src/fixes_repo.rs
@@ -189,7 +189,7 @@ impl FixesRepository {
                 .execute(&mut conn)
             {
                 Ok(_) => {
-                    metrics::counter!("aprs.fixes.inserted").increment(1);
+                    metrics::counter!("aprs.fixes.inserted_total").increment(1);
                     trace!(
                         "Inserted fix | Aircraft: {:?} | {:.6},{:.6} @ {}ft | https://maps.google.com/maps?q={:.6},{:.6}",
                         new_fix.aircraft_id,
@@ -225,7 +225,7 @@ impl FixesRepository {
                         "Duplicate fix detected for aircraft {} at {}",
                         new_fix.aircraft_id, new_fix.timestamp
                     );
-                    metrics::counter!("aprs.fixes.duplicate_on_redelivery").increment(1);
+                    metrics::counter!("aprs.fixes.duplicate_on_redelivery_total").increment(1);
                     // Not an error - just skip the duplicate
                     Ok(())
                 }

--- a/src/flight_tracker/flight_lifecycle.rs
+++ b/src/flight_tracker/flight_lifecycle.rs
@@ -216,14 +216,15 @@ pub(crate) async fn timeout_flight(
             let mut flights = active_flights.write().await;
             flights.remove(&aircraft_id);
 
-            metrics::counter!("flight_tracker.flight_ended.timed_out").increment(1);
+            metrics::counter!("flight_tracker.flight_ended.timed_out_total").increment(1);
             let phase_label = match timeout_phase {
                 TimeoutPhase::Climbing => "climbing",
                 TimeoutPhase::Cruising => "cruising",
                 TimeoutPhase::Descending => "descending",
                 TimeoutPhase::Unknown => "unknown",
             };
-            metrics::counter!("flight_tracker.timeout.phase", "phase" => phase_label).increment(1);
+            metrics::counter!("flight_tracker.timeout.phase_total", "phase" => phase_label)
+                .increment(1);
 
             Ok(())
         }
@@ -550,7 +551,7 @@ pub(crate) async fn complete_flight(
                     Ok(Some(d)) => d,
                     _ => {
                         tracing::error!("Failed to get aircraft for KML generation");
-                        metrics::counter!("watchlist.emails.failed").increment(1);
+                        metrics::counter!("watchlist.emails.failed_total").increment(1);
                         return;
                     }
                 };
@@ -560,7 +561,7 @@ pub(crate) async fn complete_flight(
                     Ok(Some(f)) => f,
                     _ => {
                         tracing::error!("Failed to get flight for KML generation");
-                        metrics::counter!("watchlist.emails.failed").increment(1);
+                        metrics::counter!("watchlist.emails.failed_total").increment(1);
                         return;
                     }
                 };
@@ -570,7 +571,7 @@ pub(crate) async fn complete_flight(
                     Ok(kml) => kml,
                     Err(e) => {
                         tracing::error!("Failed to generate KML: {}", e);
-                        metrics::counter!("watchlist.emails.failed").increment(1);
+                        metrics::counter!("watchlist.emails.failed_total").increment(1);
                         return;
                     }
                 };
@@ -594,7 +595,7 @@ pub(crate) async fn complete_flight(
                             ),
                             sentry::Level::Error,
                         );
-                        metrics::counter!("watchlist.emails.failed").increment(1);
+                        metrics::counter!("watchlist.emails.failed_total").increment(1);
                         return;
                     }
                 };
@@ -618,7 +619,8 @@ pub(crate) async fn complete_flight(
                                 {
                                     Ok(_) => {
                                         tracing::info!("Sent flight completion email to {}", email);
-                                        metrics::counter!("watchlist.emails.sent").increment(1);
+                                        metrics::counter!("watchlist.emails.sent_total")
+                                            .increment(1);
                                     }
                                     Err(e) => {
                                         tracing::error!("Failed to send email to {}: {}", email, e);
@@ -629,7 +631,8 @@ pub(crate) async fn complete_flight(
                                             ),
                                             sentry::Level::Error,
                                         );
-                                        metrics::counter!("watchlist.emails.failed").increment(1);
+                                        metrics::counter!("watchlist.emails.failed_total")
+                                            .increment(1);
                                     }
                                 }
                             }
@@ -639,7 +642,7 @@ pub(crate) async fn complete_flight(
                                 "Failed to get user {} for email notification",
                                 user_id
                             );
-                            metrics::counter!("watchlist.emails.failed").increment(1);
+                            metrics::counter!("watchlist.emails.failed_total").increment(1);
                         }
                     }
                 }
@@ -657,12 +660,12 @@ pub(crate) async fn complete_flight(
                     ),
                     sentry::Level::Error,
                 );
-                metrics::counter!("watchlist.emails.failed").increment(1);
+                metrics::counter!("watchlist.emails.failed_total").increment(1);
             }
         }
     });
 
-    metrics::counter!("flight_tracker.flight_ended.landed").increment(1);
+    metrics::counter!("flight_tracker.flight_ended.landed_total").increment(1);
 
     Ok(true) // Return true to indicate flight was completed normally
 }

--- a/src/flight_tracker/location.rs
+++ b/src/flight_tracker/location.rs
@@ -184,14 +184,15 @@ pub(crate) async fn create_start_end_location(
         Ok(result) => {
             let latency_ms = start.elapsed().as_millis() as f64;
             metrics::histogram!("flight_tracker.location.pelias.latency_ms").record(latency_ms);
-            metrics::counter!("flight_tracker.location.pelias.success").increment(1);
+            metrics::counter!("flight_tracker.location.pelias.success_total").increment(1);
 
             // Check if we got structured data (city/state/country) vs just a generic name
             let has_structured_data =
                 result.city.is_some() || result.state.is_some() || result.country.is_some();
 
             if !has_structured_data {
-                metrics::counter!("flight_tracker.location.pelias.no_structured_data").increment(1);
+                metrics::counter!("flight_tracker.location.pelias.no_structured_data_total")
+                    .increment(1);
                 debug!(
                     "Pelias returned no structured data for {} location ({}, {}), only name: {}",
                     context, latitude, longitude, result.display_name
@@ -240,7 +241,7 @@ pub(crate) async fn create_start_end_location(
                         "end (timeout)" => "end_timeout",
                         _ => "unknown",
                     };
-                    metrics::counter!("flight_tracker.location.created", "type" => metric_type)
+                    metrics::counter!("flight_tracker.location.created_total", "type" => metric_type)
                         .increment(1);
 
                     Some(created_location.id)
@@ -255,7 +256,7 @@ pub(crate) async fn create_start_end_location(
             }
         }
         Err(e) => {
-            metrics::counter!("flight_tracker.location.pelias.failure").increment(1);
+            metrics::counter!("flight_tracker.location.pelias.failure_total").increment(1);
             warn!(
                 "Reverse geocoding failed for {} location at coordinates ({}, {}): {}",
                 context, latitude, longitude, e

--- a/src/flight_tracker/mod.rs
+++ b/src/flight_tracker/mod.rs
@@ -435,7 +435,7 @@ impl FlightTracker {
                 // Clean up the device lock after successful timeout
                 self.cleanup_device_lock(aircraft_id).await;
                 // Increment timeout counter
-                metrics::counter!("flight_tracker_timeouts_detected").increment(1);
+                metrics::counter!("flight_tracker_timeouts_detected_total").increment(1);
             }
         }
 

--- a/src/geocoding/photon.rs
+++ b/src/geocoding/photon.rs
@@ -245,7 +245,7 @@ impl PhotonClient {
                     Some(10.0) => "10",
                     _ => "other",
                 };
-                metrics::counter!("flight_tracker.location.photon.retry", "radius_km" => radius_label)
+                metrics::counter!("flight_tracker.location.photon.retry_total", "radius_km" => radius_label)
                     .increment(1);
 
                 if let Some(r) = radius {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -75,6 +75,24 @@ pub fn init_metrics() -> PrometheusHandle {
             ],
         )
         .expect("failed to set buckets for http_request_duration_seconds")
+        // Configure NATS publish duration histograms with millisecond buckets
+        // Buckets: 0.5ms, 1ms, 2ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1000ms
+        .set_buckets_for_metric(
+            metrics_exporter_prometheus::Matcher::Full("aprs_nats_publish_duration_ms".to_string()),
+            &[
+                0.5, 1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0,
+            ],
+        )
+        .expect("failed to set buckets for aprs_nats_publish_duration_ms")
+        .set_buckets_for_metric(
+            metrics_exporter_prometheus::Matcher::Full(
+                "beast_nats_publish_duration_ms".to_string(),
+            ),
+            &[
+                0.5, 1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0,
+            ],
+        )
+        .expect("failed to set buckets for beast_nats_publish_duration_ms")
         .install_recorder()
         .expect("failed to install Prometheus recorder")
 }
@@ -244,167 +262,167 @@ pub async fn analytics_metrics_task(pool: crate::web::PgPool) {
 /// This ensures metrics always appear in Prometheus queries even if no events have occurred
 pub fn initialize_aprs_ingest_metrics() {
     // APRS connection metrics
-    metrics::counter!("aprs.connection.established").absolute(0);
-    metrics::counter!("aprs.connection.ended").absolute(0);
-    metrics::counter!("aprs.connection.failed").absolute(0);
-    metrics::counter!("aprs.connection.operation_failed").absolute(0);
+    metrics::counter!("aprs.connection.established_total").absolute(0);
+    metrics::counter!("aprs.connection.ended_total").absolute(0);
+    metrics::counter!("aprs.connection.failed_total").absolute(0);
+    metrics::counter!("aprs.connection.operation_failed_total").absolute(0);
     metrics::gauge!("aprs.connection.connected").set(0.0);
 
     // APRS keepalive metrics
-    metrics::counter!("aprs.keepalive.sent").absolute(0);
+    metrics::counter!("aprs.keepalive.sent_total").absolute(0);
 
     // Message type tracking (received from APRS-IS)
-    metrics::counter!("aprs.raw_message.received.server").absolute(0);
-    metrics::counter!("aprs.raw_message.received.aprs").absolute(0);
-    metrics::counter!("aprs.raw_message.queued.server").absolute(0);
-    metrics::counter!("aprs.raw_message.queued.aprs").absolute(0);
+    metrics::counter!("aprs.raw_message.received.server_total").absolute(0);
+    metrics::counter!("aprs.raw_message.received.aprs_total").absolute(0);
+    metrics::counter!("aprs.raw_message.queued.server_total").absolute(0);
+    metrics::counter!("aprs.raw_message.queued.aprs_total").absolute(0);
 
     // NATS publishing metrics (ingest-ogn publishes to NATS with fire-and-forget)
-    metrics::counter!("aprs.nats.published").absolute(0);
-    metrics::counter!("aprs.nats.publish_error").absolute(0);
-    metrics::counter!("aprs.nats.slow_publish").absolute(0);
+    metrics::counter!("aprs.nats.published_total").absolute(0);
+    metrics::counter!("aprs.nats.publish_error_total").absolute(0);
+    metrics::counter!("aprs.nats.slow_publish_total").absolute(0);
     metrics::histogram!("aprs.nats.publish_duration_ms").record(0.0);
 
     // Connection timeout metric
-    metrics::counter!("aprs.connection.timeout").absolute(0);
+    metrics::counter!("aprs.connection.timeout_total").absolute(0);
 }
 
 /// Initialize Beast ingest metrics to zero/default values
 /// This ensures metrics always appear in Prometheus queries even if no events have occurred
 pub fn initialize_beast_ingest_metrics() {
     // Beast connection metrics
-    metrics::counter!("beast.connection.established").absolute(0);
-    metrics::counter!("beast.connection.failed").absolute(0);
-    metrics::counter!("beast.operation.failed").absolute(0);
-    metrics::counter!("beast.timeout").absolute(0);
+    metrics::counter!("beast.connection.established_total").absolute(0);
+    metrics::counter!("beast.connection.failed_total").absolute(0);
+    metrics::counter!("beast.operation.failed_total").absolute(0);
+    metrics::counter!("beast.timeout_total").absolute(0);
     metrics::gauge!("beast.connection.connected").set(0.0);
 
     // Beast data metrics
-    metrics::counter!("beast.bytes.received").absolute(0);
-    metrics::counter!("beast.frames.published").absolute(0);
-    metrics::counter!("beast.frames.dropped").absolute(0);
+    metrics::counter!("beast.bytes.received_total").absolute(0);
+    metrics::counter!("beast.frames.published_total").absolute(0);
+    metrics::counter!("beast.frames.dropped_total").absolute(0);
     metrics::gauge!("beast.message_rate").set(0.0);
 
     // NATS publishing metrics (ingest-adsb publishes to NATS)
-    metrics::counter!("beast.nats.published").absolute(0);
-    metrics::counter!("beast.nats.publish_error").absolute(0);
-    metrics::counter!("beast.nats.slow_publish").absolute(0);
-    metrics::counter!("beast.nats.publish_timeout").absolute(0);
-    metrics::counter!("beast.nats.connection_failed").absolute(0);
-    metrics::counter!("beast.nats.stream_setup_failed").absolute(0);
+    metrics::counter!("beast.nats.published_total").absolute(0);
+    metrics::counter!("beast.nats.publish_error_total").absolute(0);
+    metrics::counter!("beast.nats.slow_publish_total").absolute(0);
+    metrics::counter!("beast.nats.publish_timeout_total").absolute(0);
+    metrics::counter!("beast.nats.connection_failed_total").absolute(0);
+    metrics::counter!("beast.nats.stream_setup_failed_total").absolute(0);
     metrics::gauge!("beast.nats.queue_depth").set(0.0);
     metrics::gauge!("beast.nats.in_flight").set(0.0);
     metrics::histogram!("beast.nats.publish_duration_ms").record(0.0);
 
     // General ingestion metrics
-    metrics::counter!("beast.ingest_failed").absolute(0);
+    metrics::counter!("beast.ingest_failed_total").absolute(0);
 }
 
 /// Initialize Beast consumer metrics to zero/default values
 /// This ensures metrics always appear in Prometheus queries even if no events have occurred
 pub fn initialize_beast_consumer_metrics() {
     // NATS consumer metrics (consume-beast consumes from NATS)
-    metrics::counter!("beast.nats.consumed").absolute(0);
-    metrics::counter!("beast.nats.receive_error").absolute(0);
-    metrics::counter!("beast.nats.ack_error").absolute(0);
-    metrics::counter!("beast.nats.invalid_message").absolute(0);
-    metrics::counter!("beast.nats.connection_failed").absolute(0);
-    metrics::counter!("beast.nats.consumer_setup_failed").absolute(0);
+    metrics::counter!("beast.nats.consumed_total").absolute(0);
+    metrics::counter!("beast.nats.receive_error_total").absolute(0);
+    metrics::counter!("beast.nats.ack_error_total").absolute(0);
+    metrics::counter!("beast.nats.invalid_message_total").absolute(0);
+    metrics::counter!("beast.nats.connection_failed_total").absolute(0);
+    metrics::counter!("beast.nats.consumer_setup_failed_total").absolute(0);
 
     // Beast consumer processing metrics
-    metrics::counter!("beast.consumer.received").absolute(0);
-    metrics::counter!("beast.consumer.invalid_message").absolute(0);
-    metrics::counter!("beast.consumer.send_errors").absolute(0);
-    metrics::counter!("beast.consumer.messages_stored").absolute(0);
-    metrics::counter!("beast.consumer.write_errors").absolute(0);
+    metrics::counter!("beast.consumer.received_total").absolute(0);
+    metrics::counter!("beast.consumer.invalid_message_total").absolute(0);
+    metrics::counter!("beast.consumer.send_errors_total").absolute(0);
+    metrics::counter!("beast.consumer.messages_stored_total").absolute(0);
+    metrics::counter!("beast.consumer.write_errors_total").absolute(0);
     metrics::histogram!("beast.consumer.batch_write_ms").record(0.0);
 
     // Beast decoding metrics
-    metrics::counter!("beast.consumer.decoded").absolute(0);
-    metrics::counter!("beast.consumer.decode_error").absolute(0);
-    metrics::counter!("beast.consumer.json_error").absolute(0);
+    metrics::counter!("beast.consumer.decoded_total").absolute(0);
+    metrics::counter!("beast.consumer.decode_error_total").absolute(0);
+    metrics::counter!("beast.consumer.json_error_total").absolute(0);
 
     // General consumption metrics
-    metrics::counter!("beast.consume_failed").absolute(0);
+    metrics::counter!("beast.consume_failed_total").absolute(0);
 }
 
 /// Initialize SOAR run metrics to zero/default values
 /// This ensures metrics always appear in Prometheus queries even if no events have occurred
 pub fn initialize_run_metrics() {
     // Flight tracker metrics
-    metrics::counter!("flight_tracker_timeouts_detected").absolute(0);
+    metrics::counter!("flight_tracker_timeouts_detected_total").absolute(0);
     metrics::gauge!("flight_tracker_active_aircraft").set(0.0);
 
     // Flight coalescing metrics
-    metrics::counter!("flight_tracker.coalesce.resumed").absolute(0);
-    metrics::counter!("flight_tracker.coalesce.callsign_mismatch").absolute(0);
-    metrics::counter!("flight_tracker.coalesce.no_timeout_flight").absolute(0);
-    metrics::counter!("flight_tracker.coalesce.rejected.callsign").absolute(0);
-    metrics::counter!("flight_tracker.coalesce.rejected.probable_landing").absolute(0);
+    metrics::counter!("flight_tracker.coalesce.resumed_total").absolute(0);
+    metrics::counter!("flight_tracker.coalesce.callsign_mismatch_total").absolute(0);
+    metrics::counter!("flight_tracker.coalesce.no_timeout_flight_total").absolute(0);
+    metrics::counter!("flight_tracker.coalesce.rejected.callsign_total").absolute(0);
+    metrics::counter!("flight_tracker.coalesce.rejected.probable_landing_total").absolute(0);
     metrics::histogram!("flight_tracker.coalesce.rejected.distance_km").record(0.0);
     metrics::histogram!("flight_tracker.coalesce.resumed.distance_km").record(0.0);
 
     // Flight timeout phase tracking
-    metrics::counter!("flight_tracker.timeout.phase", "phase" => "climbing").absolute(0);
-    metrics::counter!("flight_tracker.timeout.phase", "phase" => "cruising").absolute(0);
-    metrics::counter!("flight_tracker.timeout.phase", "phase" => "descending").absolute(0);
-    metrics::counter!("flight_tracker.timeout.phase", "phase" => "unknown").absolute(0);
+    metrics::counter!("flight_tracker.timeout.phase_total", "phase" => "climbing").absolute(0);
+    metrics::counter!("flight_tracker.timeout.phase_total", "phase" => "cruising").absolute(0);
+    metrics::counter!("flight_tracker.timeout.phase_total", "phase" => "descending").absolute(0);
+    metrics::counter!("flight_tracker.timeout.phase_total", "phase" => "unknown").absolute(0);
 
     // Flight creation metrics
-    metrics::counter!("flight_tracker.flight_created.takeoff").absolute(0);
-    metrics::counter!("flight_tracker.flight_created.airborne").absolute(0);
+    metrics::counter!("flight_tracker.flight_created.takeoff_total").absolute(0);
+    metrics::counter!("flight_tracker.flight_created.airborne_total").absolute(0);
 
     // Flight end metrics
-    metrics::counter!("flight_tracker.flight_ended.landed").absolute(0);
-    metrics::counter!("flight_tracker.flight_ended.timed_out").absolute(0);
+    metrics::counter!("flight_tracker.flight_ended.landed_total").absolute(0);
+    metrics::counter!("flight_tracker.flight_ended.timed_out_total").absolute(0);
 
     // Receiver status metrics
     metrics::counter!("receiver_status_updates_total").absolute(0);
 
     // Elevation cache metrics
-    metrics::counter!("elevation_cache_hits").absolute(0);
-    metrics::counter!("elevation_cache_misses").absolute(0);
+    metrics::counter!("elevation_cache_hits_total").absolute(0);
+    metrics::counter!("elevation_cache_misses_total").absolute(0);
     metrics::gauge!("elevation_cache_entries").set(0.0);
-    metrics::counter!("elevation_tile_cache_hits").absolute(0);
-    metrics::counter!("elevation_tile_cache_misses").absolute(0);
+    metrics::counter!("elevation_tile_cache_hits_total").absolute(0);
+    metrics::counter!("elevation_tile_cache_misses_total").absolute(0);
     metrics::gauge!("elevation_tile_cache_entries").set(0.0);
 
     // Receiver cache metrics
-    metrics::counter!("generic_processor.receiver_cache.hit").absolute(0);
-    metrics::counter!("generic_processor.receiver_cache.miss").absolute(0);
+    metrics::counter!("generic_processor.receiver_cache.hit_total").absolute(0);
+    metrics::counter!("generic_processor.receiver_cache.miss_total").absolute(0);
 
     // NATS publisher metrics
-    metrics::counter!("nats_publisher_fixes_published").absolute(0);
+    metrics::counter!("nats_publisher_fixes_published_total").absolute(0);
     metrics::gauge!("nats_publisher_queue_depth").set(0.0);
-    metrics::counter!("nats_publisher_errors").absolute(0);
+    metrics::counter!("nats_publisher_errors_total").absolute(0);
 
     // Queue drop/close counters
-    metrics::counter!("aprs.raw_message_queue.full").absolute(0);
-    metrics::counter!("aprs.aircraft_queue.full").absolute(0);
-    metrics::counter!("aprs.aircraft_queue.closed").absolute(0);
-    metrics::counter!("aprs.receiver_status_queue.full").absolute(0);
-    metrics::counter!("aprs.receiver_status_queue.closed").absolute(0);
-    metrics::counter!("aprs.receiver_position_queue.full").absolute(0);
-    metrics::counter!("aprs.receiver_position_queue.closed").absolute(0);
-    metrics::counter!("aprs.server_status_queue.full").absolute(0);
-    metrics::counter!("aprs.server_status_queue.closed").absolute(0);
+    metrics::counter!("aprs.raw_message_queue.full_total").absolute(0);
+    metrics::counter!("aprs.aircraft_queue.full_total").absolute(0);
+    metrics::counter!("aprs.aircraft_queue.closed_total").absolute(0);
+    metrics::counter!("aprs.receiver_status_queue.full_total").absolute(0);
+    metrics::counter!("aprs.receiver_status_queue.closed_total").absolute(0);
+    metrics::counter!("aprs.receiver_position_queue.full_total").absolute(0);
+    metrics::counter!("aprs.receiver_position_queue.closed_total").absolute(0);
+    metrics::counter!("aprs.server_status_queue.full_total").absolute(0);
+    metrics::counter!("aprs.server_status_queue.closed_total").absolute(0);
 
     // NATS consumer metrics (soar-run consumes from NATS, doesn't publish)
     metrics::gauge!("aprs.nats.intake_queue_depth").set(0.0);
-    metrics::counter!("aprs.nats.consumed").absolute(0);
-    metrics::counter!("aprs.nats.process_error").absolute(0);
-    metrics::counter!("aprs.nats.decode_error").absolute(0);
-    metrics::counter!("aprs.nats.ack_error").absolute(0);
-    metrics::counter!("aprs.nats.receive_error").absolute(0);
-    metrics::counter!("aprs.nats.acked_immediately").absolute(0);
-    metrics::counter!("aprs.nats.intake_queue_full").absolute(0);
+    metrics::counter!("aprs.nats.consumed_total").absolute(0);
+    metrics::counter!("aprs.nats.process_error_total").absolute(0);
+    metrics::counter!("aprs.nats.decode_error_total").absolute(0);
+    metrics::counter!("aprs.nats.ack_error_total").absolute(0);
+    metrics::counter!("aprs.nats.receive_error_total").absolute(0);
+    metrics::counter!("aprs.nats.acked_immediately_total").absolute(0);
+    metrics::counter!("aprs.nats.intake_queue_full_total").absolute(0);
 
     // Message processing counters by type
-    metrics::counter!("aprs.messages.processed.aircraft").absolute(0);
-    metrics::counter!("aprs.messages.processed.receiver_status").absolute(0);
-    metrics::counter!("aprs.messages.processed.receiver_position").absolute(0);
-    metrics::counter!("aprs.messages.processed.server").absolute(0);
-    metrics::counter!("aprs.messages.processed.total").absolute(0);
+    metrics::counter!("aprs.messages.processed.aircraft_total").absolute(0);
+    metrics::counter!("aprs.messages.processed.receiver_status_total").absolute(0);
+    metrics::counter!("aprs.messages.processed.receiver_position_total").absolute(0);
+    metrics::counter!("aprs.messages.processed.server_total").absolute(0);
+    metrics::counter!("aprs.messages.processed.total_total").absolute(0);
 
     // Aircraft position processing latency metrics
     metrics::histogram!("aprs.aircraft.lookup_ms").record(0.0);
@@ -423,37 +441,41 @@ pub fn initialize_run_metrics() {
     metrics::histogram!("aprs.aircraft.flight_update_last_fix_ms").record(0.0);
 
     // Photon reverse geocoding metrics
-    metrics::counter!("flight_tracker.location.photon.success").absolute(0);
-    metrics::counter!("flight_tracker.location.photon.failure").absolute(0);
-    metrics::counter!("flight_tracker.location.photon.no_structured_data").absolute(0);
+    metrics::counter!("flight_tracker.location.photon.success_total").absolute(0);
+    metrics::counter!("flight_tracker.location.photon.failure_total").absolute(0);
+    metrics::counter!("flight_tracker.location.photon.no_structured_data_total").absolute(0);
     metrics::histogram!("flight_tracker.location.photon.latency_ms").record(0.0);
-    metrics::counter!("flight_tracker.location.photon.retry", "radius_km" => "exact").absolute(0);
-    metrics::counter!("flight_tracker.location.photon.retry", "radius_km" => "1").absolute(0);
-    metrics::counter!("flight_tracker.location.photon.retry", "radius_km" => "5").absolute(0);
-    metrics::counter!("flight_tracker.location.photon.retry", "radius_km" => "10").absolute(0);
-    metrics::counter!("flight_tracker.location.created", "type" => "start_takeoff").absolute(0);
-    metrics::counter!("flight_tracker.location.created", "type" => "start_airborne").absolute(0);
-    metrics::counter!("flight_tracker.location.created", "type" => "end_landing").absolute(0);
-    metrics::counter!("flight_tracker.location.created", "type" => "end_timeout").absolute(0);
+    metrics::counter!("flight_tracker.location.photon.retry_total", "radius_km" => "exact")
+        .absolute(0);
+    metrics::counter!("flight_tracker.location.photon.retry_total", "radius_km" => "1").absolute(0);
+    metrics::counter!("flight_tracker.location.photon.retry_total", "radius_km" => "5").absolute(0);
+    metrics::counter!("flight_tracker.location.photon.retry_total", "radius_km" => "10")
+        .absolute(0);
+    metrics::counter!("flight_tracker.location.created_total", "type" => "start_takeoff")
+        .absolute(0);
+    metrics::counter!("flight_tracker.location.created_total", "type" => "start_airborne")
+        .absolute(0);
+    metrics::counter!("flight_tracker.location.created_total", "type" => "end_landing").absolute(0);
+    metrics::counter!("flight_tracker.location.created_total", "type" => "end_timeout").absolute(0);
 
     // Beast (ADS-B) processing metrics
-    metrics::counter!("beast.run.process_beast_message.called").absolute(0);
-    metrics::counter!("beast.run.invalid_message").absolute(0);
-    metrics::counter!("beast.run.decode.success").absolute(0);
-    metrics::counter!("beast.run.decode.failed").absolute(0);
-    metrics::counter!("beast.run.icao_extraction_failed").absolute(0);
-    metrics::counter!("beast.run.aircraft_lookup_failed").absolute(0);
-    metrics::counter!("beast.run.raw_message_stored").absolute(0);
-    metrics::counter!("beast.run.raw_message_store_failed").absolute(0);
-    metrics::counter!("beast.run.adsb_to_fix_failed").absolute(0);
-    metrics::counter!("beast.run.fixes_processed").absolute(0);
-    metrics::counter!("beast.run.fix_processing_failed").absolute(0);
-    metrics::counter!("beast.run.no_fix_created").absolute(0);
-    metrics::counter!("beast.run.intake.processed").absolute(0);
-    metrics::counter!("beast.run.nats.consumed").absolute(0);
-    metrics::counter!("beast.run.nats.connection_failed").absolute(0);
-    metrics::counter!("beast.run.nats.subscription_failed").absolute(0);
-    metrics::counter!("beast.run.nats.subscription_ended").absolute(0);
+    metrics::counter!("beast.run.process_beast_message.called_total").absolute(0);
+    metrics::counter!("beast.run.invalid_message_total").absolute(0);
+    metrics::counter!("beast.run.decode.success_total").absolute(0);
+    metrics::counter!("beast.run.decode.failed_total").absolute(0);
+    metrics::counter!("beast.run.icao_extraction_failed_total").absolute(0);
+    metrics::counter!("beast.run.aircraft_lookup_failed_total").absolute(0);
+    metrics::counter!("beast.run.raw_message_stored_total").absolute(0);
+    metrics::counter!("beast.run.raw_message_store_failed_total").absolute(0);
+    metrics::counter!("beast.run.adsb_to_fix_failed_total").absolute(0);
+    metrics::counter!("beast.run.fixes_processed_total").absolute(0);
+    metrics::counter!("beast.run.fix_processing_failed_total").absolute(0);
+    metrics::counter!("beast.run.no_fix_created_total").absolute(0);
+    metrics::counter!("beast.run.intake.processed_total").absolute(0);
+    metrics::counter!("beast.run.nats.consumed_total").absolute(0);
+    metrics::counter!("beast.run.nats.connection_failed_total").absolute(0);
+    metrics::counter!("beast.run.nats.subscription_failed_total").absolute(0);
+    metrics::counter!("beast.run.nats.subscription_ended_total").absolute(0);
     metrics::gauge!("beast.run.nats.lag_seconds").set(0.0);
     metrics::gauge!("beast.run.nats.intake_queue_depth").set(0.0);
     metrics::histogram!("beast.run.message_processing_latency_ms").record(0.0);
@@ -463,8 +485,8 @@ pub fn initialize_run_metrics() {
 /// This ensures metrics always appear in Prometheus queries even if no events have occurred
 pub fn initialize_analytics_metrics() {
     // Analytics cache hit/miss metrics
-    metrics::counter!("analytics.cache.hit").absolute(0);
-    metrics::counter!("analytics.cache.miss").absolute(0);
+    metrics::counter!("analytics.cache.hit_total").absolute(0);
+    metrics::counter!("analytics.cache.miss_total").absolute(0);
     metrics::gauge!("analytics.cache.size").set(0.0);
 
     // Analytics query duration metrics (in milliseconds)
@@ -478,17 +500,17 @@ pub fn initialize_analytics_metrics() {
     metrics::histogram!("analytics.query.summary_ms").record(0.0);
 
     // Analytics API endpoint request counters
-    metrics::counter!("analytics.api.daily_flights.requests").absolute(0);
-    metrics::counter!("analytics.api.hourly_flights.requests").absolute(0);
-    metrics::counter!("analytics.api.duration_distribution.requests").absolute(0);
-    metrics::counter!("analytics.api.aircraft_outliers.requests").absolute(0);
-    metrics::counter!("analytics.api.top_aircraft.requests").absolute(0);
-    metrics::counter!("analytics.api.club_analytics.requests").absolute(0);
-    metrics::counter!("analytics.api.airport_activity.requests").absolute(0);
-    metrics::counter!("analytics.api.summary.requests").absolute(0);
+    metrics::counter!("analytics.api.daily_flights.requests_total").absolute(0);
+    metrics::counter!("analytics.api.hourly_flights.requests_total").absolute(0);
+    metrics::counter!("analytics.api.duration_distribution.requests_total").absolute(0);
+    metrics::counter!("analytics.api.aircraft_outliers.requests_total").absolute(0);
+    metrics::counter!("analytics.api.top_aircraft.requests_total").absolute(0);
+    metrics::counter!("analytics.api.club_analytics.requests_total").absolute(0);
+    metrics::counter!("analytics.api.airport_activity.requests_total").absolute(0);
+    metrics::counter!("analytics.api.summary.requests_total").absolute(0);
 
     // Analytics API error counters
-    metrics::counter!("analytics.api.errors").absolute(0);
+    metrics::counter!("analytics.api.errors_total").absolute(0);
 
     // Analytics data metrics (updated periodically by background task)
     metrics::gauge!("analytics.flights.today").set(0.0);
@@ -501,27 +523,27 @@ pub fn initialize_analytics_metrics() {
 /// Initialize airspace-related metrics
 pub fn initialize_airspace_metrics() {
     // Airspace sync metrics (for pull-airspaces command)
-    metrics::counter!("airspace_sync.total_fetched").absolute(0);
-    metrics::counter!("airspace_sync.total_inserted").absolute(0);
+    metrics::counter!("airspace_sync.total_fetched_total").absolute(0);
+    metrics::counter!("airspace_sync.total_inserted_total").absolute(0);
     metrics::gauge!("airspace_sync.last_run_timestamp").set(0.0);
     metrics::gauge!("airspace_sync.success").set(0.0);
 
     // Airspace API endpoint metrics
-    metrics::counter!("api.airspaces.requests").absolute(0);
-    metrics::counter!("api.airspaces.errors").absolute(0);
+    metrics::counter!("api.airspaces.requests_total").absolute(0);
+    metrics::counter!("api.airspaces.errors_total").absolute(0);
     metrics::histogram!("api.airspaces.duration_ms").record(0.0);
     metrics::gauge!("api.airspaces.results_count").set(0.0);
 }
 
 pub fn initialize_coverage_metrics() {
     // Coverage API metrics
-    metrics::counter!("coverage.api.hexes.requests").absolute(0);
-    metrics::counter!("coverage.api.hexes.success").absolute(0);
-    metrics::counter!("coverage.api.errors").absolute(0);
+    metrics::counter!("coverage.api.hexes.requests_total").absolute(0);
+    metrics::counter!("coverage.api.hexes.success_total").absolute(0);
+    metrics::counter!("coverage.api.errors_total").absolute(0);
     metrics::histogram!("coverage.api.hexes.count").record(0.0);
     metrics::histogram!("coverage.query.hexes_ms").record(0.0);
-    metrics::counter!("coverage.cache.hit").absolute(0);
-    metrics::counter!("coverage.cache.miss").absolute(0);
+    metrics::counter!("coverage.cache.hit_total").absolute(0);
+    metrics::counter!("coverage.cache.miss_total").absolute(0);
 }
 
 /// Health check handler for APRS ingestion service

--- a/src/nats_publisher.rs
+++ b/src/nats_publisher.rs
@@ -101,11 +101,11 @@ impl NatsFixPublisher {
                 match publish_to_nats(&client_clone, &aircraft_id, &fix_with_flight).await {
                     Ok(()) => {
                         fixes_published += 1;
-                        metrics::counter!("nats_publisher_fixes_published").increment(1);
+                        metrics::counter!("nats_publisher_fixes_published_total").increment(1);
                     }
                     Err(e) => {
                         error!("Failed to publish fix for device {}: {}", aircraft_id, e);
-                        metrics::counter!("nats_publisher_errors").increment(1);
+                        metrics::counter!("nats_publisher_errors_total").increment(1);
                     }
                 }
 
@@ -154,7 +154,7 @@ impl NatsFixPublisher {
             Err(flume::SendError(_)) => {
                 // NATS publisher task has shut down
                 error!("NATS publisher channel is closed - cannot publish fix");
-                metrics::counter!("nats_publisher_errors").increment(1);
+                metrics::counter!("nats_publisher_errors_total").increment(1);
             }
         }
     }

--- a/src/packet_processors/generic.rs
+++ b/src/packet_processors/generic.rs
@@ -79,7 +79,7 @@ impl GenericProcessor {
         let receiver_id = if let Some(cached_id) = self.receiver_cache.get(&receiver_callsign) {
             // Cache hit - use cached receiver ID
             trace!("Receiver {} found in cache", receiver_callsign);
-            metrics::counter!("generic_processor.receiver_cache.hit").increment(1);
+            metrics::counter!("generic_processor.receiver_cache.hit_total").increment(1);
             cached_id
         } else {
             // Cache miss - lookup/insert in database
@@ -87,7 +87,7 @@ impl GenericProcessor {
                 "Receiver {} not in cache, querying database",
                 receiver_callsign
             );
-            metrics::counter!("generic_processor.receiver_cache.miss").increment(1);
+            metrics::counter!("generic_processor.receiver_cache.miss_total").increment(1);
 
             match self
                 .receiver_repo

--- a/src/raw_messages_repo.rs
+++ b/src/raw_messages_repo.rs
@@ -187,7 +187,7 @@ impl RawMessagesRepository {
                 .execute(&mut conn)
             {
                 Ok(_) => {
-                    metrics::counter!("aprs.messages.inserted").increment(1);
+                    metrics::counter!("aprs.messages.inserted_total").increment(1);
                     Ok::<Uuid, anyhow::Error>(message_id)
                 }
                 Err(diesel::result::Error::DatabaseError(
@@ -196,7 +196,7 @@ impl RawMessagesRepository {
                 )) => {
                     // Duplicate message on redelivery - this is expected after crashes
                     debug!("Duplicate aprs_message detected on redelivery");
-                    metrics::counter!("aprs.messages.duplicate_on_redelivery").increment(1);
+                    metrics::counter!("aprs.messages.duplicate_on_redelivery_total").increment(1);
 
                     // Find existing message ID by natural key
                     let existing = raw_messages
@@ -246,7 +246,7 @@ impl RawMessagesRepository {
 
             match insert_result {
                 Ok(_) => {
-                    metrics::counter!("beast.messages.inserted").increment(1);
+                    metrics::counter!("beast.messages.inserted_total").increment(1);
                     Ok::<Uuid, anyhow::Error>(message_id)
                 }
                 Err(diesel::result::Error::DatabaseError(
@@ -255,7 +255,7 @@ impl RawMessagesRepository {
                 )) => {
                     // Duplicate message on redelivery - this is expected after crashes
                     debug!("Duplicate beast message detected on redelivery");
-                    metrics::counter!("beast.messages.duplicate_on_redelivery").increment(1);
+                    metrics::counter!("beast.messages.duplicate_on_redelivery_total").increment(1);
 
                     // Find existing message ID by natural key
                     use crate::schema::raw_messages::dsl::*;
@@ -306,9 +306,9 @@ impl RawMessagesRepository {
                     .execute(conn)?;
 
                     if insert_result > 0 {
-                        metrics::counter!("beast.messages.inserted").increment(1);
+                        metrics::counter!("beast.messages.inserted_total").increment(1);
                     } else {
-                        metrics::counter!("beast.messages.duplicate_on_redelivery").increment(1);
+                        metrics::counter!("beast.messages.duplicate_on_redelivery_total").increment(1);
                     }
                 }
                 Ok(())

--- a/src/receiver_repo.rs
+++ b/src/receiver_repo.rs
@@ -881,7 +881,7 @@ impl ReceiverRepository {
             let elapsed = now.signed_duration_since(last_update);
             if elapsed.num_seconds() < 5 {
                 // Less than 5 seconds since last update - skip database write
-                metrics::counter!("receiver_repo.latest_packet_at.skipped").increment(1);
+                metrics::counter!("receiver_repo.latest_packet_at.skipped_total").increment(1);
                 return Ok(true);
             }
         }
@@ -904,7 +904,7 @@ impl ReceiverRepository {
         // Update cache with the current timestamp
         if result.is_ok() {
             self.latest_packet_at_cache.insert(receiver_id, now);
-            metrics::counter!("receiver_repo.latest_packet_at.updated").increment(1);
+            metrics::counter!("receiver_repo.latest_packet_at.updated_total").increment(1);
         }
 
         result

--- a/src/web.rs
+++ b/src/web.rs
@@ -559,16 +559,16 @@ pub async fn start_web_server(interface: String, port: u16, pool: PgPool) -> Res
     metrics::gauge!("websocket_connections").set(0.0);
     metrics::gauge!("websocket_active_subscriptions").set(0.0);
     metrics::gauge!("websocket_queue_depth").set(0.0);
-    metrics::counter!("websocket_messages_sent").absolute(0);
-    metrics::counter!("websocket_send_errors").absolute(0);
-    metrics::counter!("websocket_serialization_errors").absolute(0);
-    metrics::counter!("websocket_aircraft_subscribes").absolute(0);
-    metrics::counter!("websocket_aircraft_unsubscribes").absolute(0);
-    metrics::counter!("websocket_area_subscribes").absolute(0);
-    metrics::counter!("websocket_area_unsubscribes").absolute(0);
-    metrics::counter!("websocket_area_bulk_subscribes").absolute(0);
-    metrics::counter!("websocket_area_bulk_unsubscribes").absolute(0);
-    metrics::counter!("websocket_area_bulk_validation_errors").absolute(0);
+    metrics::counter!("websocket_messages_sent_total").absolute(0);
+    metrics::counter!("websocket_send_errors_total").absolute(0);
+    metrics::counter!("websocket_serialization_errors_total").absolute(0);
+    metrics::counter!("websocket_aircraft_subscribes_total").absolute(0);
+    metrics::counter!("websocket_aircraft_unsubscribes_total").absolute(0);
+    metrics::counter!("websocket_area_subscribes_total").absolute(0);
+    metrics::counter!("websocket_area_unsubscribes_total").absolute(0);
+    metrics::counter!("websocket_area_bulk_subscribes_total").absolute(0);
+    metrics::counter!("websocket_area_bulk_unsubscribes_total").absolute(0);
+    metrics::counter!("websocket_area_bulk_validation_errors_total").absolute(0);
 
     // Initialize analytics metrics
     crate::metrics::initialize_analytics_metrics();


### PR DESCRIPTION
## Summary

This PR addresses multiple Grafana dashboard issues and standardizes all counter metrics to follow Prometheus naming conventions by adding the `_total` suffix.

### Metrics Changes (⚠️ Breaking Change - Historical Data)

- Renamed **187 counter metrics** to add `_total` suffix for Prometheus compliance
- Eliminates PromQL warnings: *"metric might not be a counter, name does not end in _total"*
- Examples:
  - `aprs_connection_established` → `aprs_connection_established_total`
  - `flight_tracker_flight_created_takeoff` → `flight_tracker_flight_created_takeoff_total`
  - `nats_publisher_fixes_published` → `nats_publisher_fixes_published_total`

### Grafana Dashboard Fixes

#### Ingest-OGN Dashboard
- ✅ Added histogram bucket configuration for `aprs_nats_publish_duration_ms` and `beast_nats_publish_duration_ms`
- ✅ Fixed duplicate panel ID (two panels with `id: 100`)
- ✅ Fixed Connection & Ingestion Errors panel - now shows 4 distinct error types instead of duplicates

#### Run-Core Dashboard
- ✅ Fixed NATS Publishing Errors panel to initialize to zero with `or vector(0)`

#### Run-Routing Dashboard
- ✅ Moved "Receiver Status Updates" panel from run-flights dashboard (more appropriate location)

#### NATS Dashboard
- ✅ Renamed "SOAR NATS Performance" → "SOAR - NATS Infrastructure" for clarity

#### Analytics Dashboard
- ✅ Extended "Hourly Flight Activity" from 48 hours to 30 days

#### All Dashboards
- ✅ Updated all 12 Grafana dashboards with renamed metrics (`_total` suffix)
- ✅ Fixed redundant dashboard titles

### Other Changes

- Updated `CLAUDE.md` with deployment safety rules
- Added `metrics::histogram` bucket configuration in `src/metrics.rs` for NATS publish duration

## Impact

⚠️ **Breaking Change:** Old metric names will no longer receive new data after services restart
- Dashboards will automatically use new metric names
- No data loss - existing historical data remains in database
- Services need restart to emit metrics with new names

## Testing

- ✅ `cargo fmt` - Passed
- ✅ `cargo check` - Passed (3m 59s)
- ✅ All pre-commit hooks passed (clippy, formatting, JSON validation)
- ✅ 44 files modified

## Deployment Notes

After merging, services need to be restarted in this order:
1. Restart `ingest-ogn` service
2. Restart `ingest-adsb` service  
3. Restart `soar run` service

Grafana dashboards will automatically pick up the new metrics and display without PromQL warnings.