### PR TITLE
Hotfix: Add RuntimeDirectory to soar-run systemd services

### DIFF
--- a/infrastructure/systemd/soar-run-staging.service
+++ b/infrastructure/systemd/soar-run-staging.service
@@ -18,6 +18,10 @@ ExecReload=/bin/kill -s HUP $MAINPID
 # Environment variables (staging environment)
 EnvironmentFile=/etc/soar/env-staging
 
+# Runtime directory for Unix sockets
+RuntimeDirectory=soar
+RuntimeDirectoryMode=0755
+
 # Security settings
 NoNewPrivileges=yes
 ReadWritePaths=-/var/soar

--- a/infrastructure/systemd/soar-run.service
+++ b/infrastructure/systemd/soar-run.service
@@ -18,6 +18,10 @@ ExecReload=/bin/kill -s HUP $MAINPID
 # Environment variables
 EnvironmentFile=/etc/soar/env-production
 
+# Runtime directory for Unix sockets
+RuntimeDirectory=soar
+RuntimeDirectoryMode=0755
+
 # Security settings
 NoNewPrivileges=yes
 ReadWritePaths=-/var/soar


### PR DESCRIPTION
## Problem

Staging deployment is failing with:
```
Failed to create socket directory: "/var/run/soar"
```

The Unix socket server needs to create `/var/run/soar/run.sock` but the directory doesn't exist and the service doesn't have permission to create it.

## Solution

Added `RuntimeDirectory=soar` and `RuntimeDirectoryMode=0755` to both service files:
- `soar-run-staging.service`
- `soar-run.service`

Systemd will automatically create `/var/run/soar` with ownership `soar:soar` when the service starts.

## Files Changed
- `infrastructure/systemd/soar-run-staging.service`
- `infrastructure/systemd/soar-run.service`

## Urgency
**CRITICAL** - Staging is currently down and needs this fix to start.