### PR TITLE
fix: populate country_code during aircraft upsert

### DIFF
--- a/src/aircraft_repo.rs
+++ b/src/aircraft_repo.rs
@@ -83,13 +83,15 @@ impl AircraftRepository {
                     aircraft::home_base_airport_ident.eq(diesel::dsl::sql(
                         "COALESCE(EXCLUDED.home_base_airport_ident, aircraft.home_base_airport_ident)"
                     )),
+                    aircraft::country_code.eq(diesel::dsl::sql(
+                        "COALESCE(EXCLUDED.country_code, aircraft.country_code)"
+                    )),
                     aircraft::updated_at.eq(diesel::dsl::now),
                     // NOTE: We do NOT update the following fields because they come from real-time packets:
                     // - aircraft_type_ogn (from OGN packets)
                     // - icao_model_code (from ADSB packets)
                     // - adsb_emitter_category (from ADSB packets)
                     // - tracker_device_type (from tracker packets)
-                    // - country_code (derived from ICAO address, managed separately)
                     // - last_fix_at (managed by fix processing)
                     // - club_id (managed by club assignment logic)
                 ))


### PR DESCRIPTION
## Summary
- Fix aircraft upsert to populate `country_code` when new data is available
- Use COALESCE to preserve existing values and never overwrite with NULL
- Resolves issue where aircraft with registrations had NULL country codes

## Problem
Aircraft could have NULL `country_code` even with valid registrations like "LX-VCF" because:
1. The upsert logic explicitly excluded `country_code` from updates
2. Daily backfill runs would populate missing country codes
3. BUT real-time fix processing would update aircraft AFTER backfill runs
4. Each update reset `updated_at` without touching `country_code`, keeping it NULL until next day's backfill

Example: Aircraft LX-VCF (Luxembourg) showed no country flag despite having both registration and ICAO address.

## Solution
Added `country_code` to the upsert update logic with COALESCE:
```rust
aircraft::country_code.eq(diesel::dsl::sql(
    "COALESCE(EXCLUDED.country_code, aircraft.country_code)"
)),
```

This ensures:
- ✅ New country codes are populated when available (from ICAO address or registration)
- ✅ Existing country codes are preserved
- ✅ NULL values are never written over existing data
- ✅ Aircraft updated after backfill runs will get country codes immediately

## Test Plan
- [x] `cargo fmt` - formatting passed
- [x] `cargo check` - compilation successful
- [x] Pre-commit hooks passed (clippy, tests)
- [ ] Verify on staging: LX-VCF gets country code "LU" on next fix update
- [ ] Monitor Grafana for any upsert errors after deployment