### PR TITLE
feat: increase cluster grid size to 3 degrees

### DIFF
--- a/src/actions/aircraft_search.rs
+++ b/src/actions/aircraft_search.rs
@@ -294,7 +294,7 @@ async fn search_aircraft_by_bbox(
     if total_count > 250 {
         info!("Total count exceeds 250, using clustering");
 
-        let grid_size = 1.0; // 1.0 degree (~111km)
+        let grid_size = 3.0; // 3.0 degrees (~333km)
 
         match fixes_repo
             .get_clustered_aircraft_in_bounding_box(


### PR DESCRIPTION
## Summary

Increases the cluster grid size from 1.0° to 3.0° (~111km to ~333km cells) for even larger, more visible clusters at world-scale zoom levels.

## Change

- Grid size: 1.0° → 3.0° (~333km cells)

## Rationale

Larger clusters make it easier to visualize aircraft density when zoomed out to continental or global scale. The 3-degree grid ensures clusters are clearly visible and distinguishable at any zoom level.

## Test plan

- [x] Zoom out to world view and verify clusters are larger
- [x] Check that cluster polygons are more visible