### PR TITLE
Add component labels to metrics and fix analytics dashboard

### DIFF
--- a/infrastructure/grafana-dashboard-analytics.json
+++ b/infrastructure/grafana-dashboard-analytics.json
@@ -176,7 +176,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT\n  date as time,\n  (SELECT COUNT(*) FROM flights f\n   JOIN aircraft d ON f.aircraft_id = d.id\n   WHERE f.takeoff_time::date = fad.date\n   AND d.ogn_aircraft_type = 'glider') as \"Glider Flights\",\n  tow_count as \"Tow Flights\"\nFROM flight_analytics_daily fad\nWHERE date >= CURRENT_DATE - 30\nORDER BY date ASC",
+          "rawSql": "SELECT\n  date as time,\n  (SELECT COUNT(*) FROM flights f\n   JOIN aircraft d ON f.aircraft_id = d.id\n   WHERE f.takeoff_time::date = fad.date\n   AND d.aircraft_type_ogn = 'glider') as \"Glider Flights\",\n  tow_count as \"Tow Flights\"\nFROM flight_analytics_daily fad\nWHERE date >= CURRENT_DATE - 30\nORDER BY date ASC",
           "refId": "A",
           "sql": {
             "columns": [],

--- a/src/commands/ingest_adsb.rs
+++ b/src/commands/ingest_adsb.rs
@@ -99,7 +99,7 @@ pub async fn handle_ingest_adsb(
         info!("Starting metrics server on port {}", metrics_port);
         tokio::spawn(
             async move {
-                soar::metrics::start_metrics_server(metrics_port).await;
+                soar::metrics::start_metrics_server(metrics_port, Some("ingest-adsb")).await;
             }
             .instrument(tracing::info_span!("metrics_server")),
         );

--- a/src/commands/ingest_ogn.rs
+++ b/src/commands/ingest_ogn.rs
@@ -77,7 +77,7 @@ pub async fn handle_ingest_ogn(
         info!("Starting metrics server on port {}", metrics_port);
         tokio::spawn(
             async move {
-                soar::metrics::start_metrics_server(metrics_port).await;
+                soar::metrics::start_metrics_server(metrics_port, Some("ingest-ogn")).await;
             }
             .instrument(tracing::info_span!("metrics_server")),
         );

--- a/src/commands/pull_data.rs
+++ b/src/commands/pull_data.rs
@@ -163,7 +163,7 @@ pub async fn handle_pull_data(diesel_pool: Pool<ConnectionManager<PgConnection>>
     let soar_env = env::var("SOAR_ENV").unwrap_or_default();
     let metrics_port = if soar_env == "staging" { 9102 } else { 9092 };
     tokio::spawn(async move {
-        soar::metrics::start_metrics_server(metrics_port).await;
+        soar::metrics::start_metrics_server(metrics_port, Some("pull-data")).await;
     });
 
     // Create temporary directory with date only (no time)

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -339,7 +339,7 @@ pub async fn handle_run(
         info!("Starting metrics server on port {}", metrics_port);
         tokio::spawn(
             async move {
-                soar::metrics::start_metrics_server(metrics_port).await;
+                soar::metrics::start_metrics_server(metrics_port, Some("run")).await;
             }
             .instrument(tracing::info_span!("metrics_server")),
         );

--- a/src/web.rs
+++ b/src/web.rs
@@ -547,8 +547,8 @@ pub async fn start_web_server(interface: String, port: u16, pool: PgPool) -> Res
         scope.set_tag("operation", "web-server");
     });
 
-    // Initialize Prometheus metrics exporter
-    let metrics_handle = crate::metrics::init_metrics();
+    // Initialize Prometheus metrics exporter with "web" component label
+    let metrics_handle = crate::metrics::init_metrics(Some("web"));
     METRICS_HANDLE
         .set(metrics_handle)
         .expect("Metrics handle already initialized");


### PR DESCRIPTION
## Summary
- Add global `component` labels to all Prometheus metrics exporters
- Fix analytics dashboard SQL query column name error
- Created Beast receiver record in staging database

## Changes

### Metrics Component Labels
- Modified `init_metrics()` to accept optional component parameter
- Added component labels to all services:
  - `ingest-adsb` → `component="ingest-adsb"`
  - `ingest-ogn` → `component="ingest-ogn"`  
  - `run` → `component="run"`
  - `web` → `component="web"`
  - `pull-data` → `component="pull-data"`

This fixes the "no data" issue in Grafana dashboards that filter by component label.

### Analytics Dashboard Fix
- Fixed SQL query in `grafana-dashboard-analytics.json`
- Changed `d.ogn_aircraft_type` → `d.aircraft_type_ogn` to match actual column name

### Database Fix (Staging Only)
- Created Beast receiver record (`61190c6d-7b2b-54c5-b102-22774e5f9cee`) in staging database
- Fixes foreign key constraint violation when storing ADS-B raw messages

## Test Plan
- [x] Verified metrics now have component labels (checked `/metrics` endpoint)
- [x] Confirmed Grafana ADS-B dashboard shows data after restart
- [x] Analytics dashboard no longer shows column error
- [x] ADS-B messages successfully stored in staging database