### PR TITLE
fix: use grid cell bounds for clusters instead of aircraft min/max

### DIFF
--- a/src/actions/aircraft_search.rs
+++ b/src/actions/aircraft_search.rs
@@ -319,17 +319,26 @@ async fn search_aircraft_by_bbox(
                             (cluster.grid_lng * 1000.0) as i64
                         );
 
+                        // Calculate grid cell bounds and center
+                        // grid_lat/grid_lng are the lower-left corner of the grid cell
+                        let grid_north = cluster.grid_lat + grid_size;
+                        let grid_south = cluster.grid_lat;
+                        let grid_east = cluster.grid_lng + grid_size;
+                        let grid_west = cluster.grid_lng;
+                        let grid_center_lat = cluster.grid_lat + (grid_size / 2.0);
+                        let grid_center_lng = cluster.grid_lng + (grid_size / 2.0);
+
                         AircraftOrCluster::Cluster {
                             data: AircraftCluster {
                                 id: cluster_id,
-                                latitude: cluster.centroid_lat,
-                                longitude: cluster.centroid_lng,
+                                latitude: grid_center_lat,
+                                longitude: grid_center_lng,
                                 count: cluster.aircraft_count,
                                 bounds: ClusterBounds {
-                                    north: cluster.max_lat,
-                                    south: cluster.min_lat,
-                                    east: cluster.max_lng,
-                                    west: cluster.min_lng,
+                                    north: grid_north,
+                                    south: grid_south,
+                                    east: grid_east,
+                                    west: grid_west,
                                 },
                             },
                         }


### PR DESCRIPTION
## Summary

Fixes cluster display so all cluster rectangles are the same size and labels are centered within them.

## Problem

Previously, cluster bounds were calculated using the min/max coordinates of aircraft within each grid cell. This caused:
1. **Different sized rectangles** - Each cluster had different bounds based on how spread out the aircraft were
2. **Labels far from rectangles** - Labels used the aircraft centroid while rectangles used min/max bounds
3. **Confusing visualization** - The display didn't match the actual grid-based clustering algorithm

## Solution

Now cluster bounds are calculated based on the actual grid cell:
- **Bounds**: Use the grid cell itself (grid_lat to grid_lat+3°, grid_lng to grid_lng+3°)
- **Label position**: Center of the grid cell (grid_lat+1.5°, grid_lng+1.5°)
- **Result**: All cluster rectangles are exactly 3° x 3° and labels are always centered

## Changes

- Calculate `grid_north`, `grid_south`, `grid_east`, `grid_west` from grid cell
- Calculate `grid_center_lat`, `grid_center_lng` for label positioning
- Use these calculated values instead of `min_lat`, `max_lat`, etc.

## Test plan

- [x] Zoom out to trigger clustering
- [x] Verify all cluster rectangles are the same size (3° x 3°)
- [x] Verify labels are centered within their rectangles
- [x] Verify rectangles don't overlap (proper grid alignment)