### PR TITLE
Update all remaining references to new backup location

### DIFF
--- a/docs/BACKUP-QUICKSTART.md
+++ b/docs/BACKUP-QUICKSTART.md
@@ -9,7 +9,7 @@ For comprehensive documentation, see [DB-BACKUPS.md](./DB-BACKUPS.md).
 - PostgreSQL 17 with 420GB `soar` database
 - rclone installed (`apt install rclone`)
 - Cloud storage account (Wasabi recommended)
-- ~150GB free disk space in `/var/lib/soar/backup-temp`
+- ~150GB free disk space in `/storage/soar/backups/base`
 
 ## Step 1: Set Up Cloud Storage (5 minutes)
 
@@ -279,11 +279,11 @@ du -sh /var/lib/postgresql/18/main/pg_wal/
 
 ### Disk Space Running Low
 
-**Symptom**: `/var/lib/soar/backup-temp` filling up
+**Symptom**: `/storage/soar/backups/base` filling up
 
 **Fix**:
-1. Check for stuck backups: `ls -lh /var/lib/soar/backup-temp/`
-2. Clean old temp files: `sudo rm -rf /var/lib/soar/backup-temp/*`
+1. Check for stuck backups: `ls -lh /storage/soar/backups/base/`
+2. Clean old temp files: `sudo rm -rf /storage/soar/backups/base/*`
 3. Ensure base backup completed: `sudo journalctl -u soar-backup-base.service -n 100`
 
 ### Base Backup Taking Too Long

--- a/docs/DB-BACKUPS.md
+++ b/docs/DB-BACKUPS.md
@@ -401,7 +401,7 @@ PG_VERSION=18
 # Note: Use .pgpass for password, not environment variable
 
 # Backup paths
-BACKUP_TEMP_DIR=/var/lib/soar/backup-temp
+BACKUP_TEMP_DIR=/storage/soar/backups/base
 BACKUP_LOG_DIR=/var/log/soar
 
 # Backup compression
@@ -1167,7 +1167,7 @@ sudo journalctl -u soar-backup-base.service -f
 
 3. **Insufficient disk space**:
    ```bash
-   df -h /var/lib/soar/backup-temp
+   df -h /storage/soar/backups/base
    ```
 
    **Fix**: Clean temp directory, increase disk space

--- a/scripts/backup/base-backup
+++ b/scripts/backup/base-backup
@@ -77,7 +77,7 @@ if ! rclone listremotes | grep -q "^${RCLONE_REMOTE}:$"; then
 fi
 
 # Directories
-TEMP_DIR="${BACKUP_TEMP_DIR:-/var/lib/soar/backup-temp}"
+TEMP_DIR="${BACKUP_TEMP_DIR:-/storage/soar/backups/base}"
 mkdir -p "$TEMP_DIR"
 
 # Database connection

--- a/scripts/backup/restore
+++ b/scripts/backup/restore
@@ -110,7 +110,7 @@ if [[ ! -f "$RCLONE_CONFIG" ]]; then
 fi
 
 # Directories
-TEMP_DIR="${BACKUP_TEMP_DIR:-/var/lib/soar/backup-temp}"
+TEMP_DIR="${BACKUP_TEMP_DIR:-/storage/soar/backups/base}"
 LOG_DIR="${BACKUP_LOG_DIR:-/var/log/soar}"
 mkdir -p "$TEMP_DIR" "$LOG_DIR"
 

--- a/scripts/provision
+++ b/scripts/provision
@@ -642,7 +642,7 @@ sudo mkdir -p /var/soar/archive
 sudo mkdir -p /var/soar/elevation
 sudo mkdir -p /etc/soar
 sudo mkdir -p /var/lib/nats/jetstream
-sudo mkdir -p /var/lib/soar/backup-temp
+sudo mkdir -p /storage/soar/backups/base
 
 # Set ownership for soar user
 echo -e "${BLUE}Setting ownership for soar user...${NC}"
@@ -653,8 +653,8 @@ sudo chmod 755 /home/soar
 
 # Set ownership for backup temp directory (used by postgres user)
 echo -e "${BLUE}Setting ownership for backup temp directory...${NC}"
-sudo chown -R postgres:postgres /var/lib/soar/backup-temp
-sudo chmod 750 /var/lib/soar/backup-temp
+sudo chown -R postgres:postgres /storage/soar/backups/base
+sudo chmod 750 /storage/soar/backups/base
 
 # Download elevation data with rclone
 echo -e "${BLUE}Setting up elevation data...${NC}"


### PR DESCRIPTION
## Summary
This PR completes the backup location migration started in #750 by updating all remaining references from `/var/lib/soar/backup-temp` to `/storage/soar/backups/base`.

## Changes
- **scripts/provision**: Update directory creation and permissions for new location
- **scripts/backup/base-backup**: Update default TEMP_DIR fallback value
- **scripts/backup/restore**: Update default TEMP_DIR fallback value
- **docs/BACKUP-QUICKSTART.md**: Update prerequisites and troubleshooting sections
- **docs/DB-BACKUPS.md**: Update example configurations and troubleshooting

## Why
PR #750 updated the systemd service and example config, but several scripts and documentation files still referenced the old path. This ensures complete consistency across all backup-related files.

## Testing
Verified with grep that no references to `/var/lib/soar/backup-temp` remain in the codebase.

## Related
- Completes #750