### PR TITLE
fix: make archive --before argument a flag instead of positional

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -239,7 +239,7 @@ enum Commands {
         /// Cannot be a future date. Flights are archived before this date,
         /// Fixes/ReceiverStatuses before date+1, AprsMessages before date+2.
         /// Defaults to 21 days ago if not specified.
-        #[arg(value_name = "BEFORE_DATE")]
+        #[arg(long, value_name = "BEFORE_DATE")]
         before: Option<String>,
 
         /// Directory where archive files will be stored


### PR DESCRIPTION
## Summary

The archive systemd services (both production and staging) were failing because of an argument mismatch between the service configuration and the command implementation.

## Problem

The systemd service files use:
```bash
soar archive --archive-path /var/soar/archive --before YYYY-MM-DD
```

But the code expected `before` as a **positional argument** (without `--`), causing the archive process to fail.

## Solution

Added `#[arg(long)]` to the `Archive.before` parameter to make it accept `--before` as a proper flag argument, matching the systemd service file syntax.

## Changes

- Modified `src/main.rs:242` to add `#[arg(long)]` to the `before` parameter
- The argument remains optional and defaults to 21 days ago if not specified

## Testing

- ✅ `cargo check` passes
- ✅ `cargo clippy` passes with no warnings
- ✅ Pre-commit hooks pass
- ✅ Verified command help shows correct syntax: `--before <BEFORE_DATE>`

## Command Syntax

**Before:**
```bash
soar archive YYYY-MM-DD --archive-path /path  # Expected positional arg
```

**After:**
```bash
soar archive --archive-path /path --before YYYY-MM-DD  # Matches systemd service
```