### PR TITLE
fix: improve clustering behavior and viewport management

### DIFF
--- a/src/actions/aircraft_search.rs
+++ b/src/actions/aircraft_search.rs
@@ -294,7 +294,7 @@ async fn search_aircraft_by_bbox(
     if total_count > 250 {
         info!("Total count exceeds 250, using clustering");
 
-        let grid_size = 0.25; // 0.25 degrees (~28km)
+        let grid_size = 1.0; // 1.0 degree (~111km)
 
         match fixes_repo
             .get_clustered_aircraft_in_bounding_box(


### PR DESCRIPTION
## Summary

Fixes clustering activation and viewport management issues on the operations map:

- **Fix clustering activation on zoom**: Clustering now activates automatically when zoomed out to world view, regardless of area tracker state
- **Add 1-second zoom debounce**: Prevents excessive API calls during continuous zooming
- **Clear aircraft outside viewport**: "Forgets" aircraft outside the current viewport by clearing the registry
- **Add console logs**: Tracks aircraft/cluster count every time markers are added to map
- **Increase cluster grid size**: Changed from 0.25° to 1.0° (~28km to ~111km cells) for more visible clusters

## Problem

Previously, when zooming out to world view, clustering would not activate until the page was refreshed. This was because clustering only occurred when the area tracker was active.

## Solution

Now the viewport change handlers (zoom and pan) always fetch aircraft in the current bounding box, which automatically triggers clustering if >250 aircraft are found. This works independently of the area tracker state.

Additionally, zooming and panning now completely replace the client-side aircraft registry with only the aircraft visible in the current viewport, reducing memory usage and improving performance.

## Test plan

- [x] Zoom out to world view and verify clustering activates after 1 second
- [x] Zoom in to a region and verify individual aircraft appear after 1 second
- [x] Pan the map and verify aircraft outside viewport are cleared
- [x] Check console logs for `[AIRCRAFT COUNT]` messages
- [x] Verify clusters are larger/more visible with 1.0° grid size