### PR TITLE
Fix soar-deploy to prevent reinstalling production Prometheus configs on staging

### DIFF
--- a/infrastructure/prometheus-scrape-configs/soar-aprs-ingest-staging.yml
+++ b/infrastructure/prometheus-scrape-configs/soar-aprs-ingest-staging.yml
@@ -5,7 +5,7 @@
 # Prometheus will automatically reload this file every 30 seconds.
 
 - targets:
-    - 'localhost:9094'
+    - 'localhost:9194'
   labels:
     instance: 'soar-staging'
     component: 'ingest-ogn'

--- a/infrastructure/prometheus-scrape-configs/soar-ingest-adsb-staging.yml
+++ b/infrastructure/prometheus-scrape-configs/soar-ingest-adsb-staging.yml
@@ -5,7 +5,7 @@
 # Prometheus will automatically reload this file every 30 seconds.
 
 - targets:
-    - 'localhost:9096'
+    - 'localhost:9196'
   labels:
     instance: 'soar-staging'
     component: 'ingest-adsb'

--- a/infrastructure/prometheus-scrape-configs/soar-run-staging.yml
+++ b/infrastructure/prometheus-scrape-configs/soar-run-staging.yml
@@ -5,7 +5,7 @@
 # Prometheus will automatically reload this file every 30 seconds.
 
 - targets:
-    - 'localhost:9092'
+    - 'localhost:9192'
   labels:
     instance: 'soar-staging'
     component: 'run'

--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -586,22 +586,59 @@ if [ -d "$DEPLOY_DIR/prometheus-scrape-configs" ]; then
     log_info "Installing Prometheus scrape-configs files (legacy file_sd_configs)..."
     mkdir -p /etc/prometheus/scrape-configs
 
-    # Remove old SOAR scrape-config files that aren't in the deployment
+    # Remove old SOAR scrape-config files for this environment
     if [ -d "/etc/prometheus/scrape-configs" ]; then
-        log_info "Cleaning up old scrape-config files..."
+        log_info "Cleaning up old scrape-config files for $ENVIRONMENT..."
         for old_config in /etc/prometheus/scrape-configs/soar-*.yml; do
             if [ -f "$old_config" ]; then
                 config_basename=$(basename "$old_config")
-                if [ ! -f "$DEPLOY_DIR/prometheus-scrape-configs/$config_basename" ]; then
-                    log_info "Removing obsolete scrape-config: $config_basename"
-                    rm -f "$old_config"
+
+                # Check if this file matches the current environment
+                if [ "$ENVIRONMENT" = "staging" ]; then
+                    # In staging, remove only staging files that aren't in deployment
+                    if [[ "$config_basename" =~ -staging\.yml$ ]]; then
+                        if [ ! -f "$DEPLOY_DIR/prometheus-scrape-configs/$config_basename" ]; then
+                            log_info "Removing obsolete scrape-config: $config_basename"
+                            rm -f "$old_config"
+                        fi
+                    fi
+                else
+                    # In production, remove only production files (no -staging suffix) that aren't in deployment
+                    if [[ ! "$config_basename" =~ -staging\.yml$ ]]; then
+                        if [ ! -f "$DEPLOY_DIR/prometheus-scrape-configs/$config_basename" ]; then
+                            log_info "Removing obsolete scrape-config: $config_basename"
+                            rm -f "$old_config"
+                        fi
+                    fi
                 fi
             fi
         done
     fi
 
-    cp "$DEPLOY_DIR/prometheus-scrape-configs"/*.yml /etc/prometheus/scrape-configs/
-    chmod 644 /etc/prometheus/scrape-configs/*.yml
+    # Copy only environment-appropriate Prometheus scrape configs
+    if [ "$ENVIRONMENT" = "staging" ]; then
+        log_info "Installing staging Prometheus scrape configs (*-staging.yml)..."
+        for config_file in "$DEPLOY_DIR/prometheus-scrape-configs"/*-staging.yml; do
+            if [ -f "$config_file" ]; then
+                cp "$config_file" /etc/prometheus/scrape-configs/
+                chmod 644 "/etc/prometheus/scrape-configs/$(basename "$config_file")"
+                log_info "  Installed: $(basename "$config_file")"
+            fi
+        done
+    else
+        log_info "Installing production Prometheus scrape configs (not *-staging.yml)..."
+        for config_file in "$DEPLOY_DIR/prometheus-scrape-configs"/*.yml; do
+            if [ -f "$config_file" ]; then
+                config_basename=$(basename "$config_file")
+                # Skip staging files in production deployment and README
+                if [[ ! "$config_basename" =~ -staging\.yml$ ]] && [[ ! "$config_basename" =~ README ]]; then
+                    cp "$config_file" /etc/prometheus/scrape-configs/
+                    chmod 644 "/etc/prometheus/scrape-configs/$config_basename"
+                    log_info "  Installed: $config_basename"
+                fi
+            fi
+        done
+    fi
 
     # Set ownership to prometheus user if it exists
     if id "prometheus" &>/dev/null; then


### PR DESCRIPTION
## Summary
Follow-up fix to PR #760. Updates soar-deploy to apply environment-aware logic to
the `prometheus-scrape-configs` directory (same pattern as `prometheus-jobs`).

This prevents production Prometheus scrape configs from being reinstalled on staging
servers during deployments.

## Problem
After PR #760 merged, we discovered that `soar-deploy` was still copying ALL scrape-config
files from `prometheus-scrape-configs/` directory, overwriting the environment-specific
configs we had just configured. This happened because:

1. PR #760 only updated the `prometheus-jobs` section of soar-deploy
2. The `prometheus-scrape-configs` section still used `cp *.yml` to copy everything
3. This would reinstall production configs on staging servers on next deployment

## Solution
- ✅ Apply same environment-aware logic to `prometheus-scrape-configs` installation
- ✅ Staging: only install `*-staging.yml` files
- ✅ Production: only install non-staging files (skip `*-staging.yml`)
- ✅ Update staging scrape-config files to use correct 919x ports:
  - `soar-run-staging`: 9092 → 9192
  - `soar-aprs-ingest-staging`: 9094 → 9194  
  - `soar-ingest-adsb-staging`: 9096 → 9196

## Testing
- ✅ Manually verified on staging server after removing production configs
- ✅ Pre-commit hooks passed
- ✅ Changes match existing pattern from `prometheus-jobs` section

## Files Changed
- `infrastructure/soar-deploy` - Apply environment-aware logic to scrape-configs
- `infrastructure/prometheus-scrape-configs/soar-run-staging.yml` - Port 9092 → 9192
- `infrastructure/prometheus-scrape-configs/soar-aprs-ingest-staging.yml` - Port 9094 → 9194
- `infrastructure/prometheus-scrape-configs/soar-ingest-adsb-staging.yml` - Port 9096 → 9196