### PR TITLE
Add monitoring for envelope intake and PacketRouter internal queues

### DIFF
--- a/src/packet_processors/router.rs
+++ b/src/packet_processors/router.rs
@@ -356,4 +356,12 @@ impl PacketRouter {
             }
         }
     }
+
+    /// Get the current depth of the internal message queue
+    ///
+    /// This returns the number of messages pending processing in the internal worker pool.
+    /// Useful for monitoring backpressure in the packet processing pipeline.
+    pub fn internal_queue_depth(&self) -> usize {
+        self.internal_queue_tx.len()
+    }
 }


### PR DESCRIPTION
## Summary

Adds **critical visibility into two previously unmonitored queues** that are the first points of backpressure in the ingestion pipeline.

## Problem

When you see this log:
```
Jan 04 02:56:03 supervillain soar-ingest-ogn-staging[3691319]: 
  Slow socket send: 17709.0ms
```

It means the **entire pipeline is blocked**, but we don't know where the bottleneck started because **two critical queues are invisible**.

## Root Cause: Backpressure Cascade

When database operations slow down, backpressure propagates backwards through the pipeline:

1. ✅ **Aircraft workers slow** → Aircraft queue fills (1,000) - **MONITORED**
2. ❌ **PacketRouter blocks** → Internal queue fills (1,000) - **NOT MONITORED**
3. ❌ **Envelope router blocks** → Envelope intake fills (10,000) - **NOT MONITORED**
4. 🚨 **Socket reads block** → ingest-ogn writes slow (17+ seconds)

The two unmonitored queues hide the progression of the problem.

## Solution

### New Metrics

- `socket.envelope_intake_queue.depth` - First queue after socket reads (10,000 capacity)
- `aprs.router.internal_queue.depth` - PacketRouter worker pool queue (1,000 capacity)

### New Warning Logs

**Envelope intake queue** - warns at **80% full** (8,000/10,000):
```
Envelope intake queue building up: 8500/10000 messages (85% full) - socket reads may slow down
```
Higher threshold because this is the **last line of defense** before socket blocking.

**Internal queue** - warns at **50% full** (500/1,000):
```
PacketRouter internal queue building up: 750/1000 messages (75% full)
```
Matches existing pattern for downstream queues.

## Impact

✅ **Early detection** of backpressure before socket reads block  
✅ **Pinpoint bottlenecks** - see exactly where the pipeline slows down  
✅ **Prevent "Slow socket send" errors** by addressing issues upstream  

### Example Diagnosis Flow

**Before** (blind):
```
→ Aircraft queue: 1000/1000 (100% full)
→ ??? 
→ ???
→ Slow socket send: 17709.0ms
```

**After** (full visibility):
```
→ Aircraft queue: 1000/1000 (100% full) - workers can't keep up
→ Internal queue: 950/1000 (95% full) - router workers blocking
→ Envelope intake: 9500/10000 (95% full) - envelope router blocking
→ WARNING: socket reads may slow down
```

Now operators can see the **full cascade** and identify the root cause (slow aircraft workers).

## Implementation Details

**src/packet_processors/router.rs:**
- Added `internal_queue_depth()` method to expose queue depth

**src/commands/run.rs:**
- Cloned `envelope_rx` before moving to router task
- Added both queues to 10-second metrics reporter
- Added warning thresholds (80% envelope, 50% internal)

## Testing

- ✅ `cargo check` passes
- ✅ `cargo fmt` passes
- ✅ `cargo clippy` passes
- ✅ Pre-commit hooks pass

## Files Changed

- `src/packet_processors/router.rs` (+8 lines)
- `src/commands/run.rs` (+30 lines)