### PR TITLE
Pin bincode to exact version 1.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ aws-sdk-s3 = "1.80"
 prost = "0.13"
 prost-types = "0.13"
 crc32fast = "1.4"
-bincode = "1.3"
+bincode = "=1.3.3"
 
 [dev-dependencies]
 hex-literal = "1.1"


### PR DESCRIPTION
## Summary
Pins the `bincode` crate to exact version 1.3.3 to prevent unintended version updates.

## Changes
- Changed `bincode = "1.3"` to `bincode = "=1.3.3"` in Cargo.toml

## Rationale
Using an exact version pin (`=1.3.3`) prevents Cargo from automatically updating to newer patch versions, which could introduce breaking changes or compatibility issues with our serialization format.

## Testing
- Pre-commit hooks passed