### PR TITLE
Fix SIGTERM handling in ingest-ogn and ingest-adsb

### DIFF
--- a/src/commands/ingest_adsb.rs
+++ b/src/commands/ingest_adsb.rs
@@ -103,6 +103,10 @@ pub async fn handle_ingest_adsb(
     // Set up signal handling for immediate shutdown
     info!("Setting up shutdown handlers...");
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let (beast_publisher_shutdown_tx, beast_publisher_shutdown_rx) =
+        tokio::sync::oneshot::channel::<()>();
+    let (sbs_publisher_shutdown_tx, sbs_publisher_shutdown_rx) =
+        tokio::sync::oneshot::channel::<()>();
 
     // Spawn signal handler task for both SIGINT and SIGTERM
     tokio::spawn(async move {
@@ -138,8 +142,10 @@ pub async fn handle_ingest_adsb(
             }
         }
 
-        // Signal shutdown
+        // Signal shutdown to clients and publishers
         let _ = shutdown_tx.send(());
+        let _ = beast_publisher_shutdown_tx.send(());
+        let _ = sbs_publisher_shutdown_tx.send(());
     });
 
     // Create persistent queues for buffering messages
@@ -228,25 +234,36 @@ pub async fn handle_ingest_adsb(
 
     // Spawn Beast publisher task: reads from queue → sends to socket
     let beast_queue_for_publisher = beast_queue.clone();
+    let mut beast_publisher_shutdown_rx_inner = beast_publisher_shutdown_rx;
     let beast_publisher_handle = tokio::spawn(async move {
         info!("Beast publisher task started");
         loop {
-            match beast_queue_for_publisher.recv().await {
-                Ok(message) => {
-                    // Send to socket
-                    if let Err(e) = beast_socket_client.send(message).await {
-                        error!("Failed to send Beast message to socket: {}", e);
-                        metrics::counter!("beast.socket.send_error_total").increment(1);
+            tokio::select! {
+                // Check for shutdown signal first (biased)
+                _ = &mut beast_publisher_shutdown_rx_inner => {
+                    info!("Beast publisher task received shutdown signal, exiting...");
+                    break;
+                }
+                // Process queue messages
+                recv_result = beast_queue_for_publisher.recv() => {
+                    match recv_result {
+                        Ok(message) => {
+                            // Send to socket
+                            if let Err(e) = beast_socket_client.send(message).await {
+                                error!("Failed to send Beast message to socket: {}", e);
+                                metrics::counter!("beast.socket.send_error_total").increment(1);
 
-                        // Reconnect and retry
-                        if let Err(e) = beast_socket_client.reconnect().await {
-                            error!("Failed to reconnect Beast socket: {}", e);
+                                // Reconnect and retry
+                                if let Err(e) = beast_socket_client.reconnect().await {
+                                    error!("Failed to reconnect Beast socket: {}", e);
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            error!("Failed to receive from Beast queue: {}", e);
+                            break;
                         }
                     }
-                }
-                Err(e) => {
-                    error!("Failed to receive from Beast queue: {}", e);
-                    break;
                 }
             }
         }
@@ -255,25 +272,36 @@ pub async fn handle_ingest_adsb(
 
     // Spawn SBS publisher task: reads from queue → sends to socket
     let sbs_queue_for_publisher = sbs_queue.clone();
+    let mut sbs_publisher_shutdown_rx_inner = sbs_publisher_shutdown_rx;
     let sbs_publisher_handle = tokio::spawn(async move {
         info!("SBS publisher task started");
         loop {
-            match sbs_queue_for_publisher.recv().await {
-                Ok(message) => {
-                    // Send to socket
-                    if let Err(e) = sbs_socket_client.send(message).await {
-                        error!("Failed to send SBS message to socket: {}", e);
-                        metrics::counter!("sbs.socket.send_error_total").increment(1);
+            tokio::select! {
+                // Check for shutdown signal first (biased)
+                _ = &mut sbs_publisher_shutdown_rx_inner => {
+                    info!("SBS publisher task received shutdown signal, exiting...");
+                    break;
+                }
+                // Process queue messages
+                recv_result = sbs_queue_for_publisher.recv() => {
+                    match recv_result {
+                        Ok(message) => {
+                            // Send to socket
+                            if let Err(e) = sbs_socket_client.send(message).await {
+                                error!("Failed to send SBS message to socket: {}", e);
+                                metrics::counter!("sbs.socket.send_error_total").increment(1);
 
-                        // Reconnect and retry
-                        if let Err(e) = sbs_socket_client.reconnect().await {
-                            error!("Failed to reconnect SBS socket: {}", e);
+                                // Reconnect and retry
+                                if let Err(e) = sbs_socket_client.reconnect().await {
+                                    error!("Failed to reconnect SBS socket: {}", e);
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            error!("Failed to receive from SBS queue: {}", e);
+                            break;
                         }
                     }
-                }
-                Err(e) => {
-                    error!("Failed to receive from SBS queue: {}", e);
-                    break;
                 }
             }
         }

--- a/src/commands/ingest_ogn.rs
+++ b/src/commands/ingest_ogn.rs
@@ -96,6 +96,7 @@ pub async fn handle_ingest_ogn(
     // Set up signal handling for immediate shutdown
     info!("Setting up shutdown handlers...");
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let (publisher_shutdown_tx, publisher_shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
     // Spawn signal handler task for both SIGINT and SIGTERM
     tokio::spawn(async move {
@@ -131,8 +132,9 @@ pub async fn handle_ingest_ogn(
             }
         }
 
-        // Signal shutdown
+        // Signal shutdown to both client and publisher
         let _ = shutdown_tx.send(());
+        let _ = publisher_shutdown_tx.send(());
     });
 
     // Create OGN (APRS) client config
@@ -194,25 +196,36 @@ pub async fn handle_ingest_ogn(
 
     // Spawn publisher task: reads from queue → sends to socket
     let queue_for_publisher = queue.clone();
+    let mut publisher_shutdown_rx_inner = publisher_shutdown_rx;
     let publisher_handle = tokio::spawn(async move {
         info!("Publisher task started");
         loop {
-            match queue_for_publisher.recv().await {
-                Ok(message) => {
-                    // Send to socket
-                    if let Err(e) = socket_client.send(message.into_bytes()).await {
-                        error!("Failed to send to socket: {}", e);
-                        metrics::counter!("aprs.socket.send_error_total").increment(1);
+            tokio::select! {
+                // Check for shutdown signal first (biased)
+                _ = &mut publisher_shutdown_rx_inner => {
+                    info!("Publisher task received shutdown signal, exiting...");
+                    break;
+                }
+                // Process queue messages
+                recv_result = queue_for_publisher.recv() => {
+                    match recv_result {
+                        Ok(message) => {
+                            // Send to socket
+                            if let Err(e) = socket_client.send(message.into_bytes()).await {
+                                error!("Failed to send to socket: {}", e);
+                                metrics::counter!("aprs.socket.send_error_total").increment(1);
 
-                        // Reconnect and retry
-                        if let Err(e) = socket_client.reconnect().await {
-                            error!("Failed to reconnect to socket: {}", e);
+                                // Reconnect and retry
+                                if let Err(e) = socket_client.reconnect().await {
+                                    error!("Failed to reconnect to socket: {}", e);
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            error!("Failed to receive from queue: {}", e);
+                            break;
                         }
                     }
-                }
-                Err(e) => {
-                    error!("Failed to receive from queue: {}", e);
-                    break;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixed a critical bug where `ingest-ogn` and `ingest-adsb` services would log "exiting immediately" when receiving SIGTERM but would hang indefinitely instead of shutting down. The issue was caused by publisher tasks running in infinite loops without shutdown signal handling.

**Root Cause:**
- Signal handler sent shutdown signal to client tasks only
- Publisher tasks (socket publishers) ran in infinite loops reading from queues
- Main function waited for publisher tasks that never stopped
- Result: Services appeared to acknowledge SIGTERM but never actually exited

**Changes:**
- Added separate shutdown channels for all publisher tasks (OGN, Beast, SBS)
- Updated signal handlers to broadcast shutdown to both clients and publishers
- Modified publisher tasks to use `tokio::select!` to listen for shutdown signals while processing queue messages
- Services now exit immediately and cleanly when SIGTERM/SIGINT is received

## Test plan

- [ ] Build and deploy to staging
- [ ] Verify services start normally
- [ ] Send SIGTERM to `soar-ingest-ogn-staging` and verify immediate shutdown
- [ ] Send SIGTERM to `soar-ingest-adsb-staging` and verify immediate shutdown
- [ ] Check systemd logs for clean shutdown messages
- [ ] Verify no hung processes after restart