### PR TITLE
Remove RuntimeDirectory from ingest services to fix socket reconnection

### DIFF
--- a/infrastructure/systemd/soar-ingest-adsb-staging.service
+++ b/infrastructure/systemd/soar-ingest-adsb-staging.service
@@ -19,10 +19,6 @@ ExecReload=/bin/kill -s HUP $MAINPID
 # Environment variables
 EnvironmentFile=/etc/soar/env-staging
 
-# Runtime directory for Unix sockets
-RuntimeDirectory=soar
-RuntimeDirectoryMode=0755
-
 # Security settings
 NoNewPrivileges=yes
 

--- a/infrastructure/systemd/soar-ingest-adsb.service
+++ b/infrastructure/systemd/soar-ingest-adsb.service
@@ -19,10 +19,6 @@ ExecReload=/bin/kill -s HUP $MAINPID
 # Environment variables
 EnvironmentFile=/etc/soar/env-production
 
-# Runtime directory for Unix sockets
-RuntimeDirectory=soar
-RuntimeDirectoryMode=0755
-
 # Security settings
 NoNewPrivileges=yes
 

--- a/infrastructure/systemd/soar-ingest-ogn-staging.service
+++ b/infrastructure/systemd/soar-ingest-ogn-staging.service
@@ -19,10 +19,6 @@ ExecReload=/bin/kill -s HUP $MAINPID
 # Environment variables (staging environment)
 EnvironmentFile=/etc/soar/env-staging
 
-# Runtime directory for Unix sockets
-RuntimeDirectory=soar
-RuntimeDirectoryMode=0755
-
 # Security settings
 NoNewPrivileges=yes
 

--- a/infrastructure/systemd/soar-ingest-ogn.service
+++ b/infrastructure/systemd/soar-ingest-ogn.service
@@ -19,10 +19,6 @@ ExecReload=/bin/kill -s HUP $MAINPID
 # Environment variables
 EnvironmentFile=/etc/soar/env-production
 
-# Runtime directory for Unix sockets
-RuntimeDirectory=soar
-RuntimeDirectoryMode=0755
-
 # Security settings
 NoNewPrivileges=yes
 


### PR DESCRIPTION
## Summary
- Remove `RuntimeDirectory=soar` from all ingest service files (ogn, adsb, staging variants)
- Fixes issue where restarting an ingest service would cause systemd to delete `/run/soar/`, removing the socket that `soar-run` created
- Only `soar-run` should own the RuntimeDirectory since it creates and manages the socket file

## Root Cause
When multiple systemd services specify the same `RuntimeDirectory`, systemd cleans up the directory when *any* of them stops. This caused the socket file to be deleted when restarting ingesters, preventing reconnection.

## Test plan
- [ ] Restart `soar-ingest-ogn-staging` while `soar-run-staging` is running
- [ ] Verify ingest service reconnects successfully (no "No such file or directory" errors)