### PR TITLE
Fix Grafana dashboard issues and performance optimizations

### DIFF
--- a/infrastructure/grafana-dashboard-run-routing.json
+++ b/infrastructure/grafana-dashboard-run-routing.json
@@ -1116,13 +1116,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_nats_consumed_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_intake_processed_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "OGN Messages/sec",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "OGN Messages Consumed from NATS",
+      "title": "OGN Messages Processed from Socket",
       "type": "timeseries",
       "id": 11
     },
@@ -1207,13 +1207,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_nats_process_error_total{component=\"run\",environment=\"$environment\"}[$__rate_interval]) or\nrate(aprs_nats_decode_error_total{component=\"run\",environment=\"$environment\"}[$__rate_interval]) or\nrate(aprs_nats_receive_error_total{component=\"run\",environment=\"$environment\"}[$__rate_interval]) or\nrate(aprs_nats_ack_error_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "expr": "rate(aprs_parse_failed_total{component=\"run\",environment=\"$environment\"}[$__rate_interval]) or\nrate(socket_router_aprs_send_error_total{component=\"run\",environment=\"$environment\"}[$__rate_interval]) or\nrate(socket_router_decode_error_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
           "legendFormat": "{{__name__}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "OGN NATS Errors",
+      "title": "OGN Socket Processing Errors",
       "type": "timeseries",
       "id": 12
     },
@@ -1298,13 +1298,24 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "aprs_nats_intake_queue_depth{component=\"run\",environment=\"$environment\"}",
-          "legendFormat": "Queue Depth",
+          "expr": "socket_envelope_intake_queue_depth{component=\"run\",environment=\"$environment\"}",
+          "legendFormat": "Socket Envelope Queue",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "aprs_nats_intake_queue_depth{component=\"run\",environment=\"$environment\"}",
+          "legendFormat": "APRS Processing Queue",
+          "range": true,
+          "refId": "B"
         }
       ],
-      "title": "OGN NATS Intake Queue Depth",
+      "title": "OGN Intake Queue Depth",
       "type": "timeseries",
       "id": 13
     },
@@ -1728,8 +1739,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_nats_acked_immediately_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
-          "legendFormat": "Acked Immediately",
+          "expr": "rate(socket_router_aprs_routed_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "legendFormat": "OGN Routed to Intake Queue",
           "range": true,
           "refId": "A"
         },
@@ -1739,13 +1750,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_nats_intake_queue_full_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
-          "legendFormat": "Intake Queue Full",
+          "expr": "rate(socket_router_beast_routed_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "legendFormat": "ADS-B Routed to Intake Queue",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "OGN NATS Processing Details",
+      "title": "Socket Router Throughput",
       "type": "timeseries",
       "id": 17
     },

--- a/infrastructure/prometheus-jobs/soar-ingest-adsb-staging.yml
+++ b/infrastructure/prometheus-jobs/soar-ingest-adsb-staging.yml
@@ -9,7 +9,7 @@ scrape_configs:
     scrape_timeout: 5s
     static_configs:
       - targets:
-          - 'localhost:9096'
+          - 'localhost:9196'
         labels:
           instance: 'soar-staging'
           component: 'ingest-adsb'

--- a/infrastructure/prometheus-jobs/soar-ingest-ogn-staging.yml
+++ b/infrastructure/prometheus-jobs/soar-ingest-ogn-staging.yml
@@ -9,7 +9,7 @@ scrape_configs:
     scrape_timeout: 5s
     static_configs:
       - targets:
-          - 'localhost:9094'
+          - 'localhost:9194'
         labels:
           instance: 'soar-staging'
           component: 'ingest-ogn'

--- a/infrastructure/prometheus-jobs/soar-run-staging.yml
+++ b/infrastructure/prometheus-jobs/soar-run-staging.yml
@@ -9,7 +9,7 @@ scrape_configs:
     scrape_timeout: 1s
     static_configs:
       - targets:
-          - 'localhost:9092'
+          - 'localhost:9192'
         labels:
           instance: 'soar-staging'
           component: 'run'

--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -514,22 +514,59 @@ if [ -d "$DEPLOY_DIR/prometheus-jobs" ]; then
     log_info "Installing Prometheus job configuration files..."
     mkdir -p /etc/prometheus/jobs
 
-    # Remove old SOAR Prometheus job files that aren't in the deployment
+    # Remove old SOAR Prometheus job files for this environment
     if [ -d "/etc/prometheus/jobs" ]; then
-        log_info "Cleaning up old Prometheus job files..."
+        log_info "Cleaning up old Prometheus job files for $ENVIRONMENT..."
         for old_job in /etc/prometheus/jobs/soar-*.yml; do
             if [ -f "$old_job" ]; then
                 job_basename=$(basename "$old_job")
-                if [ ! -f "$DEPLOY_DIR/prometheus-jobs/$job_basename" ]; then
-                    log_info "Removing obsolete Prometheus job: $job_basename"
-                    rm -f "$old_job"
+
+                # Check if this file matches the current environment
+                if [ "$ENVIRONMENT" = "staging" ]; then
+                    # In staging, remove only staging files that aren't in deployment
+                    if [[ "$job_basename" =~ -staging\.yml$ ]]; then
+                        if [ ! -f "$DEPLOY_DIR/prometheus-jobs/$job_basename" ]; then
+                            log_info "Removing obsolete Prometheus job: $job_basename"
+                            rm -f "$old_job"
+                        fi
+                    fi
+                else
+                    # In production, remove only production files (no -staging suffix) that aren't in deployment
+                    if [[ ! "$job_basename" =~ -staging\.yml$ ]]; then
+                        if [ ! -f "$DEPLOY_DIR/prometheus-jobs/$job_basename" ]; then
+                            log_info "Removing obsolete Prometheus job: $job_basename"
+                            rm -f "$old_job"
+                        fi
+                    fi
                 fi
             fi
         done
     fi
 
-    cp "$DEPLOY_DIR/prometheus-jobs"/*.yml /etc/prometheus/jobs/
-    chmod 644 /etc/prometheus/jobs/*.yml
+    # Copy only environment-appropriate Prometheus job configs
+    if [ "$ENVIRONMENT" = "staging" ]; then
+        log_info "Installing staging Prometheus job configs (*-staging.yml)..."
+        for job_file in "$DEPLOY_DIR/prometheus-jobs"/*-staging.yml; do
+            if [ -f "$job_file" ]; then
+                cp "$job_file" /etc/prometheus/jobs/
+                chmod 644 "/etc/prometheus/jobs/$(basename "$job_file")"
+                log_info "  Installed: $(basename "$job_file")"
+            fi
+        done
+    else
+        log_info "Installing production Prometheus job configs (not *-staging.yml)..."
+        for job_file in "$DEPLOY_DIR/prometheus-jobs"/*.yml; do
+            if [ -f "$job_file" ]; then
+                job_basename=$(basename "$job_file")
+                # Skip staging files in production deployment
+                if [[ ! "$job_basename" =~ -staging\.yml$ ]]; then
+                    cp "$job_file" /etc/prometheus/jobs/
+                    chmod 644 "/etc/prometheus/jobs/$job_basename"
+                    log_info "  Installed: $job_basename"
+                fi
+            fi
+        done
+    fi
 
     # Set ownership to prometheus user if it exists
     if id "prometheus" &>/dev/null; then

--- a/src/commands/ingest_adsb.rs
+++ b/src/commands/ingest_adsb.rs
@@ -74,8 +74,8 @@ pub async fn handle_ingest_adsb(
     // Start metrics server in production/staging mode (AFTER metrics are initialized)
     if is_production || is_staging {
         // Allow overriding metrics port via METRICS_PORT env var (for blue-green deployment)
-        // Auto-assign default based on environment: production=9094, staging=9096
-        let default_port = if is_staging { 9096 } else { 9094 };
+        // Auto-assign default based on environment: production=9094, staging=9196
+        let default_port = if is_staging { 9196 } else { 9094 };
         let metrics_port = env::var("METRICS_PORT")
             .ok()
             .and_then(|p| p.parse::<u16>().ok())
@@ -218,10 +218,10 @@ pub async fn handle_ingest_adsb(
         }
     };
 
-    // Mark socket as connected in health state (reuse nats_connected field for now)
+    // Mark socket as connected in health state
     {
         let mut health = health_state.write().await;
-        health.nats_connected =
+        health.socket_connected =
             beast_socket_client.is_connected() || sbs_socket_client.is_connected();
     }
 

--- a/src/commands/pull_data.rs
+++ b/src/commands/pull_data.rs
@@ -159,9 +159,9 @@ pub async fn handle_pull_data(diesel_pool: Pool<ConnectionManager<PgConnection>>
     info!("Starting pull-data operation");
 
     // Start metrics server for profiling during data pull
-    // Auto-assign port based on environment to avoid conflicts: production=9092, staging=9102
+    // Auto-assign port based on environment to avoid conflicts: production=9092, staging=9202
     let soar_env = env::var("SOAR_ENV").unwrap_or_default();
-    let metrics_port = if soar_env == "staging" { 9102 } else { 9092 };
+    let metrics_port = if soar_env == "staging" { 9202 } else { 9092 };
     tokio::spawn(async move {
         soar::metrics::start_metrics_server(metrics_port, Some("pull-data")).await;
     });

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -319,8 +319,8 @@ pub async fn handle_run(
 
     // Start metrics server in the background (AFTER metrics are initialized)
     if is_production || is_staging {
-        // Auto-assign port based on environment: production=9091, staging=9092
-        let metrics_port = if is_staging { 9092 } else { 9091 };
+        // Auto-assign port based on environment: production=9091, staging=9192
+        let metrics_port = if is_staging { 9192 } else { 9091 };
         info!("Starting metrics server on port {}", metrics_port);
         tokio::spawn(
             async move {

--- a/src/fixes_repo.rs
+++ b/src/fixes_repo.rs
@@ -1021,15 +1021,15 @@ impl FixesRepository {
             let updated_count = if let Some(end_time) = end_time {
                 diesel::update(fixes)
                     .filter(aircraft_id.eq(aircraft_id_param))
-                    .filter(timestamp.ge(start_time))
-                    .filter(timestamp.le(end_time))
+                    .filter(received_at.ge(start_time))
+                    .filter(received_at.le(end_time))
                     .filter(flight_id.is_null())
                     .set(flight_id.eq(flight_id_param))
                     .execute(&mut conn)?
             } else {
                 diesel::update(fixes)
                     .filter(aircraft_id.eq(aircraft_id_param))
-                    .filter(timestamp.ge(start_time))
+                    .filter(received_at.ge(start_time))
                     .filter(flight_id.is_null())
                     .set(flight_id.eq(flight_id_param))
                     .execute(&mut conn)?
@@ -1062,7 +1062,7 @@ impl FixesRepository {
 
             let results = fixes
                 .filter(flight_id.eq(flight_id_param))
-                .order(timestamp.asc())
+                .order(received_at.asc())
                 .limit(limit)
                 .select(Fix::as_select())
                 .load::<Fix>(&mut conn)?;
@@ -1200,8 +1200,8 @@ impl FixesRepository {
 
             let fix_row: Option<Fix> = fixes
                 .filter(flight_id.eq(flight_id_val))
-                .filter(timestamp.ge(cutoff_time))
-                .order(timestamp.desc())
+                .filter(received_at.ge(cutoff_time))
+                .order(received_at.desc())
                 .select(Fix::as_select())
                 .first(&mut conn)
                 .optional()?;

--- a/src/flight_tracker/location.rs
+++ b/src/flight_tracker/location.rs
@@ -13,7 +13,7 @@ const GEOCODING_ENABLED_FOR_TAKEOFF_LANDING: bool = false;
 /// Enable reverse geocoding for start/end locations using Pelias
 /// When true, create_start_end_location() will use Pelias city-level reverse geocoding
 /// When false, start_location_id and end_location_id will be null
-const GEOCODING_ENABLED_FOR_START_END: bool = false;
+const GEOCODING_ENABLED_FOR_START_END: bool = true;
 
 /// Find nearest airport within 2km of given coordinates
 /// Returns the airport ID (not the identifier string)


### PR DESCRIPTION
## Summary
Multiple improvements to metrics, monitoring, and query performance:

- Fix missing Grafana metrics and dashboard "No data" issues
- Resolve port conflicts between production and staging
- Clean up legacy NATS naming (system now uses Unix sockets)
- Initialize all metrics to zero for proper Grafana display
- Optimize fixes table queries for TimescaleDB partitioning

## Metrics & Monitoring
- ✅ Enable Pelias geocoding to generate `flight_tracker_location_pelias_success_total` metrics
- ✅ Fix port conflicts: staging metrics ports changed from 909x to 919x range
- ✅ Add custom histogram buckets for coalesce distance (km), gap duration (hours)
- ✅ Initialize all metrics to zero so they appear in Grafana before events occur
- ✅ Update soar-deploy to only install environment-appropriate Prometheus configs

## Legacy NATS Cleanup
- ✅ Remove unused `nats_url` parameter from ingest-ogn command
- ✅ Rename `nats_connected` → `socket_connected` in health structs
- ✅ Update CLI help text to reflect Unix socket architecture
- ✅ Update Grafana dashboard panels to reflect socket-based routing

## Performance Optimizations
- ✅ Fix fixes table queries to use `received_at` instead of `timestamp`
  - fixes is a TimescaleDB hypertable with composite primary key (id, received_at)
  - Partitioned by received_at for efficient time-based queries
  - Updated `get_fixes_for_flight()` to order by received_at
  - Updated `update_fixes_with_flight_id()` to filter by received_at
  - This enables proper partition pruning for better performance

## Dashboard Updates
- ✅ Rename "OGN Messages Consumed from NATS" → "OGN Messages Processed from Socket"
- ✅ Rename "OGN NATS Errors" → "OGN Socket Processing Errors"
- ✅ Rename "OGN NATS Intake Queue Depth" → "OGN Intake Queue Depth"
- ✅ Rename "OGN NATS Processing Details" → "Socket Router Throughput"
- ✅ Update all panel queries to use correct socket-based metrics

## Testing
- ✅ All pre-commit hooks passed (cargo fmt, clippy, tests)
- ✅ No breaking changes to existing functionality
- ✅ Database queries now leverage TimescaleDB partitioning properly

## Files Changed
- `src/flight_tracker/location.rs` - Enable Pelias geocoding
- `src/metrics.rs` - Add histogram buckets, initialize metrics, rename health fields
- `src/commands/run.rs` - Update metrics port for staging (9192)
- `src/commands/ingest_ogn.rs` - Remove NATS references, update port (9194)
- `src/commands/ingest_adsb.rs` - Update metrics port (9196)
- `src/commands/pull_data.rs` - Update metrics port
- `src/main.rs` - Remove nats_url from CLI
- `src/fixes_repo.rs` - Use received_at instead of timestamp in queries
- `infrastructure/prometheus-jobs/*-staging.yml` - Update ports to 919x range
- `infrastructure/soar-deploy` - Only install environment-appropriate configs
- `infrastructure/grafana-dashboard-run-routing.json` - Update panel names and queries