### PR TITLE
Add environment label to Prometheus metrics

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -78,6 +78,10 @@ pub fn init_metrics(component: Option<&str>) -> PrometheusHandle {
         builder = builder.add_global_label("component", comp);
     }
 
+    // Add environment label based on SOAR_ENV
+    let environment = std::env::var("SOAR_ENV").unwrap_or_else(|_| "development".to_string());
+    builder = builder.add_global_label("environment", environment);
+
     builder
         // Configure HTTP request duration as histogram with appropriate buckets
         // Buckets: 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s


### PR DESCRIPTION
## Summary
- Adds `environment` label to all Prometheus metrics based on `SOAR_ENV`
- Fixes Grafana dashboard queries that filter by `environment="$environment"` which weren't working because metrics didn't have this label

## Test plan
- [x] Deploy to staging and verify metrics now have `environment="staging"` label
- [x] All queue depth metrics now visible in Grafana (previously only 2 showed up)