### PR TITLE
fix: improve 3D globe aircraft loading and display

### DIFF
--- a/web/src/lib/cesium/entities.ts
+++ b/web/src/lib/cesium/entities.ts
@@ -57,9 +57,14 @@ export function createAircraftIconSVG(color: string, heading: number = 0): strin
  * Create a Cesium Entity for an aircraft
  * @param aircraft - Aircraft data
  * @param fix - Latest fix for the aircraft
+ * @param showLabel - Whether to show the text label (default: true)
  * @returns Cesium Entity configured as aircraft marker
  */
-export function createAircraftEntity(aircraft: Aircraft, fix: Fix): Entity {
+export function createAircraftEntity(
+	aircraft: Aircraft,
+	fix: Fix,
+	showLabel: boolean = true
+): Entity {
 	const altitude = fix.altitudeMslFeet || 0;
 	const altitudeMeters = altitude * FEET_TO_METERS;
 
@@ -82,20 +87,22 @@ export function createAircraftEntity(aircraft: Aircraft, fix: Fix): Entity {
 		billboard: {
 			image: iconUrl,
 			scale: 1.0,
-			verticalOrigin: VerticalOrigin.BOTTOM,
+			verticalOrigin: VerticalOrigin.CENTER, // Center the icon so selection box is centered
 			horizontalOrigin: HorizontalOrigin.CENTER,
 			heightReference: HeightReference.NONE // Use absolute altitude
 		},
-		label: {
-			text: `${displayName}\n${altitudeText}`,
-			font: '12px sans-serif',
-			fillColor: Color.WHITE,
-			outlineColor: Color.BLACK,
-			outlineWidth: 3,
-			pixelOffset: { x: 0, y: -40 } as unknown as Cartesian2,
-			heightReference: HeightReference.NONE,
-			disableDepthTestDistance: Number.POSITIVE_INFINITY // Always show label
-		},
+		label: showLabel
+			? {
+					text: `${displayName}\n${altitudeText}`,
+					font: '12px sans-serif',
+					fillColor: Color.WHITE,
+					outlineColor: Color.BLACK,
+					outlineWidth: 3,
+					pixelOffset: { x: 0, y: -30 } as unknown as Cartesian2, // Adjusted offset for centered billboard
+					heightReference: HeightReference.NONE,
+					disableDepthTestDistance: Number.POSITIVE_INFINITY // Always show label
+				}
+			: undefined, // Hide label when showLabel is false
 		description: `
 			<h3>${displayName}</h3>
 			<p><strong>Model:</strong> ${aircraft.aircraftModel || 'Unknown'}</p>


### PR DESCRIPTION
## Summary
- Use clustering API from operations page for consistent aircraft loading with bounding box
- Add zoom-based label visibility to prevent text overlap at wide zoom angles (hides labels when camera > 500km altitude)
- Implement debounced area subscription updates when globe rotates (1s debounce)
- Fix aircraft selection box centering by using CENTER vertical origin instead of BOTTOM
- Fix schema mismatch - API returns AircraftSearchResponse not Aircraft[]

## Test plan
- [ ] Load globe and verify aircraft appear with proper labels
- [ ] Zoom out and verify labels disappear at wide angles
- [ ] Zoom in and verify labels reappear
- [ ] Rotate globe and verify aircraft update smoothly without excessive API calls
- [ ] Click on aircraft and verify green selection box is centered on the icon (not with icon at top)
- [ ] Verify aircraft data displays correctly (not "Unknown")