### PR TITLE
Fix chunk metadata lookup in move_via migration

### DIFF
--- a/migrations/2026-01-07-015150-0000_move_via_to_source_metadata/up.sql
+++ b/migrations/2026-01-07-015150-0000_move_via_to_source_metadata/up.sql
@@ -2,17 +2,48 @@
 -- The 'via' column contains APRS routing information (digipeater path) which is
 -- specific to OGN/APRS and should be stored in source_metadata
 
--- Update existing rows to add 'via' to source_metadata
+-- Update existing rows to add 'via' to source_metadata in chunk-sized operations
 -- Handle both NULL and non-NULL source_metadata cases
-UPDATE fixes
-SET source_metadata = CASE
-    -- If source_metadata is NULL, create new object with just 'via'
-    WHEN source_metadata IS NULL THEN
-        jsonb_build_object('via', to_jsonb(via))
-    -- If source_metadata exists, merge 'via' into it
-    ELSE
-        source_metadata || jsonb_build_object('via', to_jsonb(via))
+DO $$
+DECLARE
+    chunk REGCLASS;
+    was_compressed BOOLEAN;
+    chunk_schema_name TEXT;
+    chunk_table_name TEXT;
+BEGIN
+    FOR chunk IN SELECT show_chunks('fixes') LOOP
+        chunk_schema_name := split_part(chunk::text, '.', 1);
+        chunk_table_name := split_part(chunk::text, '.', 2);
+
+        SELECT is_compressed
+        INTO was_compressed
+        FROM timescaledb_information.chunks
+        WHERE hypertable_name = 'fixes'
+          AND chunk_schema = chunk_schema_name
+          AND chunk_name = chunk_table_name;
+
+        IF COALESCE(was_compressed, FALSE) THEN
+            EXECUTE format('SELECT decompress_chunk(%L::regclass)', chunk::text);
+        END IF;
+
+        EXECUTE format($sql$
+            UPDATE %s
+            SET source_metadata = CASE
+                -- If source_metadata is NULL, create new object with just 'via'
+                WHEN source_metadata IS NULL THEN
+                    jsonb_build_object('via', to_jsonb(via))
+                -- If source_metadata exists, merge 'via' into it
+                ELSE
+                    source_metadata || jsonb_build_object('via', to_jsonb(via))
+            END
+        $sql$, chunk);
+
+        IF COALESCE(was_compressed, FALSE) THEN
+            EXECUTE format('SELECT compress_chunk(%L::regclass)', chunk::text);
+        END IF;
+    END LOOP;
 END;
+$$;
 
 -- Drop the 'via' column as it's now in source_metadata
 ALTER TABLE fixes DROP COLUMN via;


### PR DESCRIPTION
### Motivation
- Avoid a single large `UPDATE` that would decompress many tuples by processing the `fixes` hypertable per TimescaleDB chunk.  
- Ensure compression metadata is looked up correctly for schema-qualified chunk names.  
- Preserve the migration intent of moving `via` into `source_metadata` safely for compressed chunks.  

### Description
- Replace the global `UPDATE fixes ...` with a `DO $$ ... $$` block that iterates `SELECT show_chunks('fixes')` and updates each chunk individually.  
- Decompress and recompress chunks as needed using `decompress_chunk` and `compress_chunk` when `timescaledb_information.chunks.is_compressed` is true.  
- Extract `chunk_schema_name` and `chunk_table_name` from the `REGCLASS` returned by `show_chunks` and use those values to query `timescaledb_information.chunks` for correct metadata lookup.  
- Perform the per-chunk `UPDATE` via `EXECUTE format(..., chunk)` and keep the final `ALTER TABLE fixes DROP COLUMN via` to remove the migrated column.  

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695de56019188329a25b4b43c62c517b)