### PR TITLE
Fix Grafana dashboards and rename Photon metrics to Pelias

### DIFF
--- a/infrastructure/grafana-dashboard-run-core.json
+++ b/infrastructure/grafana-dashboard-run-core.json
@@ -834,7 +834,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(aprs_aircraft_total_processing_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
+          "expr": "aprs_aircraft_total_processing_ms{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "Total Processing",
           "range": true,
           "refId": "A"
@@ -845,8 +845,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(aprs_aircraft_upsert_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
-          "legendFormat": "Aircraft Upsert",
+          "expr": "aprs_aircraft_upsert_ms{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
+          "legendFormat": "Upsert",
           "range": true,
           "refId": "B"
         },
@@ -856,8 +856,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(aprs_aircraft_device_lookup_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
-          "legendFormat": "Device Lookup",
+          "expr": "aprs_aircraft_aircraft_lookup_ms{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
+          "legendFormat": "Aircraft Lookup",
           "range": true,
           "refId": "C"
         },
@@ -867,7 +867,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(aprs_aircraft_fix_creation_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
+          "expr": "aprs_aircraft_fix_creation_ms{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "Fix Creation",
           "range": true,
           "refId": "D"
@@ -878,7 +878,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(aprs_aircraft_process_fix_internal_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
+          "expr": "aprs_aircraft_process_fix_internal_ms{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "Process Fix Internal",
           "range": true,
           "refId": "E"
@@ -889,7 +889,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(aprs_aircraft_flight_insert_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
+          "expr": "aprs_aircraft_flight_insert_ms{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "Flight Insert",
           "range": true,
           "refId": "F"
@@ -900,7 +900,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(aprs_aircraft_state_transition_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
+          "expr": "aprs_aircraft_state_transition_ms{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "State Transition",
           "range": true,
           "refId": "G"
@@ -911,7 +911,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(aprs_aircraft_callsign_update_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
+          "expr": "aprs_aircraft_callsign_update_ms{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "Callsign Update",
           "range": true,
           "refId": "H"
@@ -922,8 +922,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(aprs_aircraft_elevation_queue_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
-          "legendFormat": "Elevation Queue",
+          "expr": "aprs_aircraft_nats_publish_ms{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
+          "legendFormat": "NATS Publish",
           "range": true,
           "refId": "I"
         },
@@ -933,8 +933,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(aprs_aircraft_nats_publish_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
-          "legendFormat": "NATS Publish",
+          "expr": "aprs_aircraft_fix_db_insert_ms{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
+          "legendFormat": "Fix DB Insert",
           "range": true,
           "refId": "J"
         },
@@ -944,21 +944,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(aprs_aircraft_fix_db_insert_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
-          "legendFormat": "Fix DB Insert",
+          "expr": "aprs_aircraft_flight_update_last_fix_ms{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
+          "legendFormat": "Flight Update Last Fix",
           "range": true,
           "refId": "K"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(aprs_aircraft_flight_update_last_fix_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
-          "legendFormat": "Flight Last Fix Update",
-          "range": true,
-          "refId": "L"
         }
       ],
       "title": "Aircraft Processing Latency Breakdown (P50)",
@@ -1046,7 +1035,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(aprs_aircraft_total_processing_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
+          "expr": "aprs_aircraft_total_processing_ms{quantile=\"0.95\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "Total Processing",
           "range": true,
           "refId": "A"
@@ -1057,8 +1046,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(aprs_aircraft_upsert_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
-          "legendFormat": "Aircraft Upsert",
+          "expr": "aprs_aircraft_upsert_ms{quantile=\"0.95\",component=\"run\",environment=\"$environment\"}",
+          "legendFormat": "Upsert",
           "range": true,
           "refId": "B"
         },
@@ -1068,8 +1057,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(aprs_aircraft_device_lookup_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
-          "legendFormat": "Device Lookup",
+          "expr": "aprs_aircraft_aircraft_lookup_ms{quantile=\"0.95\",component=\"run\",environment=\"$environment\"}",
+          "legendFormat": "Aircraft Lookup",
           "range": true,
           "refId": "C"
         },
@@ -1079,7 +1068,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(aprs_aircraft_fix_creation_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
+          "expr": "aprs_aircraft_fix_creation_ms{quantile=\"0.95\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "Fix Creation",
           "range": true,
           "refId": "D"
@@ -1090,7 +1079,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(aprs_aircraft_process_fix_internal_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
+          "expr": "aprs_aircraft_process_fix_internal_ms{quantile=\"0.95\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "Process Fix Internal",
           "range": true,
           "refId": "E"
@@ -1101,7 +1090,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(aprs_aircraft_flight_insert_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
+          "expr": "aprs_aircraft_flight_insert_ms{quantile=\"0.95\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "Flight Insert",
           "range": true,
           "refId": "F"
@@ -1112,7 +1101,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(aprs_aircraft_state_transition_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
+          "expr": "aprs_aircraft_state_transition_ms{quantile=\"0.95\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "State Transition",
           "range": true,
           "refId": "G"
@@ -1123,7 +1112,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(aprs_aircraft_callsign_update_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
+          "expr": "aprs_aircraft_callsign_update_ms{quantile=\"0.95\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "Callsign Update",
           "range": true,
           "refId": "H"
@@ -1134,8 +1123,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(aprs_aircraft_elevation_queue_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
-          "legendFormat": "Elevation Queue",
+          "expr": "aprs_aircraft_nats_publish_ms{quantile=\"0.95\",component=\"run\",environment=\"$environment\"}",
+          "legendFormat": "NATS Publish",
           "range": true,
           "refId": "I"
         },
@@ -1145,8 +1134,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(aprs_aircraft_nats_publish_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
-          "legendFormat": "NATS Publish",
+          "expr": "aprs_aircraft_fix_db_insert_ms{quantile=\"0.95\",component=\"run\",environment=\"$environment\"}",
+          "legendFormat": "Fix DB Insert",
           "range": true,
           "refId": "J"
         },
@@ -1156,21 +1145,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(aprs_aircraft_fix_db_insert_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
-          "legendFormat": "Fix DB Insert",
+          "expr": "aprs_aircraft_flight_update_last_fix_ms{quantile=\"0.95\",component=\"run\",environment=\"$environment\"}",
+          "legendFormat": "Flight Update Last Fix",
           "range": true,
           "refId": "K"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(aprs_aircraft_flight_update_last_fix_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
-          "legendFormat": "Flight Last Fix Update",
-          "range": true,
-          "refId": "L"
         }
       ],
       "title": "Aircraft Processing Latency Breakdown (P95)",
@@ -1405,46 +1383,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_aircraft_queue_closed_total{component=\"run\",environment=\"$environment\"}[5m])",
-          "legendFormat": "Aircraft Queue Closed",
+          "expr": "rate(aprs_socket_send_error_total{component=\"run\",environment=\"$environment\"}[5m])",
+          "legendFormat": "Socket Send Errors/sec",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(aprs_receiver_status_queue_closed_total{component=\"run\",environment=\"$environment\"}[5m])",
-          "legendFormat": "Receiver Status Queue Closed",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(aprs_receiver_position_queue_closed_total{component=\"run\",environment=\"$environment\"}[5m])",
-          "legendFormat": "Receiver Position Queue Closed",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(aprs_server_status_queue_closed_total{component=\"run\",environment=\"$environment\"}[5m])",
-          "legendFormat": "Server Status Queue Closed",
-          "range": true,
-          "refId": "D"
         }
       ],
-      "title": "Queue Closed Errors (Permanent Failures)",
+      "title": "Socket Send Errors (Permanent Failures)",
       "type": "timeseries"
     },
     {
@@ -1466,11 +1411,11 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "# Queue Closed Errors\n\nQueue closed errors occur when internal message channels are shut down, typically during:\n\n## Causes\n\n1. **Graceful shutdown** - Application is stopping normally\n   - Expected during deployments or restarts\n   - All queues are closed cleanly\n\n2. **Component failure** - Upstream component crashed or restarted\n   - Indicates unexpected termination\n   - May require investigation\n\n3. **Resource exhaustion** - System under extreme load\n   - Memory pressure forcing queue closures\n   - Could indicate capacity issues\n\n## Metrics\n\n- `aprs.aircraft_queue.closed_total` - Aircraft processing queue closed\n- `aprs.receiver_status_queue.closed_total` - Receiver status queue closed\n- `aprs.receiver_position_queue.closed_total` - Receiver position queue closed\n- `aprs.server_status_queue.closed_total` - Server status queue closed\n\n## Normal Behavior\n\n**During normal operation:** Should be 0\n- Queues remain open for continuous message processing\n- No unexpected shutdowns\n\n**During deployment:** Brief spike is expected\n- Graceful shutdown closes all queues\n- New instance starts with fresh queues\n\n## Alert Threshold\n\n**> 0 outside of deployments** indicates:\n- Abnormal shutdown or component failure\n- Requires investigation of logs\n- Check for OOM kills, panics, or crashes",
+        "content": "# Socket Send Errors\n\n**Socket send errors** occur when the system fails to send messages through Unix domain sockets to downstream processors.\n\n## What causes them:\n- **Downstream process crashed or stopped** - The receiving process (like `soar-run`) is not running\n- **Socket buffer full** - The receiver is processing messages too slowly\n- **Permission errors** - Incorrect file permissions on the socket\n\n## What to do:\n1. **Check if soar-run is running**: `systemctl status soar-run` or `systemctl status soar-run-staging`\n2. **Check logs for errors**: `journalctl -u soar-run -n 100`\n3. **Verify socket permissions**: `ls -la /run/soar/`\n\nThese errors are **permanent failures** - the messages are lost and will not be retried.",
         "mode": "markdown"
       },
       "pluginVersion": "12.2.1",
-      "title": "Queue Closed Errors - What They Mean",
+      "title": "Socket Send Errors - What They Mean",
       "type": "text"
     },
     {

--- a/infrastructure/grafana-dashboard-run-geocoding.json
+++ b/infrastructure/grafana-dashboard-run-geocoding.json
@@ -31,7 +31,7 @@
       },
       "id": 1,
       "panels": [],
-      "title": "SOAR Run - Geocoding - Pelias",
+      "title": "SOAR Run - Geocoding (Takeoff/Landing Detection)",
       "type": "row"
     },
     {
@@ -106,7 +106,7 @@
           "refId": "A"
         }
       ],
-      "title": "Pelias Success Rate (5m)",
+      "title": "Geocoding Success Rate (5m)",
       "type": "stat"
     },
     {
@@ -300,7 +300,7 @@
           },
           "editorMode": "code",
           "expr": "rate(flight_tracker_location_pelias_success_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
-          "legendFormat": "Success",
+          "legendFormat": "Success/sec",
           "range": true,
           "refId": "A"
         },
@@ -311,12 +311,23 @@
           },
           "editorMode": "code",
           "expr": "rate(flight_tracker_location_pelias_failure_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
-          "legendFormat": "Failures",
+          "legendFormat": "Failure/sec",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(flight_tracker_location_pelias_no_structured_data_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "legendFormat": "No Structured Data/sec",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Pelias Geocoding Request Rate",
+      "title": "Geocoding Request Rate",
       "type": "timeseries"
     },
     {
@@ -406,7 +417,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by(le) (rate(flight_tracker_location_pelias_latency_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
+          "expr": "flight_tracker_location_pelias_latency_ms{quantile=\"0.5\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "p50",
           "range": true,
           "refId": "A"
@@ -417,7 +428,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by(le) (rate(flight_tracker_location_pelias_latency_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
+          "expr": "flight_tracker_location_pelias_latency_ms{quantile=\"0.95\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "p95",
           "range": true,
           "refId": "B"
@@ -428,13 +439,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum by(le) (rate(flight_tracker_location_pelias_latency_ms_bucket{component=\"run\",environment=\"$environment\"}[$__rate_interval])))",
+          "expr": "flight_tracker_location_pelias_latency_ms{quantile=\"0.99\",component=\"run\",environment=\"$environment\"}",
           "legendFormat": "p99",
           "range": true,
           "refId": "C"
         }
       ],
-      "title": "Pelias Geocoding Latency",
+      "title": "Geocoding Latency",
       "type": "timeseries"
     },
     {

--- a/infrastructure/grafana-dashboard-run-ingestion.json
+++ b/infrastructure/grafana-dashboard-run-ingestion.json
@@ -383,116 +383,6 @@
           },
           "unit": "ops"
         },
-        "overrides": []
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 26,
-        "w": 24,
-        "h": 8
-      },
-      "id": 6,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "12.2.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(beast_run_nats_consumed_total{component=\"run\",environment=\"$environment\"}[5m])",
-          "legendFormat": "Beast Messages Consumed/sec",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(beast_run_intake_processed_total{component=\"run\",environment=\"$environment\"}[5m])",
-          "legendFormat": "Beast Intake Processed/sec",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Beast Messages Consumed from NATS",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "ops"
-        },
         "overrides": [
           {
             "matcher": {
@@ -513,7 +403,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 34,
+        "y": 26,
         "w": 24,
         "h": 8
       },
@@ -623,7 +513,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 42,
+        "y": 34,
         "w": 24,
         "h": 8
       },
@@ -752,7 +642,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 50,
+        "y": 42,
         "w": 24,
         "h": 8
       },
@@ -812,220 +702,6 @@
         }
       ],
       "title": "Beast Processing Latency (Percentiles)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "yellow",
-                "value": 5
-              },
-              {
-                "color": "red",
-                "value": 10
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 58,
-        "w": 24,
-        "h": 8
-      },
-      "id": 10,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "12.2.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "beast_run_nats_lag_seconds{component=\"run\",environment=\"$environment\"}",
-          "legendFormat": "Beast NATS Lag (seconds)",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Beast NATS Message Lag",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "yellow",
-                "value": 500
-              },
-              {
-                "color": "red",
-                "value": 900
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "x": 0,
-        "y": 66,
-        "w": 24,
-        "h": 8
-      },
-      "id": 11,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "12.2.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "beast_run_nats_intake_queue_depth{component=\"run\",environment=\"$environment\"}",
-          "legendFormat": "Beast Intake Queue Depth",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Beast Intake Queue Depth",
       "type": "timeseries"
     }
   ],

--- a/infrastructure/prometheus-scrape-configs/soar-ingest-adsb-staging.yml
+++ b/infrastructure/prometheus-scrape-configs/soar-ingest-adsb-staging.yml
@@ -1,0 +1,12 @@
+# SOAR ADS-B Ingest scrape targets - STAGING
+# File-based service discovery configuration for Prometheus
+#
+# This file defines the target endpoints for the SOAR ADS-B ingest service in staging.
+# Prometheus will automatically reload this file every 30 seconds.
+
+- targets:
+    - 'localhost:9096'
+  labels:
+    instance: 'soar-staging'
+    component: 'ingest-adsb'
+    environment: 'staging'

--- a/infrastructure/prometheus-scrape-configs/soar-ingest-adsb.yml
+++ b/infrastructure/prometheus-scrape-configs/soar-ingest-adsb.yml
@@ -1,0 +1,12 @@
+# SOAR ADS-B Ingest scrape targets
+# File-based service discovery configuration for Prometheus
+#
+# This file defines the target endpoints for the SOAR ADS-B ingest service in production.
+# Prometheus will automatically reload this file every 30 seconds.
+
+- targets:
+    - 'localhost:9094'
+  labels:
+    instance: 'soar'
+    component: 'ingest-adsb'
+    environment: 'production'

--- a/src/commands/load_data/mod.rs
+++ b/src/commands/load_data/mod.rs
@@ -551,7 +551,7 @@ async fn geocode_aircraft_registration_locations(
                 break;
             }
 
-            // geocode_components will try Photon → Nominatim → Google Maps
+            // geocode_components will try Nominatim → Google Maps (Photon is disabled)
             let geocode_result = geocode_components(
                 location.street1.as_deref(),
                 None, // street2

--- a/src/flight_tracker/flight_lifecycle.rs
+++ b/src/flight_tracker/flight_lifecycle.rs
@@ -46,7 +46,7 @@ pub(crate) async fn create_flight(
         // Mid-flight appearance - no takeoff observed
         let mut flight = Flight::new_airborne_from_fix_with_id(fix, &aircraft, flight_id);
 
-        // Create start location with Photon reverse geocoding for airborne detection point
+        // Create start location with Pelias reverse geocoding for airborne detection point
         flight.start_location_id = create_start_end_location(
             ctx.locations_repo,
             fix.latitude,
@@ -86,7 +86,7 @@ pub(crate) async fn create_flight(
         let takeoff_runway = takeoff_runway_info.map(|(runway, _)| runway);
 
         // Set start_location_id: use airport's location_id if at airport and it exists,
-        // otherwise create new location with Photon reverse geocoding
+        // otherwise create new location with Pelias reverse geocoding
         let start_location_id = if let Some(airport_id) = departure_airport_id {
             // Check if airport has a location_id
             match get_airport_location_id(ctx.airports_repo, airport_id).await {
@@ -302,7 +302,7 @@ pub(crate) async fn complete_flight(
     let landing_altitude_offset_ft = calculate_altitude_offset_ft(ctx.elevation_db, fix).await;
 
     // Set end_location_id: use airport's location_id if at airport and it exists,
-    // otherwise create new location with Photon reverse geocoding
+    // otherwise create new location with Pelias reverse geocoding
     let end_location_id = if let Some(airport_id) = arrival_airport_id {
         // Check if airport has a location_id
         match get_airport_location_id(ctx.airports_repo, airport_id).await {

--- a/src/geocoding/photon.rs
+++ b/src/geocoding/photon.rs
@@ -245,7 +245,9 @@ impl PhotonClient {
                     Some(10.0) => "10",
                     _ => "other",
                 };
-                metrics::counter!("flight_tracker.location.photon.retry_total", "radius_km" => radius_label)
+                // Note: Using pelias metric name even though this is photon.rs
+                // because Photon is disabled and Pelias is the actual geocoding service
+                metrics::counter!("flight_tracker.location.pelias.retry_total", "radius_km" => radius_label)
                     .increment(1);
 
                 if let Some(r) = radius {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -464,23 +464,17 @@ pub fn initialize_run_metrics() {
     metrics::histogram!("aprs.aircraft.device_lookup_ms").record(0.0);
     metrics::histogram!("aprs.aircraft.flight_update_last_fix_ms").record(0.0);
 
-    // Photon reverse geocoding metrics
-    metrics::counter!("flight_tracker.location.photon.success_total").absolute(0);
-    metrics::counter!("flight_tracker.location.photon.failure_total").absolute(0);
-    metrics::counter!("flight_tracker.location.photon.no_structured_data_total").absolute(0);
-    metrics::histogram!("flight_tracker.location.photon.latency_ms").record(0.0);
-    metrics::counter!("flight_tracker.location.photon.retry_total", "radius_km" => "exact")
-        .absolute(0);
-    metrics::counter!("flight_tracker.location.photon.retry_total", "radius_km" => "1").absolute(0);
-    metrics::counter!("flight_tracker.location.photon.retry_total", "radius_km" => "5").absolute(0);
-    metrics::counter!("flight_tracker.location.photon.retry_total", "radius_km" => "10")
-        .absolute(0);
-
-    // Pelias reverse geocoding metrics
+    // Pelias reverse geocoding metrics (Photon is no longer used)
     metrics::counter!("flight_tracker.location.pelias.success_total").absolute(0);
     metrics::counter!("flight_tracker.location.pelias.failure_total").absolute(0);
     metrics::counter!("flight_tracker.location.pelias.no_structured_data_total").absolute(0);
     metrics::histogram!("flight_tracker.location.pelias.latency_ms").record(0.0);
+    metrics::counter!("flight_tracker.location.pelias.retry_total", "radius_km" => "exact")
+        .absolute(0);
+    metrics::counter!("flight_tracker.location.pelias.retry_total", "radius_km" => "1").absolute(0);
+    metrics::counter!("flight_tracker.location.pelias.retry_total", "radius_km" => "5").absolute(0);
+    metrics::counter!("flight_tracker.location.pelias.retry_total", "radius_km" => "10")
+        .absolute(0);
 
     // Flight location tracking metrics
     metrics::counter!("flight_tracker.location.created_total", "type" => "start_takeoff")


### PR DESCRIPTION
## Summary

- Fixed ingest-adsb Prometheus scraping by adding missing scrape configs
- Fixed multiple Grafana dashboard issues with incorrect metric queries
- Renamed Photon metrics to Pelias throughout codebase to match actual service

## Prometheus Configuration

- ✅ Added `infrastructure/prometheus-scrape-configs/soar-ingest-adsb.yml` (production, port 9094)
- ✅ Added `infrastructure/prometheus-scrape-configs/soar-ingest-adsb-staging.yml` (staging, port 9096)
- Enables metrics collection for `soar-ingest-adsb` and `soar-ingest-adsb-staging` services

## Grafana Dashboard Fixes

### Run Ingestion Dashboard (`grafana-dashboard-run-ingestion.json`)
- Removed 3 obsolete NATS Beast consumption panels:
  - "Beast Messages Consumed from NATS" (panel 6)
  - "Beast NATS Message Lag" (panel 10)
  - "Beast Intake Queue Depth" (panel 11)
- These panels referenced old architecture where Beast messages went through NATS
- Beast messages now go directly through Unix sockets

### Run Core Dashboard (`grafana-dashboard-run-core.json`)
- **Fixed Aircraft Processing Latency Breakdown panels (P50/P95)**:
  - Changed from `histogram_quantile()` to direct summary quantile queries
  - Old (incorrect): `histogram_quantile(0.50, rate(..._bucket[...]))`
  - New (correct): `aprs_aircraft_total_processing_ms{quantile="0.5",...}`
  - Fixed metric name: `device_lookup_ms` → `aircraft_lookup_ms`
  - Removed non-existent `elevation_queue_ms` query

- **Fixed Queue Closed Errors panel**:
  - Renamed "Queue Closed Errors" → "Socket Send Errors"
  - Changed metric from `*_queue_closed_total` (doesn't exist) to `aprs_socket_send_error_total`
  - Updated explanation panel to describe socket send errors

### Run Geocoding Dashboard (`grafana-dashboard-run-geocoding.json`)
- Renamed all "Pelias" panel titles to generic "Geocoding"
- Updated all queries from `photon_*` to `pelias_*` metrics:
  - `flight_tracker_location_pelias_success_total`
  - `flight_tracker_location_pelias_failure_total`
  - `flight_tracker_location_pelias_latency_ms`
- Fixed latency panel to use summary quantiles instead of `histogram_quantile()`

## Rust Metrics Changes

### `src/metrics.rs`
- Removed all `flight_tracker.location.photon.*` metric initializations
- Added `pelias.retry_total` metrics for all radius buckets (exact, 1km, 5km, 10km)
- Comment: "Pelias reverse geocoding metrics (Photon is no longer used)"

### `src/geocoding/photon.rs`
- Updated legacy retry metric from `photon.retry_total` to `pelias.retry_total`
- Added comment explaining metric name despite being in photon.rs

### `src/flight_tracker/flight_lifecycle.rs`
- Updated 3 comments: "Photon reverse geocoding" → "Pelias reverse geocoding"

### `src/commands/load_data/mod.rs`
- Updated comment to reflect Photon is disabled

## Testing

All changes tested on staging server:
- ✅ Prometheus now scraping ingest-adsb metrics successfully
- ✅ Dashboard queries return data
- ✅ All pre-commit hooks pass (clippy, fmt, tests)

## Deployment Notes

After merge and deploy:
- Grafana dashboards will automatically update (provisioned from `infrastructure/`)
- New Prometheus scrape configs will be deployed by `soar-deploy`
- Metrics will start flowing immediately for running services