### PR TITLE
perf: Optimize fixes queries with time-based partition pruning

### DIFF
--- a/migrations/2026-01-05-021514-0000_drop_redundant_watchlist_user_id_idx/down.sql
+++ b/migrations/2026-01-05-021514-0000_drop_redundant_watchlist_user_id_idx/down.sql
@@ -1,0 +1,2 @@
+-- Recreate the index if migration is rolled back
+CREATE INDEX idx_watchlist_user_id ON watchlist(user_id);

--- a/migrations/2026-01-05-021514-0000_drop_redundant_watchlist_user_id_idx/up.sql
+++ b/migrations/2026-01-05-021514-0000_drop_redundant_watchlist_user_id_idx/up.sql
@@ -1,0 +1,4 @@
+-- Drop redundant index on watchlist(user_id)
+-- This index is redundant because the primary key (user_id, aircraft_id) already indexes user_id
+-- as its left prefix, so queries on user_id can use the PK index directly
+DROP INDEX IF EXISTS idx_watchlist_user_id;

--- a/src/flight_tracker/state_transitions.rs
+++ b/src/flight_tracker/state_transitions.rs
@@ -470,9 +470,16 @@ pub(crate) async fn process_state_transition(
                         // This catches cases where aircraft didn't move far enough given its pre-timeout speed
                         let speed_distance_check_failed = if gap_hours > 1.0 {
                             // Fetch last 10 fixes before timeout to calculate average speed
+                            // Use 18-hour window to match coalescing hard timeout
+                            let start_time = chrono::Utc::now() - chrono::Duration::hours(18);
                             let pre_timeout_fixes = ctx
                                 .fixes_repo
-                                .get_fixes_for_flight(timed_out_flight.id, Some(10))
+                                .get_fixes_for_flight(
+                                    timed_out_flight.id,
+                                    Some(10),
+                                    start_time,
+                                    None,
+                                )
                                 .await
                                 .ok()
                                 .unwrap_or_default();


### PR DESCRIPTION
## Summary
Improves query performance for fix lookups by adding explicit time-based filtering and removing redundant indexes.

## Changes
- **Add time parameters to `get_fixes_for_flight()`** for partition pruning
  - Internal flight tracking: Uses 18-hour window (matches coalescing timeout)
  - API endpoint: Uses flight's actual `takeoff_time`/`last_fix_at` timestamps
  - Eliminates default behavior to ensure explicit partition pruning at call sites
- **Update `clear_flight_id()`** to filter by last 24 hours
- **Optimize `timeout_flight()`** to use in-memory position instead of DB query
- **Drop redundant `idx_watchlist_user_id` index** (covered by PK prefix)

## Performance Impact
- ✅ API queries: Only scans partitions within flight duration
- ✅ Active tracking: Limited to 18-hour window instead of full history
- ✅ Removes one SELECT query per flight timeout
- ✅ Eliminates duplicate index on watchlist table

## Migration
- Creates migration `2026-01-05-021514-0000_drop_redundant_watchlist_user_id_idx` to drop the redundant index

## Test Plan
- [x] Pre-commit hooks pass (clippy, tests, formatting)
- [ ] Monitor query performance in production
- [ ] Verify flight tracking still works correctly with 18-hour window