### PR TITLE
Change backup location to /storage/soar/backups/base

### DIFF
--- a/infrastructure/examples/backup-env.example
+++ b/infrastructure/examples/backup-env.example
@@ -113,7 +113,7 @@ PG_VERSION=18
 # Temporary directory for staging backups during creation
 # Needs space for ~150GB compressed backup during upload
 # Will be automatically created if it doesn't exist
-BACKUP_TEMP_DIR=/var/lib/soar/backup-temp
+BACKUP_TEMP_DIR=/storage/soar/backups/base
 
 # Directory for backup logs
 # Will be automatically created if it doesn't exist

--- a/infrastructure/systemd/soar-backup-base.service
+++ b/infrastructure/systemd/soar-backup-base.service
@@ -19,7 +19,7 @@ EnvironmentFile=/etc/soar/backup-env
 
 # Security settings
 NoNewPrivileges=yes
-ReadWritePaths=-/var/lib/soar/backup-temp
+ReadWritePaths=-/storage/soar/backups/base
 
 # Process limits
 LimitNOFILE=65536


### PR DESCRIPTION
## Summary
Updates the database backup system to use `/storage/soar/backups/base` instead of `/var/lib/soar/backup-temp` for staging backups.

## Changes
- Updated `soar-backup-base.service` ReadWritePaths to grant access to new location
- Updated `backup-env.example` to document new default BACKUP_TEMP_DIR

## Why
The new location provides better organization and ensures sufficient space for ~150GB compressed backups during upload.

## Deployment Notes
After deploying, update `/etc/soar/backup-env` on the server with:
```
BACKUP_TEMP_DIR=/storage/soar/backups/base
```

The backup script will automatically create this directory if it doesn't exist.