### PR TITLE
Improve deployment reliability and reduce log noise

### DIFF
--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -124,12 +124,12 @@ fi
 ACTIVE_SERVICES=(
     "soar-run${SERVICE_SUFFIX}.service"
     "soar-web${SERVICE_SUFFIX}.service"
+    "soar-ingest${SERVICE_SUFFIX}.service"
 )
 
 # Manually-deployed services (installed but not automatically started)
 # These services change infrequently and are deployed via the regular deployment process
 MANUAL_SERVICES=(
-    "soar-ingest${SERVICE_SUFFIX}.service"
 )
 
 # Timer-invoked services (only installed, not enabled or started)

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -330,9 +330,9 @@ if [ "$LOCAL_DEPLOY" = "1" ]; then
 
     log_info "Deployment will:"
     log_info "  1. Stop soar-run service"
-    log_info "  2. Run database migrations (ogn-ingest and web keep running)"
+    log_info "  2. Run database migrations (soar-ingest and web keep running)"
     log_info "  3. Stop remaining services and install new binary"
-    log_info "  4. Restart all services"
+    log_info "  4. Restart all services (soar-run, soar-web, soar-ingest)"
     echo
 
     log_info "Executing deployment script..."
@@ -384,9 +384,9 @@ else
     log_info "Deploying to $DEPLOY_SERVER"
     log_info "Deployment will:"
     log_info "  1. Stop soar-run service"
-    log_info "  2. Run database migrations (ogn-ingest and web keep running)"
+    log_info "  2. Run database migrations (soar-ingest and web keep running)"
     log_info "  3. Stop remaining services and install new binary"
-    log_info "  4. Restart all services"
+    log_info "  4. Restart all services (soar-run, soar-web, soar-ingest)"
     echo
 
     log_info "Executing deployment script..."


### PR DESCRIPTION
## Summary
- Add periodic progress output during `soar migrate` to prevent GitHub Actions SSH timeout (outputs elapsed time and system load every 30s)
- Move soar-ingest to ACTIVE_SERVICES so it's always restarted after deployment (was in MANUAL_SERVICES, only restarted if already running)
- Fix persistent queue overflow logging: log ONE warning when transitioning to disk overflow, ONE info when recovered (instead of warning on every send)

## Details

### Migration Progress Output
The `soar migrate` command now outputs progress every 30 seconds while migrations are running:
```
INFO running migration: elapsed=0s load=0.45,0.52,0.48
INFO running migration: elapsed=30s load=1.23,0.78,0.55
```
This keeps the SSH connection alive during long migrations and prevents GitHub Actions from timing out.

### soar-ingest Restart
Moved `soar-ingest` from `MANUAL_SERVICES` to `ACTIVE_SERVICES` so it's always enabled and started after deployment, rather than only being restarted if it was already running.

### Overflow Log Noise Fix
The persistent queue now tracks overflow state and only logs:
- ONE warning when first transitioning from memory channel to disk
- ONE info when recovered and back to memory channel

Previously it logged a warning on every send during overflow, which was very noisy.

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` passes  
- [x] `cargo test persistent_queue` passes
- [x] Shell script syntax validated