### PR TITLE
Fix deprecated h3_lat_lng_to_cell warning in postgres logs

### DIFF
--- a/src/commands/aggregate_coverage.rs
+++ b/src/commands/aggregate_coverage.rs
@@ -105,7 +105,7 @@ pub async fn aggregate_coverage(
 
 /// Fetch fixes and aggregate into H3 hexes using PostgreSQL h3 extension
 /// This is MUCH faster than the old approach because all H3 conversion and
-/// aggregation happens in the database using native h3_lat_lng_to_cell()
+/// aggregation happens in the database using native h3_latlng_to_cell()
 async fn fetch_and_aggregate_fixes(
     pool: PgPool,
     start_date: NaiveDate,
@@ -153,13 +153,13 @@ async fn fetch_and_aggregate_fixes(
         );
         let start = std::time::Instant::now();
 
-        // Use h3_lat_lng_to_cell() PostgreSQL function for efficient H3 conversion
+        // Use h3_latlng_to_cell() PostgreSQL function for efficient H3 conversion
         // All aggregation happens in the database - WAY faster than fetching + processing in Rust
         // Note: ST_MakePoint takes (longitude, latitude) in PostGIS (x, y order)
         let coverage_data: Vec<AggregatedCoverage> = diesel::sql_query(
             r#"
             SELECT
-                h3_lat_lng_to_cell(ST_MakePoint(longitude, latitude)::geography, $3)::bigint AS h3_index,
+                h3_latlng_to_cell(ST_MakePoint(longitude, latitude)::geography, $3)::bigint AS h3_index,
                 receiver_id,
                 DATE(received_at) AS date,
                 COUNT(*)::bigint AS fix_count,


### PR DESCRIPTION
## Summary
- Update `h3_lat_lng_to_cell` to `h3_latlng_to_cell` in the coverage aggregation SQL query
- Fixes PostgreSQL log spam from h3-pg deprecation warnings

## Test plan
- [x] Code compiles
- [x] Pre-commit hooks pass