### PR TITLE
Consolidate ingest stats logging into single log message

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -16,6 +16,12 @@ pub struct AprsIngestHealth {
     pub aprs_connected: bool,
     pub socket_connected: bool,
     pub last_message_time: Option<Instant>,
+    /// Total messages received since connection started
+    pub total_messages: u64,
+    /// Messages received in current stats interval
+    pub interval_messages: u64,
+    /// Start time of current stats interval
+    pub interval_start: Option<Instant>,
 }
 
 static APRS_HEALTH: OnceLock<Arc<RwLock<AprsIngestHealth>>> = OnceLock::new();
@@ -43,6 +49,12 @@ pub struct BeastIngestHealth {
     pub socket_connected: bool,
     pub last_message_time: Option<Instant>,
     pub last_error: Option<String>,
+    /// Total messages received since connection started
+    pub total_messages: u64,
+    /// Messages received in current stats interval
+    pub interval_messages: u64,
+    /// Start time of current stats interval
+    pub interval_start: Option<Instant>,
 }
 
 static BEAST_HEALTH: OnceLock<Arc<RwLock<BeastIngestHealth>>> = OnceLock::new();


### PR DESCRIPTION
## Summary

- Remove separate APRS/Beast/SBS stats log messages from individual clients
- Add stats tracking fields (`total_messages`, `interval_messages`, `interval_start`) to `AprsIngestHealth` and `BeastIngestHealth`
- Consolidate all stats into a single `stats:` log message in the ingest command
- Simplify log format by combining `sent` rate and `socket_send` timing

## New Log Format

**Before:**
```
INFO soar::commands::ingest: Ingest Stats (30s): recv=0.0/s (OGN:0.0 Beast:0.0 SBS:0.0) sent=138.8/s | socket_send=0.0ms | drain_eta=8.5h | queues: ogn={...} beast={...} sbs={...}
INFO soar::aprs_client: APRS stats: 401.3 msg/s, 813018 total messages
```

**After:**
```
INFO soar::commands::ingest: stats: sent={rate:138.8/s avg:0.1ms} | drain_eta=8.5h | queues: ogn={...} beast={...} sbs={...} | read: ogn={records:813018 rate:401.3/s}
```

## Test plan

- [ ] Deploy to staging and verify log output format
- [ ] Verify read stats are only shown for enabled sources
- [ ] Verify metrics gauges (aprs.message_rate, beast.message_rate, sbs.message_rate) still update correctly