### PR TITLE
feat: increase archive retention period from 21 to 45 days

### DIFF
--- a/infrastructure/systemd/soar-archive.service
+++ b/infrastructure/systemd/soar-archive.service
@@ -11,12 +11,9 @@ User=soar
 Group=soar
 WorkingDirectory=/var/soar
 
-# Run archive command with default retention (21 days ago)
-# Archives data with staggered retention:
-#   - Flights: 21+ days old
-#   - Fixes and ReceiverStatuses: 22+ days old
-#   - AprsMessages: 23+ days old
-# The archive command defaults to 21 days ago if no date is specified
+# Run archive command with default retention (45 days ago)
+# Archives all data (flights, fixes, receiver_statuses, raw_messages) 45+ days old
+# The archive command defaults to 45 days ago if no date is specified
 ExecStart=/usr/local/bin/soar archive --archive-path /var/soar/archive
 
 # Environment variables

--- a/src/commands/archive/mod.rs
+++ b/src/commands/archive/mod.rs
@@ -23,7 +23,7 @@ use tracing::info;
 /// 4. RawMessages (parents last - nothing references them anymore)
 ///
 /// All tables archive data from the same date (before_date).
-/// Defaults to 21 days ago if no before date is specified.
+/// Defaults to 45 days ago if no before date is specified.
 pub async fn handle_archive(
     pool: PgPool,
     before: Option<String>,
@@ -44,8 +44,8 @@ pub async fn handle_archive(
             before_str
         ))?
     } else {
-        // Default to 21 days ago
-        Utc::now().date_naive() - chrono::Duration::days(21)
+        // Default to 45 days ago
+        Utc::now().date_naive() - chrono::Duration::days(45)
     };
 
     // Get today's date (UTC)

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,22 +223,19 @@ enum Commands {
     },
     /// Archive old data to compressed CSV files and delete from database
     ///
-    /// Archives data with staggered retention to respect foreign key constraints:
-    /// 1. Flights (before_date + 0 days)
-    /// 2. Fixes and ReceiverStatuses (before_date + 1 day)
-    /// 3. AprsMessages (before_date + 2 days)
+    /// Archives data in correct order to respect foreign key constraints:
+    /// 1. Fixes (children - reference flights and raw_messages)
+    /// 2. ReceiverStatuses (children - reference raw_messages)
+    /// 3. Flights (parents - after fixing self-references)
+    /// 4. RawMessages (parents - archived last)
     ///
-    /// Default: Uses 21 days ago, which archives:
-    /// - Flights: 21+ days old
-    /// - Fixes and ReceiverStatuses: 22+ days old
-    /// - AprsMessages: 23+ days old
+    /// Default: Uses 45 days ago, which archives all data 45+ days old
     ///
     /// Each day's data is written to files named YYYYMMDD-{table}.csv.zst
     Archive {
         /// Archive data before this date (YYYY-MM-DD format, exclusive, UTC)
-        /// Cannot be a future date. Flights are archived before this date,
-        /// Fixes/ReceiverStatuses before date+1, AprsMessages before date+2.
-        /// Defaults to 21 days ago if not specified.
+        /// Cannot be a future date. All tables archive data before this date.
+        /// Defaults to 45 days ago if not specified.
         #[arg(long, value_name = "BEFORE_DATE")]
         before: Option<String>,
 


### PR DESCRIPTION
## Summary

Increase the default archive retention period from 21 days to 45 days to keep more historical data available in the active database.

## Changes

- **Default retention:** 21 days → 45 days
- Updated `src/commands/archive/mod.rs` to use 45-day default
- Updated `src/main.rs` documentation to reflect new retention period
- Clarified that all tables use the same retention period (not staggered)
- Updated `infrastructure/systemd/soar-archive.service` comments

## Behavior

The archive process now keeps a full **45 days** of data in the database before archiving to compressed CSV files:
- Flights
- Fixes
- ReceiverStatuses
- RawMessages

All tables archive data from the same date (simplified from previous staggered approach).

## Testing

- ✅ `cargo check` passes
- ✅ `cargo clippy` passes
- ✅ Verified help text: `./target/debug/soar archive --help`
- ✅ Pre-commit hooks pass

## Command Help Output

```
Default: Uses 45 days ago, which archives all data 45+ days old
```