### PR TITLE
feat: add --max-age-days flag and update staging retention to 45 days

### DIFF
--- a/infrastructure/systemd/soar-archive-staging.service
+++ b/infrastructure/systemd/soar-archive-staging.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=SOAR Archive (Staging) - Archive Old Data (3-day retention)
+Description=SOAR Archive (Staging) - Archive Old Data (45-day retention)
 Documentation=https://github.com/hut8/soar
 After=network-online.target postgresql.service
 Wants=network-online.target
@@ -11,10 +11,9 @@ User=soar
 Group=soar
 WorkingDirectory=/var/soar
 
-# Archive with 3-day retention (vs production's 21-day retention)
-# Calculates date dynamically: 3 days ago
-# Double %% is required in systemd unit files for date command
-ExecStart=/bin/bash -c 'source /etc/soar/env-staging && /usr/local/bin/soar-staging archive --archive-path /var/soar/archive-staging --before $(date -d "3 days ago" +%%Y-%%m-%%d)'
+# Run archive command with 45-day retention (same as production)
+# Archives all data (flights, fixes, receiver_statuses, raw_messages) 45+ days old
+ExecStart=/usr/local/bin/soar-staging archive --max-age-days 45 --archive-path /var/soar/archive-staging
 
 # Environment variables (staging environment)
 EnvironmentFile=/etc/soar/env-staging

--- a/infrastructure/systemd/soar-archive-staging.timer
+++ b/infrastructure/systemd/soar-archive-staging.timer
@@ -1,14 +1,11 @@
 # SOAR Archive Timer (Staging)
 #
 # This systemd timer automatically runs the `soar archive` command once daily at 2:00 AM
-# for the staging environment with 3-day retention.
-# It archives data older than 3 days to compressed CSV files in /var/soar/archive-staging
+# for the staging environment with 45-day retention (same as production).
+# It archives data older than 45 days to compressed CSV files in /var/soar/archive-staging
 # and deletes the archived data from the database.
 #
-# Retention periods (staggered to prevent foreign key violations):
-#   - Flights: 3+ days old
-#   - Fixes and ReceiverStatuses: 4+ days old
-#   - AprsMessages: 5+ days old
+# Retention period: 45+ days old (all tables use the same retention period)
 #
 # Installation:
 #   sudo cp soar-archive-staging.service soar-archive-staging.timer /etc/systemd/system/
@@ -27,7 +24,7 @@
 #   sudo journalctl -u soar-archive-staging.service -f
 
 [Unit]
-Description=SOAR Archive Timer (Staging) - Daily Archival with 3-Day Retention
+Description=SOAR Archive Timer (Staging) - Daily Archival with 45-Day Retention
 Requires=soar-archive-staging.service
 
 [Timer]

--- a/infrastructure/systemd/soar-archive.service
+++ b/infrastructure/systemd/soar-archive.service
@@ -11,10 +11,9 @@ User=soar
 Group=soar
 WorkingDirectory=/var/soar
 
-# Run archive command with default retention (45 days ago)
+# Run archive command with 45-day retention
 # Archives all data (flights, fixes, receiver_statuses, raw_messages) 45+ days old
-# The archive command defaults to 45 days ago if no date is specified
-ExecStart=/usr/local/bin/soar archive --archive-path /var/soar/archive
+ExecStart=/usr/local/bin/soar archive --max-age-days 45 --archive-path /var/soar/archive
 
 # Environment variables
 EnvironmentFile=/etc/soar/env-production

--- a/infrastructure/systemd/soar-archive.timer
+++ b/infrastructure/systemd/soar-archive.timer
@@ -1,13 +1,10 @@
 # SOAR Archive Timer
 #
 # This systemd timer automatically runs the `soar archive` command once daily at 2:00 AM.
-# It archives data older than specified retention periods to compressed CSV files in /var/soar/archive
+# It archives data older than 45 days to compressed CSV files in /var/soar/archive
 # and deletes the archived data from the database.
 #
-# Retention periods (staggered to prevent foreign key violations):
-#   - Flights: 8+ days old
-#   - Fixes and ReceiverStatuses: 9+ days old
-#   - AprsMessages: 10+ days old
+# Retention period: 45+ days old (all tables use the same retention period)
 #
 # Installation:
 #   sudo cp soar-archive.service soar-archive.timer /etc/systemd/system/


### PR DESCRIPTION
## Summary
- Add `--max-age-days` parameter to `archive` command for easier retention configuration without calculating dates
- Update staging environment to use 45-day retention (previously 3 days, now matches production)
- Simplify systemd service files by removing bash wrapper with dynamic date calculation
- Mark `--before` parameter as deprecated in favor of `--max-age-days`

## Changes
- **src/main.rs**: Add `--max-age-days` flag to Archive command, convert days to date internally
- **infrastructure/systemd/soar-archive.service**: Use explicit `--max-age-days 45`
- **infrastructure/systemd/soar-archive-staging.service**: Changed from 3-day to 45-day retention, simplified ExecStart
- **infrastructure/systemd/*.timer**: Updated documentation to reflect 45-day retention

## Usage
```bash
# New simplified approach
soar archive --max-age-days 45 --archive-path /var/soar/archive

# Old approach (still works, but deprecated)
soar archive --before 2025-11-15 --archive-path /var/soar/archive
```

## Test plan
- [x] cargo fmt passes
- [x] cargo clippy passes
- [x] Pre-commit hooks pass
- [ ] Verify staging service file works after deployment
- [ ] Verify production service file works after deployment