### PR TITLE
fix: enable SwiftShader for WebGL in Playwright CI tests

### DIFF
--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
 			use: {
 				...devices['Desktop Chrome'],
 				// Disable security features that can interfere with Docker/testing
+				// Enable SwiftShader for software WebGL rendering (required for Cesium)
 				launchOptions: {
 					args: [
 						'--no-sandbox',
@@ -51,8 +52,7 @@ export default defineConfig({
 						'--disable-web-security',
 						'--disable-features=IsolateOrigins,site-per-process',
 						'--disable-blink-features=AutomationControlled',
-						'--disable-gpu',
-						'--disable-software-rasterizer',
+						'--use-gl=swiftshader', // Enable software WebGL for Cesium 3D globe
 						'--disable-accelerated-2d-canvas'
 					]
 				}


### PR DESCRIPTION
## Summary

This PR fixes the flaky Cesium E2E test failures in CI by enabling SwiftShader (Google's software WebGL implementation) in Playwright's browser configuration.

## Problem

Cesium requires WebGL to render the 3D globe. The previous Playwright configuration disabled GPU rendering entirely with:
- `--disable-gpu`
- `--disable-software-rasterizer`

This caused Cesium to fail silently in CI without properly showing error states, leading to flaky test failures where:
1. Cesium Viewer initialization failed without WebGL
2. The `.cesium-viewer` element was never created  
3. Tests would timeout waiting for the viewer to appear

## Solution

Enable SwiftShader via `--use-gl=swiftshader` flag in Playwright's browser launch options. This provides software-based WebGL rendering in headless CI environments, allowing Cesium to:
- Properly initialize the Viewer
- Render the 3D globe (albeit slower than hardware acceleration)
- Create all expected DOM elements that tests verify

## Impact

- ✅ Fixes flaky `globe.test.ts` failures in PRs #703 and #702
- ✅ Tests now verify actual Cesium rendering, not just error handling
- ✅ More realistic E2E test coverage
- ⚠️ Slightly slower test execution (SwiftShader is slower than hardware GPU)

## Test Plan

Monitor the next few CI runs to ensure:
1. Globe tests pass consistently
2. No new timeout issues
3. Other tests remain unaffected