### PR TITLE
debug: add bright red outlines for cluster bounds debugging

### DIFF
--- a/web/src/routes/operations/+page.svelte
+++ b/web/src/routes/operations/+page.svelte
@@ -1584,6 +1584,17 @@
 		});
 
 		// Create polygon outline for the cluster bounds
+		// DEBUG: Using bright red outline to visualize grid cells
+		console.log('[CLUSTER DEBUG] Bounds:', {
+			id: cluster.id,
+			north: cluster.bounds.north,
+			south: cluster.bounds.south,
+			east: cluster.bounds.east,
+			west: cluster.bounds.west,
+			width: cluster.bounds.east - cluster.bounds.west,
+			height: cluster.bounds.north - cluster.bounds.south
+		});
+
 		const polygon = new google.maps.Polygon({
 			paths: [
 				{ lat: cluster.bounds.north, lng: cluster.bounds.west },
@@ -1591,10 +1602,10 @@
 				{ lat: cluster.bounds.south, lng: cluster.bounds.east },
 				{ lat: cluster.bounds.south, lng: cluster.bounds.west }
 			],
-			strokeColor: '#3B82F6',
-			strokeOpacity: 0.8,
-			strokeWeight: 2,
-			fillColor: '#3B82F6',
+			strokeColor: '#FF0000', // DEBUG: Bright red
+			strokeOpacity: 1.0, // DEBUG: Fully opaque
+			strokeWeight: 4, // DEBUG: Thick outline
+			fillColor: '#FF0000', // DEBUG: Red fill
 			fillOpacity: 0.1,
 			map: map,
 			zIndex: 400


### PR DESCRIPTION
## Summary

Adds bright red debug visualization to cluster rectangles to help diagnose sizing issues.

## Changes

- **Bright red outline**: Changed stroke from blue to red (#FF0000)
- **Fully opaque**: Changed opacity from 0.8 to 1.0
- **Thicker stroke**: Changed weight from 2px to 4px
- **Console logging**: Logs bounds with width/height for each cluster

## Purpose

This helps debug whether:
1. The backend is correctly calculating 3°x3° grid cells
2. The frontend is correctly rendering the bounds
3. Different sized rectangles are from the backend data or rendering issue

## How to Use

1. Zoom out to trigger clustering
2. Open browser console
3. Look for `[CLUSTER DEBUG] Bounds:` messages
4. Check if width and height are both 3.0 degrees
5. Visually inspect red rectangles on map

## Expected Output

If working correctly, all console logs should show:
```
width: 3
height: 3
```

And all red rectangles should be the same size.