### PR TITLE
Improve queue management and fix migrations, tracing, and logging

### DIFF
--- a/src/beast/client.rs
+++ b/src/beast/client.rs
@@ -397,6 +397,28 @@ impl BeastClient {
         let mut retry_delay = config.retry_delay_seconds;
 
         loop {
+            // Before connecting/reconnecting, wait for queue to be ready
+            // This prevents reconnecting when the queue is still full
+            if !queue.is_ready_for_connection() {
+                let capacity = queue.capacity_percent();
+                info!(
+                    "Queue at {}% capacity, waiting for it to drain to 75% before reconnecting",
+                    capacity
+                );
+                metrics::counter!("beast.connection_deferred_total").increment(1);
+
+                // Wait for queue to drain
+                while !queue.is_ready_for_connection() {
+                    tokio::time::sleep(Duration::from_secs(5)).await;
+                }
+
+                let new_capacity = queue.capacity_percent();
+                info!(
+                    "Queue drained to {}% capacity, proceeding with reconnection",
+                    new_capacity
+                );
+            }
+
             let result =
                 Self::connect_and_run(&config, raw_message_tx.clone(), health_state.clone()).await;
 

--- a/src/flight_tracker/location.rs
+++ b/src/flight_tracker/location.rs
@@ -102,7 +102,7 @@ pub(crate) async fn create_or_find_location(
             };
             match locations_repo.find_or_create(params).await {
                 Ok(created_location) => {
-                    info!(
+                    debug!(
                         "Created/found location {} for coordinates ({}, {}): {}",
                         created_location.id, latitude, longitude, result.display_name
                     );
@@ -118,8 +118,8 @@ pub(crate) async fn create_or_find_location(
             }
         }
         Err(e) => {
-            warn!(
-                "Reverse geocoding failed for coordinates ({}, {}): {}",
+            info!(
+                "Pelias reverse geocoding returned no result for coordinates ({}, {}): {}",
                 latitude, longitude, e
             );
             None
@@ -250,7 +250,7 @@ pub(crate) async fn create_start_end_location(
             };
             match locations_repo.find_or_create(params).await {
                 Ok(created_location) => {
-                    info!(
+                    debug!(
                         "Created/found {} location {} for coordinates ({}, {}): {}",
                         context, created_location.id, latitude, longitude, result.display_name
                     );
@@ -279,8 +279,8 @@ pub(crate) async fn create_start_end_location(
         }
         Err(e) => {
             metrics::counter!("flight_tracker.location.pelias.failure_total").increment(1);
-            warn!(
-                "Reverse geocoding failed for {} location at coordinates ({}, {}): {:?}",
+            info!(
+                "Pelias reverse geocoding returned no result for {} location at ({}, {}): {:?}",
                 context, latitude, longitude, e
             );
             None


### PR DESCRIPTION
## Summary

- **Database migrations only run for `soar migrate`**: Other commands (web, run, ingest) no longer auto-run migrations on startup
- **Fix persistent queue capacity calculation**: Uses actual data size (write_offset - read_offset) instead of file size, since the file doesn't shrink while draining
- **Add queue compaction**: When file is mostly consumed and nearing capacity, compact to reclaim space by rewriting with only unconsumed data
- **Queue-ready reconnection logic**: Disconnect from APRS/Beast/SBS when queue is full, wait until drained to 75% capacity before reconnecting
- **Add drain time estimate to ingest stats logging**: Shows estimated time to drain queue based on current throughput
- **Fix trace accumulation in Tempo**: Spawned enrichment tasks now create new root spans instead of inheriting parent context (was causing 154MB+ traces)
- **Adjust log levels**: Location creation success → debug, Pelias failures stay at INFO

## Test plan

- [ ] Verify `soar web` and `soar run` no longer run migrations on startup
- [ ] Verify `soar migrate` still runs migrations correctly
- [ ] Monitor queue capacity metrics in Grafana
- [ ] Verify Tempo trace sizes are reasonable after deploy
- [ ] Check ingest stats logs show drain time estimate