### PR TITLE
Fix: Remove graceful shutdown from ingest services

### DIFF
--- a/src/commands/ingest_adsb.rs
+++ b/src/commands/ingest_adsb.rs
@@ -100,54 +100,6 @@ pub async fn handle_ingest_adsb(
         .context("Failed to acquire instance lock - is another adsb-ingest instance running?")?;
     info!("Instance lock acquired for {}", lock_name);
 
-    // Set up signal handling for immediate shutdown
-    info!("Setting up shutdown handlers...");
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
-    let (beast_publisher_shutdown_tx, beast_publisher_shutdown_rx) =
-        tokio::sync::oneshot::channel::<()>();
-    let (sbs_publisher_shutdown_tx, sbs_publisher_shutdown_rx) =
-        tokio::sync::oneshot::channel::<()>();
-
-    // Spawn signal handler task for both SIGINT and SIGTERM
-    tokio::spawn(async move {
-        #[cfg(unix)]
-        {
-            use tokio::signal::unix::{SignalKind, signal};
-
-            let mut sigterm =
-                signal(SignalKind::terminate()).expect("Failed to register SIGTERM handler");
-            let mut sigint =
-                signal(SignalKind::interrupt()).expect("Failed to register SIGINT handler");
-
-            tokio::select! {
-                _ = sigterm.recv() => {
-                    info!("Received SIGTERM, exiting immediately...");
-                }
-                _ = sigint.recv() => {
-                    info!("Received SIGINT (Ctrl+C), exiting immediately...");
-                }
-            }
-        }
-
-        #[cfg(not(unix))]
-        {
-            match tokio::signal::ctrl_c().await {
-                Ok(()) => {
-                    info!("Received SIGINT (Ctrl+C), exiting immediately...");
-                }
-                Err(err) => {
-                    error!("Failed to listen for SIGINT signal: {}", err);
-                    return;
-                }
-            }
-        }
-
-        // Signal shutdown to clients and publishers
-        let _ = shutdown_tx.send(());
-        let _ = beast_publisher_shutdown_tx.send(());
-        let _ = sbs_publisher_shutdown_tx.send(());
-    });
-
     // Create persistent queues for buffering messages
     let beast_queue_path = std::path::PathBuf::from("/var/lib/soar/queues/adsb-beast.queue");
     let beast_queue = std::sync::Arc::new(
@@ -243,59 +195,49 @@ pub async fn handle_ingest_adsb(
 
     // Spawn Beast publisher task: reads from queue → sends to socket
     let beast_queue_for_publisher = beast_queue.clone();
-    let mut beast_publisher_shutdown_rx_inner = beast_publisher_shutdown_rx;
     let stats_sent_clone = stats_messages_sent.clone();
     let stats_time_clone = stats_send_time_total_ms.clone();
     let stats_slow_clone = stats_slow_sends.clone();
-    let beast_publisher_handle = tokio::spawn(async move {
+    let _beast_publisher_handle = tokio::spawn(async move {
         info!("Beast publisher task started");
         loop {
-            tokio::select! {
-                // Check for shutdown signal first (biased)
-                _ = &mut beast_publisher_shutdown_rx_inner => {
-                    info!("Beast publisher task received shutdown signal, exiting...");
-                    break;
-                }
-                // Process queue messages
-                recv_result = beast_queue_for_publisher.recv() => {
-                    match recv_result {
-                        Ok(message) => {
-                            // Track send timing
-                            let send_start = std::time::Instant::now();
+            match beast_queue_for_publisher.recv().await {
+                Ok(message) => {
+                    // Track send timing
+                    let send_start = std::time::Instant::now();
 
-                            // Send to socket
-                            match beast_socket_client.send(message).await {
-                                Ok(_) => {
-                                    // Track stats
-                                    let send_duration_ms = send_start.elapsed().as_millis() as u64;
-                                    stats_sent_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    stats_time_clone.fetch_add(send_duration_ms, std::sync::atomic::Ordering::Relaxed);
-                                    if send_duration_ms > 100 {
-                                        stats_slow_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    }
+                    // Send to socket
+                    match beast_socket_client.send(message).await {
+                        Ok(_) => {
+                            // Track stats
+                            let send_duration_ms = send_start.elapsed().as_millis() as u64;
+                            stats_sent_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            stats_time_clone
+                                .fetch_add(send_duration_ms, std::sync::atomic::Ordering::Relaxed);
+                            if send_duration_ms > 100 {
+                                stats_slow_clone.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            }
 
-                                    // Successfully delivered - commit the message so it won't be replayed
-                                    if let Err(e) = beast_queue_for_publisher.commit().await {
-                                        error!("Failed to commit Beast message offset: {}", e);
-                                    }
-                                }
-                                Err(e) => {
-                                    error!("Failed to send Beast message to socket: {}", e);
-                                    metrics::counter!("beast.socket.send_error_total").increment(1);
-
-                                    // DON'T commit - message will be replayed on next recv()
-                                    // Reconnect and retry
-                                    if let Err(e) = beast_socket_client.reconnect().await {
-                                        error!("Failed to reconnect Beast socket: {}", e);
-                                    }
-                                }
+                            // Successfully delivered - commit the message so it won't be replayed
+                            if let Err(e) = beast_queue_for_publisher.commit().await {
+                                error!("Failed to commit Beast message offset: {}", e);
                             }
                         }
                         Err(e) => {
-                            error!("Failed to receive from Beast queue: {}", e);
-                            break;
+                            error!("Failed to send Beast message to socket: {}", e);
+                            metrics::counter!("beast.socket.send_error_total").increment(1);
+
+                            // DON'T commit - message will be replayed on next recv()
+                            // Reconnect and retry
+                            if let Err(e) = beast_socket_client.reconnect().await {
+                                error!("Failed to reconnect Beast socket: {}", e);
+                            }
                         }
                     }
+                }
+                Err(e) => {
+                    error!("Failed to receive from Beast queue: {}", e);
+                    break;
                 }
             }
         }
@@ -304,142 +246,112 @@ pub async fn handle_ingest_adsb(
 
     // Spawn SBS publisher task: reads from queue → sends to socket
     let sbs_queue_for_publisher = sbs_queue.clone();
-    let mut sbs_publisher_shutdown_rx_inner = sbs_publisher_shutdown_rx;
     let stats_sent_clone_sbs = stats_messages_sent.clone();
     let stats_time_clone_sbs = stats_send_time_total_ms.clone();
     let stats_slow_clone_sbs = stats_slow_sends.clone();
-    let sbs_publisher_handle = tokio::spawn(async move {
+    let _sbs_publisher_handle = tokio::spawn(async move {
         info!("SBS publisher task started");
         loop {
-            tokio::select! {
-                // Check for shutdown signal first (biased)
-                _ = &mut sbs_publisher_shutdown_rx_inner => {
-                    info!("SBS publisher task received shutdown signal, exiting...");
-                    break;
-                }
-                // Process queue messages
-                recv_result = sbs_queue_for_publisher.recv() => {
-                    match recv_result {
-                        Ok(message) => {
-                            // Track send timing
-                            let send_start = std::time::Instant::now();
+            match sbs_queue_for_publisher.recv().await {
+                Ok(message) => {
+                    // Track send timing
+                    let send_start = std::time::Instant::now();
 
-                            // Send to socket
-                            match sbs_socket_client.send(message).await {
-                                Ok(_) => {
-                                    // Track stats
-                                    let send_duration_ms = send_start.elapsed().as_millis() as u64;
-                                    stats_sent_clone_sbs.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    stats_time_clone_sbs.fetch_add(send_duration_ms, std::sync::atomic::Ordering::Relaxed);
-                                    if send_duration_ms > 100 {
-                                        stats_slow_clone_sbs.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    }
+                    // Send to socket
+                    match sbs_socket_client.send(message).await {
+                        Ok(_) => {
+                            // Track stats
+                            let send_duration_ms = send_start.elapsed().as_millis() as u64;
+                            stats_sent_clone_sbs.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            stats_time_clone_sbs
+                                .fetch_add(send_duration_ms, std::sync::atomic::Ordering::Relaxed);
+                            if send_duration_ms > 100 {
+                                stats_slow_clone_sbs
+                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            }
 
-                                    // Successfully delivered - commit the message so it won't be replayed
-                                    if let Err(e) = sbs_queue_for_publisher.commit().await {
-                                        error!("Failed to commit SBS message offset: {}", e);
-                                    }
-                                }
-                                Err(e) => {
-                                    error!("Failed to send SBS message to socket: {}", e);
-                                    metrics::counter!("sbs.socket.send_error_total").increment(1);
-
-                                    // DON'T commit - message will be replayed on next recv()
-                                    // Reconnect and retry
-                                    if let Err(e) = sbs_socket_client.reconnect().await {
-                                        error!("Failed to reconnect SBS socket: {}", e);
-                                    }
-                                }
+                            // Successfully delivered - commit the message so it won't be replayed
+                            if let Err(e) = sbs_queue_for_publisher.commit().await {
+                                error!("Failed to commit SBS message offset: {}", e);
                             }
                         }
                         Err(e) => {
-                            error!("Failed to receive from SBS queue: {}", e);
-                            break;
+                            error!("Failed to send SBS message to socket: {}", e);
+                            metrics::counter!("sbs.socket.send_error_total").increment(1);
+
+                            // DON'T commit - message will be replayed on next recv()
+                            // Reconnect and retry
+                            if let Err(e) = sbs_socket_client.reconnect().await {
+                                error!("Failed to reconnect SBS socket: {}", e);
+                            }
                         }
                     }
+                }
+                Err(e) => {
+                    error!("Failed to receive from SBS queue: {}", e);
+                    break;
                 }
             }
         }
         info!("SBS publisher task stopped");
     });
 
-    // Create broadcast channel for shutdown signal (multiple tasks need to receive it)
-    let (shutdown_broadcast_tx, _) = tokio::sync::broadcast::channel::<()>(1);
-
-    // Spawn signal handler task
-    let shutdown_tx_clone = shutdown_broadcast_tx.clone();
-    tokio::spawn(async move {
-        let _ = shutdown_rx.await;
-        info!("Shutdown signal received, broadcasting to all client tasks...");
-        let _ = shutdown_tx_clone.send(());
-    });
-
     // Spawn periodic stats reporting task
     let beast_queue_for_stats = beast_queue.clone();
     let sbs_queue_for_stats = sbs_queue.clone();
-    let shutdown_rx_for_stats = shutdown_broadcast_tx.subscribe();
     let stats_frames_rx = stats_frames_received.clone();
     let stats_msgs_sent = stats_messages_sent.clone();
     let stats_send_time = stats_send_time_total_ms.clone();
     let stats_slow = stats_slow_sends.clone();
 
     tokio::spawn(async move {
-        let mut shutdown_rx = shutdown_rx_for_stats;
         let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(30));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {
-            tokio::select! {
-                _ = shutdown_rx.recv() => {
-                    info!("Stats reporting task shutting down");
-                    break;
+            interval.tick().await;
+
+            // Get and reset counters atomically
+            let frames_count = stats_frames_rx.swap(0, std::sync::atomic::Ordering::Relaxed);
+            let sent_count = stats_msgs_sent.swap(0, std::sync::atomic::Ordering::Relaxed);
+            let total_send_time = stats_send_time.swap(0, std::sync::atomic::Ordering::Relaxed);
+            let slow_count = stats_slow.swap(0, std::sync::atomic::Ordering::Relaxed);
+
+            // Calculate rates (per second)
+            let frames_per_sec = frames_count as f64 / 30.0;
+            let sent_per_sec = sent_count as f64 / 30.0;
+
+            // Calculate average socket send time
+            let avg_send_time_ms = if sent_count > 0 {
+                let avg = total_send_time as f64 / sent_count as f64;
+                if slow_count > 0 {
+                    format!("{:.1}ms ({} >100ms)", avg, slow_count)
+                } else {
+                    format!("{:.1}ms", avg)
                 }
-                _ = interval.tick() => {
-                    // Get and reset counters atomically
-                    let frames_count = stats_frames_rx.swap(0, std::sync::atomic::Ordering::Relaxed);
-                    let sent_count = stats_msgs_sent.swap(0, std::sync::atomic::Ordering::Relaxed);
-                    let total_send_time = stats_send_time.swap(0, std::sync::atomic::Ordering::Relaxed);
-                    let slow_count = stats_slow.swap(0, std::sync::atomic::Ordering::Relaxed);
+            } else {
+                "N/A".to_string()
+            };
 
-                    // Calculate rates (per second)
-                    let frames_per_sec = frames_count as f64 / 30.0;
-                    let sent_per_sec = sent_count as f64 / 30.0;
+            // Get queue depths
+            let beast_depth = beast_queue_for_stats.depth().await;
+            let sbs_depth = sbs_queue_for_stats.depth().await;
 
-                    // Calculate average socket send time
-                    let avg_send_time_ms = if sent_count > 0 {
-                        let avg = total_send_time as f64 / sent_count as f64;
-                        if slow_count > 0 {
-                            format!("{:.1}ms ({} >100ms)", avg, slow_count)
-                        } else {
-                            format!("{:.1}ms", avg)
-                        }
-                    } else {
-                        "N/A".to_string()
-                    };
-
-                    // Get queue depths
-                    let beast_depth = beast_queue_for_stats.depth().await;
-                    let sbs_depth = sbs_queue_for_stats.depth().await;
-
-                    // Log comprehensive stats
-                    info!(
-                        "ADS-B Stats (30s): recv={:.1}/s sent={:.1}/s | socket_send={} | queues: beast={{mem:{} disk:{}B}} sbs={{mem:{} disk:{}B}}",
-                        frames_per_sec,
-                        sent_per_sec,
-                        avg_send_time_ms,
-                        beast_depth.memory,
-                        beast_depth.disk,
-                        sbs_depth.memory,
-                        sbs_depth.disk
-                    );
-                }
-            }
+            // Log comprehensive stats
+            info!(
+                "ADS-B Stats (30s): recv={:.1}/s sent={:.1}/s | socket_send={} | queues: beast={{mem:{} disk:{}B}} sbs={{mem:{} disk:{}B}}",
+                frames_per_sec,
+                sent_per_sec,
+                avg_send_time_ms,
+                beast_depth.memory,
+                beast_depth.disk,
+                sbs_depth.memory,
+                sbs_depth.disk
+            );
         }
     });
 
     // Spawn tasks for each Beast server
-    let mut client_handles = vec![];
-
     for beast_addr in &beast_servers {
         let (server, port) = parse_server_address(beast_addr)?;
         let config = BeastClientConfig {
@@ -452,34 +364,20 @@ pub async fn handle_ingest_adsb(
 
         let queue = beast_queue.clone();
         let health = health_state.clone();
-        let shutdown_rx = shutdown_broadcast_tx.subscribe();
-        let (client_shutdown_tx, client_shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         let stats_rx = stats_frames_received.clone();
-
-        // Bridge broadcast to oneshot
-        tokio::spawn(async move {
-            let mut rx = shutdown_rx;
-            if rx.recv().await.is_ok() {
-                let _ = client_shutdown_tx.send(());
-            }
-        });
 
         info!("Spawning Beast client for {}:{}", server, port);
         let server_clone = server.clone();
-        let handle = tokio::spawn(
+        let _handle = tokio::spawn(
             async move {
                 let mut client = BeastClient::new(config);
-                match client
-                    .start_with_queue(queue, client_shutdown_rx, health, Some(stats_rx))
-                    .await
-                {
+                match client.start_with_queue(queue, health, Some(stats_rx)).await {
                     Ok(_) => info!("Beast client {}:{} stopped normally", server, port),
                     Err(e) => error!("Beast client {}:{} failed: {}", server, port, e),
                 }
             }
             .instrument(tracing::info_span!("beast_client", server = %server_clone, port = %port)),
         );
-        client_handles.push(handle);
     }
 
     // Spawn tasks for each SBS server
@@ -495,34 +393,20 @@ pub async fn handle_ingest_adsb(
 
         let queue = sbs_queue.clone();
         let health = health_state.clone();
-        let shutdown_rx = shutdown_broadcast_tx.subscribe();
-        let (client_shutdown_tx, client_shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         let stats_rx = stats_frames_received.clone();
-
-        // Bridge broadcast to oneshot
-        tokio::spawn(async move {
-            let mut rx = shutdown_rx;
-            if rx.recv().await.is_ok() {
-                let _ = client_shutdown_tx.send(());
-            }
-        });
 
         info!("Spawning SBS client for {}:{}", server, port);
         let server_clone = server.clone();
-        let handle = tokio::spawn(
+        let _handle = tokio::spawn(
             async move {
                 let mut client = SbsClient::new(config);
-                match client
-                    .start_with_queue(queue, client_shutdown_rx, health, Some(stats_rx))
-                    .await
-                {
+                match client.start_with_queue(queue, health, Some(stats_rx)).await {
                     Ok(_) => info!("SBS client {}:{} stopped normally", server, port),
                     Err(e) => error!("SBS client {}:{} failed: {}", server, port, e),
                 }
             }
             .instrument(tracing::info_span!("sbs_client", server = %server_clone, port = %port)),
         );
-        client_handles.push(handle);
     }
 
     info!(
@@ -531,20 +415,11 @@ pub async fn handle_ingest_adsb(
         sbs_servers.len()
     );
 
-    // Wait for all client tasks to complete
-    for handle in client_handles {
-        let _ = handle.await;
+    // Keep running until process is terminated
+    // All tasks are spawned in the background and will be killed when the process exits
+    loop {
+        tokio::time::sleep(tokio::time::Duration::from_secs(3600)).await;
     }
-
-    info!("All client tasks completed, waiting for publisher tasks...");
-
-    // Wait for publisher tasks to complete
-    let _ = beast_publisher_handle.await;
-    let _ = sbs_publisher_handle.await;
-
-    info!("All tasks completed, shutting down");
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -114,7 +114,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
 			"integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.3",
@@ -1142,7 +1141,6 @@
 			"integrity": "sha512-oJrXtQiAXLvT9clCf1K4kxp3eKsQhIaZqxEyowkBcsvZDdZkbWrVmnGknxs5flTD0VGsxrxKgBCZty1EzoiMzA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@swc/helpers": "^0.5.0"
 			}
@@ -1309,7 +1307,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -1331,7 +1328,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.2.0.tgz",
 			"integrity": "sha512-qRkLWiUEZNAmYapZ7KGS5C4OmBLcP/H2foXeOEaowYCR0wi89fHejrfYfbuLVCMLp/dWZXKvQusdbUEZjERfwQ==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
@@ -1344,7 +1340,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
 			"integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
@@ -1360,7 +1355,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.208.0.tgz",
 			"integrity": "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/api-logs": "0.208.0",
 				"import-in-the-middle": "^2.0.0",
@@ -1748,7 +1742,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
 			"integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "2.2.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
@@ -1765,7 +1758,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
 			"integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "2.2.0",
 				"@opentelemetry/resources": "2.2.0",
@@ -1783,7 +1775,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
 			"integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -2795,7 +2786,6 @@
 			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.49.2.tgz",
 			"integrity": "sha512-Vp3zX/qlwerQmHMP6x0Ry1oY7eKKRcOWGc2P59srOp4zcqyn+etJyQpELgOi4+ZSUgteX8Y387NuwruLgGXLUQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -2834,7 +2824,6 @@
 			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-6.2.1.tgz",
 			"integrity": "sha512-YZs/OSKOQAQCnJvM/P+F1URotNnYNeU3P2s4oIpzm1uFaqUEqRxUB0g5ejMjEb5Gjb9/PiBI5Ktrq4rUUF8UVQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
 				"debug": "^4.4.1",
@@ -3419,7 +3408,6 @@
 			"integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.51.0",
 				"@typescript-eslint/types": "8.51.0",
@@ -4256,7 +4244,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -4513,7 +4500,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -4890,7 +4876,6 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -6440,7 +6425,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -6625,7 +6609,6 @@
 			"integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -6642,7 +6625,6 @@
 			"integrity": "sha512-xL49LCloMoZRvSwa6IEdN2GV6cq2IqpYGstYtMT+5wmml1/dClEoI0MZR78MiVPpu6BdQFfN0/y73yO6+br5Pg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"prettier": "^3.0.0",
 				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
@@ -6871,7 +6853,6 @@
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz",
 			"integrity": "sha512-/Zl4D8zPifNmyGzJS+3kVoyXeDeT/GrsJM94sACNg9RtUE0hrHa1bNPtRSrfHTMH5HjRzce6K7rlTh3Khiw+pw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -7069,7 +7050,6 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.46.1.tgz",
 			"integrity": "sha512-ynjfCHD3nP2el70kN5Pmg37sSi0EjOm9FgHYQdC4giWG/hzO3AatzXXJJgP305uIhGQxSufJLuYWtkY8uK/8RA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -7163,8 +7143,7 @@
 			"version": "4.1.18",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
 			"integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -7297,7 +7276,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -7480,7 +7458,6 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
 			"integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",


### PR DESCRIPTION
## Summary

This PR removes the graceful shutdown logic from `ingest-ogn` and `ingest-adsb` services that was causing systemd to wait 30 seconds and send SIGKILL because the tasks weren't completing on SIGTERM.

**Changes:**
- Removed all shutdown channels (`shutdown_rx` parameters) from ingest client methods
- Removed shutdown signal handlers from `ingest-ogn` and `ingest-adsb` commands  
- Removed shutdown checks from message processing loops in APRS, Beast, and SBS clients
- Services now rely on Rust's default signal handler to exit immediately on SIGTERM

**Impact:**
- Services will now exit immediately when receiving SIGTERM from systemd
- No more 30-second wait followed by SIGKILL
- Background tasks will be terminated immediately when the process exits

## Test plan

- [x] Code compiles with `cargo check`
- [x] Pre-commit hooks pass (fmt, clippy, tests)
- [ ] Deploy to staging and verify restart behavior:
  - `sudo systemctl restart soar-ingest-ogn-staging`
  - `journalctl -u soar-ingest-ogn-staging -n 50` - should show immediate exit
  - `sudo systemctl restart soar-ingest-adsb-staging`
  - `journalctl -u soar-ingest-adsb-staging -n 50` - should show immediate exit
- [ ] Verify services restart cleanly and reconnect to data sources