### PR TITLE
Improve clustering behavior on operations page

### DIFF
--- a/src/actions/aircraft_search.rs
+++ b/src/actions/aircraft_search.rs
@@ -290,11 +290,11 @@ async fn search_aircraft_by_bbox(
 
     info!("Total aircraft in bounding box: {}", total_count);
 
-    // Use clustering if total count exceeds 50 aircraft
-    if total_count > 50 {
-        info!("Total count exceeds 50, using clustering");
+    // Use clustering if total count exceeds 250 aircraft
+    if total_count > 250 {
+        info!("Total count exceeds 250, using clustering");
 
-        let grid_size = 0.1; // 0.1 degrees (~11km)
+        let grid_size = 0.25; // 0.25 degrees (~28km)
 
         match fixes_repo
             .get_clustered_aircraft_in_bounding_box(


### PR DESCRIPTION
## Summary
This PR improves the aircraft clustering behavior on the operations page by making clusters larger and more visually intuitive.

## Changes

### Backend (`src/actions/aircraft_search.rs`)
- **Increased clustering threshold** from 50 to 250 aircraft
  - Prevents premature clustering when there aren't many aircraft visible
- **Increased grid size** from 0.1° to 0.25° (~11km to ~28km)
  - Creates larger clusters with more aircraft per cluster
  - Significantly reduces single-aircraft clusters

### Frontend (`web/src/routes/operations/+page.svelte`)
- **Replaced circular cluster markers** with polygon outlines
  - Polygons show the actual geographic bounds of each cluster
  - 10% blue fill with 80% opacity border
- **Added compact labeled markers** at cluster centroids
  - Small airplane icon (16x16px) + aircraft count
  - Blue background with rounded corners and hover effects
- **Updated cleanup logic** to properly remove both markers and polygons

## Visual Changes
**Before:** Small circles with counts (most clusters had only 1 aircraft)
**After:** Polygon outlines showing cluster area + compact label with icon and count

## Testing
- ✅ Rust: `cargo fmt` and `cargo check` passed
- ✅ Frontend: TypeScript type checking passed
- ✅ Frontend: Linting and formatting passed
- ✅ All pre-commit hooks passed