### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-ingest.yml
+++ b/.github/workflows/deploy-ingest.yml
@@ -1,5 +1,8 @@
 name: Deploy Ingest Services
 
+permissions:
+  contents: read
+
 # Manual workflow for deploying ingest-* services to staging or production
 # These services change infrequently and don't need to be deployed with every push
 


### PR DESCRIPTION
Potential fix for [https://github.com/hut8/soar/security/code-scanning/15](https://github.com/hut8/soar/security/code-scanning/15)

In general, to fix this issue, you explicitly define a `permissions` block either at the top level of the workflow (applies to all jobs that don’t override it) or within the specific job. The permissions should be restricted to the least required scopes. Since this workflow uses `actions/checkout@v6`, it needs only `contents: read` for `GITHUB_TOKEN`. All other operations are done via SSH using `secrets.SSH_PRIVATE_KEY` and do not require additional token permissions.

The best minimal fix without changing behavior is to add a top-level `permissions` block after the `name` (or after `on:`) with `contents: read`. This ensures that the `GITHUB_TOKEN` cannot write to the repository while still allowing `actions/checkout` to function. No imports or new methods are needed because this is a YAML workflow change only. Concretely, in `.github/workflows/deploy-ingest.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file so it applies to all jobs in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
