### PR TITLE
Reduce staging archive retention from 45 to 7 days

### DIFF
--- a/infrastructure/systemd/soar-archive-staging.service
+++ b/infrastructure/systemd/soar-archive-staging.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=SOAR Archive (Staging) - Archive Old Data (45-day retention)
+Description=SOAR Archive (Staging) - Archive Old Data (7-day retention)
 Documentation=https://github.com/hut8/soar
 After=network-online.target postgresql.service
 Wants=network-online.target
@@ -11,9 +11,9 @@ User=soar
 Group=soar
 WorkingDirectory=/var/soar
 
-# Run archive command with 45-day retention (same as production)
-# Archives all data (flights, fixes, receiver_statuses, raw_messages) 45+ days old
-ExecStart=/usr/local/bin/soar-staging archive --max-age-days 45 --archive-path /var/soar/archive-staging
+# Run archive command with 7-day retention (shorter than production for staging)
+# Archives all data (flights, fixes, receiver_statuses, raw_messages) 7+ days old
+ExecStart=/usr/local/bin/soar-staging archive --max-age-days 7 --archive-path /var/soar/archive-staging
 
 # Environment variables (staging environment)
 EnvironmentFile=/etc/soar/env-staging


### PR DESCRIPTION
## Summary
- Reduces staging archive retention from 45 days to 7 days
- Staging doesn't need as much historical data as production
- Saves disk space on the staging server

## Changes
- Updated `infrastructure/systemd/soar-archive-staging.service` to use `--max-age-days 7`

## Test plan
- [x] Service file installed and systemd daemon reloaded on staging