### PR TITLE
Remove tracing from hot path to fix performance and trace accumulation

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -20,8 +20,7 @@ use soar::receiver_status_repo::ReceiverStatusRepository;
 use soar::server_messages_repo::ServerMessagesRepository;
 use std::env;
 use std::sync::Arc;
-use tracing::{Instrument, debug, error, info, info_span, trace, warn};
-use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
 // Queue size constants
@@ -39,7 +38,8 @@ fn queue_warning_threshold(queue_size: usize) -> usize {
 /// Process a received APRS message by parsing and routing through PacketRouter
 /// The message format is: "YYYY-MM-DDTHH:MM:SS.SSSZ <original_message>"
 /// We extract the timestamp and pass it through the processing pipeline
-#[tracing::instrument(skip(packet_router), fields(message_len = message.len()))]
+// Note: Intentionally NOT using #[tracing::instrument] here - it causes trace accumulation
+// in Tempo because spawned tasks inherit trace context and all messages end up in one huge trace.
 async fn process_aprs_message(
     message: &str,
     packet_router: &soar::packet_processors::PacketRouter,
@@ -119,7 +119,8 @@ async fn process_aprs_message(
 
 /// Process a received Beast (ADS-B) message from NATS
 /// The message format is binary: 8-byte timestamp (big-endian i64 microseconds) + Beast frame
-#[tracing::instrument(skip(aircraft_repo, beast_repo, fix_processor, cpr_decoder), fields(message_len = message_bytes.len(), %receiver_id))]
+// Note: Intentionally NOT using #[tracing::instrument] here - it causes trace accumulation
+// in Tempo because spawned tasks inherit trace context and all messages end up in one huge trace.
 async fn process_beast_message(
     message_bytes: &[u8],
     aircraft_repo: &AircraftRepository,
@@ -276,7 +277,9 @@ fn extract_icao_from_message(message: &rs1090::prelude::Message) -> Result<u32> 
 }
 
 #[allow(clippy::too_many_arguments)]
-#[tracing::instrument(skip_all)]
+// Note: Intentionally NOT using #[tracing::instrument] here because it creates a parent span
+// that causes all spawned worker tasks to inherit the same trace context, leading to
+// TRACE_TOO_LARGE errors in Tempo as the trace accumulates indefinitely.
 pub async fn handle_run(
     archive_dir: Option<String>,
     nats_url: String,
@@ -678,19 +681,13 @@ pub async fn handle_run(
             info!("Intake queue processor started");
             let mut messages_processed = 0u64;
             while let Ok(message) = nats_intake_rx.recv_async().await {
-                // Create a new root span for each message (prevents trace accumulation)
-                let span = info_span!("process_ogn_message");
-                let _ = span.set_parent(opentelemetry::Context::new());
-
-                async {
-                    metrics::gauge!("worker.active", "type" => "intake").increment(1.0);
-                    process_aprs_message(&message, &intake_router).await;
-                    messages_processed += 1;
-                    metrics::counter!("aprs.intake.processed_total").increment(1);
-                    metrics::gauge!("worker.active", "type" => "intake").decrement(1.0);
-                }
-                .instrument(span)
-                .await;
+                // Note: No tracing spans here - they cause trace accumulation in Tempo
+                // Use metrics only for observability in the hot path
+                metrics::gauge!("worker.active", "type" => "intake").increment(1.0);
+                process_aprs_message(&message, &intake_router).await;
+                messages_processed += 1;
+                metrics::counter!("aprs.intake.processed_total").increment(1);
+                metrics::gauge!("worker.active", "type" => "intake").decrement(1.0);
 
                 // Update intake queue depth metric
                 metrics::gauge!("aprs.intake_queue.depth").set(nats_intake_rx.len() as f64);
@@ -728,29 +725,22 @@ pub async fn handle_run(
 
             tokio::spawn(async move {
                 while let Ok(message_bytes) = beast_intake_rx.recv_async().await {
-                    // Create a new root span for each message (prevents trace accumulation)
-                    let span = info_span!("process_beast_message");
-                    let _ = span.set_parent(opentelemetry::Context::new());
-
-                    async {
-                        let start_time = std::time::Instant::now();
-                        process_beast_message(
-                            &message_bytes,
-                            &beast_aircraft_repo,
-                            &beast_repo_clone,
-                            &beast_fix_processor,
-                            &beast_cpr_decoder,
-                            beast_receiver_id,
-                        )
-                        .await;
-
-                        let duration = start_time.elapsed();
-                        metrics::histogram!("beast.run.process_message_duration_ms")
-                            .record(duration.as_millis() as f64);
-                        metrics::counter!("beast.run.intake.processed_total").increment(1);
-                    }
-                    .instrument(span)
+                    // Note: No tracing spans here - they cause trace accumulation in Tempo
+                    let start_time = std::time::Instant::now();
+                    process_beast_message(
+                        &message_bytes,
+                        &beast_aircraft_repo,
+                        &beast_repo_clone,
+                        &beast_fix_processor,
+                        &beast_cpr_decoder,
+                        beast_receiver_id,
+                    )
                     .await;
+
+                    let duration = start_time.elapsed();
+                    metrics::histogram!("beast.run.process_message_duration_ms")
+                        .record(duration.as_millis() as f64);
+                    metrics::counter!("beast.run.intake.processed_total").increment(1);
 
                     // Update Beast intake queue depth metric (sample from each worker)
                     metrics::gauge!("beast.intake_queue.depth").set(beast_intake_rx.len() as f64);
@@ -775,24 +765,17 @@ pub async fn handle_run(
         let processor = aircraft_position_processor.clone();
         tokio::spawn(async move {
             while let Ok((packet, context)) = worker_rx.recv_async().await {
-                // Create a new root span for each packet (prevents trace accumulation)
-                let span = info_span!("process_aircraft_position");
-                let _ = span.set_parent(opentelemetry::Context::new());
-
-                async {
-                    metrics::gauge!("worker.active", "type" => "aircraft").increment(1.0);
-                    let start = std::time::Instant::now();
-                    processor.process_aircraft_position(&packet, context).await;
-                    let duration = start.elapsed();
-                    metrics::histogram!("aprs.aircraft.duration_ms")
-                        .record(duration.as_millis() as f64);
-                    metrics::counter!("aprs.aircraft.processed_total").increment(1);
-                    metrics::counter!("aprs.messages.processed.aircraft_total").increment(1);
-                    metrics::counter!("aprs.messages.processed.total_total").increment(1);
-                    metrics::gauge!("worker.active", "type" => "aircraft").decrement(1.0);
-                }
-                .instrument(span)
-                .await;
+                // Note: No tracing spans here - they cause trace accumulation in Tempo
+                metrics::gauge!("worker.active", "type" => "aircraft").increment(1.0);
+                let start = std::time::Instant::now();
+                processor.process_aircraft_position(&packet, context).await;
+                let duration = start.elapsed();
+                metrics::histogram!("aprs.aircraft.duration_ms")
+                    .record(duration.as_millis() as f64);
+                metrics::counter!("aprs.aircraft.processed_total").increment(1);
+                metrics::counter!("aprs.messages.processed.aircraft_total").increment(1);
+                metrics::counter!("aprs.messages.processed.total_total").increment(1);
+                metrics::gauge!("worker.active", "type" => "aircraft").decrement(1.0);
             }
         });
     }
@@ -808,24 +791,17 @@ pub async fn handle_run(
         let processor = receiver_status_processor.clone();
         tokio::spawn(async move {
             while let Ok((packet, context)) = worker_rx.recv_async().await {
-                // Create a new root span for each packet (prevents trace accumulation)
-                let span = info_span!("process_receiver_status");
-                let _ = span.set_parent(opentelemetry::Context::new());
-
-                async {
-                    metrics::gauge!("worker.active", "type" => "receiver_status").increment(1.0);
-                    let start = std::time::Instant::now();
-                    processor.process_status_packet(&packet, context).await;
-                    let duration = start.elapsed();
-                    metrics::histogram!("aprs.receiver_status.duration_ms")
-                        .record(duration.as_millis() as f64);
-                    metrics::counter!("aprs.receiver_status.processed_total").increment(1);
-                    metrics::counter!("aprs.messages.processed.receiver_status_total").increment(1);
-                    metrics::counter!("aprs.messages.processed.total_total").increment(1);
-                    metrics::gauge!("worker.active", "type" => "receiver_status").decrement(1.0);
-                }
-                .instrument(span)
-                .await;
+                // Note: No tracing spans here - they cause trace accumulation in Tempo
+                metrics::gauge!("worker.active", "type" => "receiver_status").increment(1.0);
+                let start = std::time::Instant::now();
+                processor.process_status_packet(&packet, context).await;
+                let duration = start.elapsed();
+                metrics::histogram!("aprs.receiver_status.duration_ms")
+                    .record(duration.as_millis() as f64);
+                metrics::counter!("aprs.receiver_status.processed_total").increment(1);
+                metrics::counter!("aprs.messages.processed.receiver_status_total").increment(1);
+                metrics::counter!("aprs.messages.processed.total_total").increment(1);
+                metrics::gauge!("worker.active", "type" => "receiver_status").decrement(1.0);
             }
         });
     }
@@ -841,25 +817,17 @@ pub async fn handle_run(
         let processor = receiver_position_processor.clone();
         tokio::spawn(async move {
             while let Ok((packet, context)) = worker_rx.recv_async().await {
-                // Create a new root span for each packet (prevents trace accumulation)
-                let span = info_span!("process_receiver_position");
-                let _ = span.set_parent(opentelemetry::Context::new());
-
-                async {
-                    metrics::gauge!("worker.active", "type" => "receiver_position").increment(1.0);
-                    let start = std::time::Instant::now();
-                    processor.process_receiver_position(&packet, context).await;
-                    let duration = start.elapsed();
-                    metrics::histogram!("aprs.receiver_position.duration_ms")
-                        .record(duration.as_millis() as f64);
-                    metrics::counter!("aprs.receiver_position.processed_total").increment(1);
-                    metrics::counter!("aprs.messages.processed.receiver_position_total")
-                        .increment(1);
-                    metrics::counter!("aprs.messages.processed.total_total").increment(1);
-                    metrics::gauge!("worker.active", "type" => "receiver_position").decrement(1.0);
-                }
-                .instrument(span)
-                .await;
+                // Note: No tracing spans here - they cause trace accumulation in Tempo
+                metrics::gauge!("worker.active", "type" => "receiver_position").increment(1.0);
+                let start = std::time::Instant::now();
+                processor.process_receiver_position(&packet, context).await;
+                let duration = start.elapsed();
+                metrics::histogram!("aprs.receiver_position.duration_ms")
+                    .record(duration.as_millis() as f64);
+                metrics::counter!("aprs.receiver_position.processed_total").increment(1);
+                metrics::counter!("aprs.messages.processed.receiver_position_total").increment(1);
+                metrics::counter!("aprs.messages.processed.total_total").increment(1);
+                metrics::gauge!("worker.active", "type" => "receiver_position").decrement(1.0);
             }
         });
     }
@@ -871,26 +839,19 @@ pub async fn handle_run(
         let processor = server_status_processor.clone();
         tokio::spawn(async move {
             while let Ok((message, received_at)) = worker_rx.recv_async().await {
-                // Create a new root span for each message (prevents trace accumulation)
-                let span = info_span!("process_server_status");
-                let _ = span.set_parent(opentelemetry::Context::new());
-
-                async {
-                    metrics::gauge!("worker.active", "type" => "server_status").increment(1.0);
-                    let start = std::time::Instant::now();
-                    processor
-                        .process_server_message(&message, received_at)
-                        .await;
-                    let duration = start.elapsed();
-                    metrics::histogram!("aprs.server_status.duration_ms")
-                        .record(duration.as_millis() as f64);
-                    metrics::counter!("aprs.server_status.processed_total").increment(1);
-                    metrics::counter!("aprs.messages.processed.server_total").increment(1);
-                    metrics::counter!("aprs.messages.processed.total_total").increment(1);
-                    metrics::gauge!("worker.active", "type" => "server_status").decrement(1.0);
-                }
-                .instrument(span)
-                .await;
+                // Note: No tracing spans here - they cause trace accumulation in Tempo
+                metrics::gauge!("worker.active", "type" => "server_status").increment(1.0);
+                let start = std::time::Instant::now();
+                processor
+                    .process_server_message(&message, received_at)
+                    .await;
+                let duration = start.elapsed();
+                metrics::histogram!("aprs.server_status.duration_ms")
+                    .record(duration.as_millis() as f64);
+                metrics::counter!("aprs.server_status.processed_total").increment(1);
+                metrics::counter!("aprs.messages.processed.server_total").increment(1);
+                metrics::counter!("aprs.messages.processed.total_total").increment(1);
+                metrics::gauge!("worker.active", "type" => "server_status").decrement(1.0);
             }
         });
     }

--- a/src/fix_processor.rs
+++ b/src/fix_processor.rs
@@ -383,8 +383,7 @@ impl FixProcessor {
         // Step 2: Update receiver's latest_packet_at
         let receiver_id = updated_fix.receiver_id;
         let receiver_repo = self.receiver_repo.clone();
-        let receiver_span =
-            tracing::debug_span!("update_receiver_timestamp", receiver_id = %receiver_id);
+        let receiver_span = tracing::debug_span!(parent: None, "update_receiver_timestamp", receiver_id = %receiver_id);
         let _ = receiver_span.set_parent(opentelemetry::Context::new());
         tokio::spawn(
             async move {

--- a/src/flight_tracker/flight_lifecycle.rs
+++ b/src/flight_tracker/flight_lifecycle.rs
@@ -120,7 +120,7 @@ fn spawn_flight_enrichment_on_creation(
     let locations_repo = ctx.locations_repo.clone();
 
     // Create a new root span to prevent trace accumulation
-    let span = info_span!("flight_enrichment_creation", %flight_id);
+    let span = info_span!(parent: None, "flight_enrichment_creation", %flight_id);
     let _ = span.set_parent(opentelemetry::Context::new());
 
     tokio::spawn(
@@ -346,7 +346,7 @@ pub(crate) fn spawn_complete_flight(
     let device_clone = device.clone();
     let fix_clone = fix.clone();
 
-    let span = info_span!("flight_completion_background", %flight_id);
+    let span = info_span!(parent: None, "flight_completion_background", %flight_id);
     let _ = span.set_parent(opentelemetry::Context::new());
 
     tokio::spawn(
@@ -598,7 +598,7 @@ async fn complete_flight_in_background(
     let device_id_opt = device.id;
     let device_address = device.address;
 
-    let email_span = info_span!("flight_email_notification", %flight_id);
+    let email_span = info_span!(parent: None, "flight_email_notification", %flight_id);
     let _ = email_span.set_parent(opentelemetry::Context::new());
 
     tokio::spawn(
@@ -760,7 +760,7 @@ fn spawn_flight_enrichment_on_completion_direct(
     let locations_repo = locations_repo.clone();
 
     // Create a new root span to prevent trace accumulation
-    let span = info_span!("flight_enrichment_completion", %flight_id);
+    let span = info_span!(parent: None, "flight_enrichment_completion", %flight_id);
     let _ = span.set_parent(opentelemetry::Context::new());
 
     tokio::spawn(

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -93,8 +93,8 @@ fn get_trace_sampler(env: &str) -> Sampler {
             Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(0.01)))
         }
         "staging" => {
-            info!("Staging environment: using 10% trace sampling");
-            Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(0.10)))
+            info!("Staging environment: using 1% trace sampling");
+            Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(0.01)))
         }
         _ => {
             info!("Development environment: using 100% trace sampling");


### PR DESCRIPTION
## Summary
- Remove `#[tracing::instrument]` from hot path functions (`process_aprs_message`, `process_beast_message`, `handle_run`)
- Remove manual span creation from all 6 worker loops
- Reduce staging trace sampling rate from 10% to 1%

## Problem
The tracing spans in the hot path caused two issues:
1. **TRACE_TOO_LARGE errors** in Tempo due to trace accumulation - all spawned tasks inherited the same trace context
2. **Significant performance overhead** - ~9 msg/s with 10% sampling vs ~860 msg/s with OTEL disabled

## Solution
- Remove all tracing instrumentation from the message processing hot path
- Use metrics only for observability in the hot path (already in place)
- Reduce sampling rate to 1% to minimize overhead from instrumentation deeper in the call stack

## Test plan
- [x] Verified no TRACE_TOO_LARGE errors in Tempo
- [x] Verified processing rate ~360-410 msg/s with 1% sampling (acceptable tradeoff)
- [x] Verified processing rate ~860 msg/s with OTEL disabled (baseline)