### PR TITLE
feat: increase cluster grid to 5 degrees with proper alignment and centering

### DIFF
--- a/src/actions/aircraft_search.rs
+++ b/src/actions/aircraft_search.rs
@@ -294,7 +294,7 @@ async fn search_aircraft_by_bbox(
     if total_count > 250 {
         info!("Total count exceeds 250, using clustering");
 
-        let grid_size = 3.0; // 3.0 degrees (~333km)
+        let grid_size = 5.0; // 5.0 degrees (~555km)
 
         match fixes_repo
             .get_clustered_aircraft_in_bounding_box(
@@ -320,13 +320,13 @@ async fn search_aircraft_by_bbox(
                         );
 
                         // Calculate grid cell bounds and center
-                        // grid_lat/grid_lng are the lower-left corner of the grid cell
-                        let grid_north = cluster.grid_lat + grid_size;
-                        let grid_south = cluster.grid_lat;
-                        let grid_east = cluster.grid_lng + grid_size;
-                        let grid_west = cluster.grid_lng;
-                        let grid_center_lat = cluster.grid_lat + (grid_size / 2.0);
-                        let grid_center_lng = cluster.grid_lng + (grid_size / 2.0);
+                        // Align to multiples of grid_size for uniform, aligned grid cells
+                        let grid_south = (cluster.grid_lat / grid_size).floor() * grid_size;
+                        let grid_north = grid_south + grid_size;
+                        let grid_west = (cluster.grid_lng / grid_size).floor() * grid_size;
+                        let grid_east = grid_west + grid_size;
+                        let grid_center_lat = grid_south + (grid_size / 2.0);
+                        let grid_center_lng = grid_west + (grid_size / 2.0);
 
                         AircraftOrCluster::Cluster {
                             data: AircraftCluster {

--- a/web/src/routes/operations/+page.svelte
+++ b/web/src/routes/operations/+page.svelte
@@ -1626,27 +1626,29 @@
 		markerContent.style.flexDirection = 'column';
 		markerContent.style.alignItems = 'center';
 		markerContent.style.justifyContent = 'center';
-		markerContent.style.gap = '4px';
+		markerContent.style.gap = '2px';
 		markerContent.style.cursor = 'pointer';
 		markerContent.style.pointerEvents = 'auto';
+		markerContent.style.position = 'relative';
 
-		// Airplane SVG icon with white fill and shadow
+		// Airplane SVG icon with white fill and shadow - SMALLER
 		const iconDiv = document.createElement('div');
 		iconDiv.style.display = 'flex';
 		iconDiv.style.alignItems = 'center';
 		iconDiv.style.justifyContent = 'center';
 		iconDiv.style.filter = 'drop-shadow(0 2px 4px rgba(0, 0, 0, 0.8))';
-		iconDiv.innerHTML = `<svg width="24" height="24" viewBox="0 0 24 24" fill="white">
+		iconDiv.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="white">
 			<path d="M21 16v-2l-8-5V3.5c0-.83-.67-1.5-1.5-1.5S10 2.67 10 3.5V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5l8 2.5z"/>
 		</svg>`;
 
-		// Count label with shadow for visibility
+		// Count label with shadow for visibility - SMALLER
 		const countLabel = document.createElement('div');
 		countLabel.style.color = 'white';
 		countLabel.style.fontWeight = 'bold';
-		countLabel.style.fontSize = '18px';
+		countLabel.style.fontSize = '14px';
 		countLabel.style.textShadow = '0 2px 4px rgba(0, 0, 0, 0.8), 0 0 8px rgba(0, 0, 0, 0.6)';
 		countLabel.style.whiteSpace = 'nowrap';
+		countLabel.style.lineHeight = '1';
 		countLabel.textContent = cluster.count.toString();
 
 		markerContent.appendChild(iconDiv);


### PR DESCRIPTION
## Summary

Increases cluster grid size to 5 degrees and fixes alignment to ensure all cluster rectangles are uniform and properly positioned.

## Backend Changes

- **Grid size**: 3.0° → 5.0° (~555km cells)
- **Grid alignment**: Now aligns to multiples of 5 using `floor()` calculation
  - Example: latitude 44.4 snaps to grid 40-45, latitude 47.2 snaps to grid 45-50
- **True centering**: Labels positioned at exact grid cell center (e.g., 42.5°, 47.5°)

## Frontend Changes

- **Smaller icon**: 24px → 16px airplane icon
- **Smaller text**: 18px → 14px count text
- **Tighter spacing**: 4px → 2px gap between icon and text
- **Better rendering**: Added line-height: 1 and position: relative for proper layout

## Results

All cluster rectangles will now be:
- **Exactly 5° x 5°** in size
- **Aligned to multiples of 5** (e.g., 40-45, 45-50, -10 to -5, etc.)
- **Icon and text properly sized** to fit comfortably within the 5° cells
- **Console logs will show** `width: 5, height: 5` for every cluster

## Test Plan

- [x] Zoom out to trigger clustering
- [x] Open console and verify all clusters show width: 5, height: 5
- [x] Verify red rectangles are all the same size
- [x] Verify icon and number are smaller and fit within rectangles
- [x] Check that rectangles align to multiples of 5 (north/south/east/west values)