### PR TITLE
fix: correct aircraft issues API response interface

### DIFF
--- a/web/src/routes/aircraft/issues/+page.svelte
+++ b/web/src/routes/aircraft/issues/+page.svelte
@@ -6,11 +6,12 @@
 	import AircraftLink from '$lib/components/AircraftLink.svelte';
 
 	interface AircraftIssuesResponse {
-		duplicateDeviceAddresses: Aircraft[];
-		totalCount: number;
-		page: number;
-		perPage: number;
-		totalPages: number;
+		data: Aircraft[];
+		metadata: {
+			page: number;
+			totalPages: number;
+			totalCount: number;
+		};
 	}
 
 	let duplicateDevices = $state<Aircraft[]>([]);
@@ -30,11 +31,10 @@
 				method: 'GET',
 				params: { page, perPage }
 			});
-			duplicateDevices = response.duplicateDeviceAddresses || [];
-			currentPage = response.page;
-			totalPages = response.totalPages;
-			totalCount = response.totalCount;
-			perPage = response.perPage;
+			duplicateDevices = response.data || [];
+			currentPage = response.metadata.page;
+			totalPages = response.metadata.totalPages;
+			totalCount = response.metadata.totalCount;
 		} catch (err) {
 			const errorMessage = err instanceof Error ? err.message : 'Unknown error';
 			error = `Failed to load aircraft issues: ${errorMessage}`;


### PR DESCRIPTION
## Summary
Fixes the aircraft issues page which was showing "No Issues Found" despite 38,873 duplicate aircraft addresses existing in the database.

## Problem
The frontend TypeScript interface didn't match the backend API response structure, causing the data to be ignored.

## Changes
- Updated `AircraftIssuesResponse` interface to match `PaginatedDataResponse` structure
- Changed `duplicateDeviceAddresses` → `data`
- Changed flat metadata fields → nested `metadata` object

## Testing
- API endpoint verified returning 38,873 duplicate aircraft records across 3,888 pages
- Frontend build successful
- Pre-commit hooks passed