### PR TITLE
Fix deployment reliability by running soar-deploy detached from SSH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -724,8 +724,63 @@ jobs:
       - name: Execute deployment to staging
         run: |
           DEPLOY_DIR="/tmp/soar/deploy/${{ env.DEPLOY_TIMESTAMP }}"
+          DEPLOY_ID="staging-${{ env.DEPLOY_TIMESTAMP }}"
+          LOG_FILE="/var/lib/soar/deploy/logs/${DEPLOY_ID}.log"
+          STATUS_FILE="/var/lib/soar/deploy/status/${DEPLOY_ID}.status"
+
           echo "Executing deployment script for staging..."
-          ssh soar@staging.glider.flights "sudo /usr/local/bin/soar-deploy staging $DEPLOY_DIR"
+          echo "Deployment ID: $DEPLOY_ID"
+          echo "Log file: $LOG_FILE"
+
+          # Run deployment in background with nohup to survive SSH disconnection
+          # The script writes a status file on completion that we poll for
+          ssh soar@staging.glider.flights "sudo mkdir -p /var/lib/soar/deploy/logs /var/lib/soar/deploy/status && sudo chown -R soar:soar /var/lib/soar/deploy && nohup sudo /usr/local/bin/soar-deploy staging $DEPLOY_DIR > $LOG_FILE 2>&1 &"
+
+          # Give the background process a moment to start
+          sleep 3
+
+          echo "Deployment started in background, polling for completion..."
+
+          # Poll for completion (check for status file every 10 seconds, timeout after 30 minutes)
+          MAX_WAIT=1800
+          ELAPSED=0
+          POLL_INTERVAL=10
+
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            # Check if status file exists
+            if ssh soar@staging.glider.flights "test -f $STATUS_FILE" 2>/dev/null; then
+              echo "Deployment completed, fetching results..."
+
+              # Get the exit code from status file
+              EXIT_CODE=$(ssh soar@staging.glider.flights "cat $STATUS_FILE")
+              echo "Deployment exit code: $EXIT_CODE"
+
+              # Show the deployment log
+              echo ""
+              echo "=== Deployment Log ==="
+              ssh soar@staging.glider.flights "cat $LOG_FILE" || echo "(Failed to retrieve log)"
+              echo "=== End Deployment Log ==="
+              echo ""
+
+              # Exit with the same code as the deployment
+              exit $EXIT_CODE
+            fi
+
+            # Show progress
+            if [ $((ELAPSED % 60)) -eq 0 ] && [ $ELAPSED -gt 0 ]; then
+              echo "Still waiting for deployment... (${ELAPSED}s elapsed)"
+              # Show last few lines of log if available
+              ssh soar@staging.glider.flights "tail -5 $LOG_FILE 2>/dev/null" || true
+            fi
+
+            sleep $POLL_INTERVAL
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
+          done
+
+          echo "Deployment timed out after ${MAX_WAIT} seconds"
+          echo "Deployment may still be running on the server"
+          echo "Check: ssh soar@staging.glider.flights 'cat $LOG_FILE'"
+          exit 1
 
       - name: Cleanup SSH
         if: always()
@@ -843,8 +898,63 @@ jobs:
       - name: Execute deployment to production
         run: |
           DEPLOY_DIR="/tmp/soar/deploy/${{ env.DEPLOY_TIMESTAMP }}"
+          DEPLOY_ID="production-${{ env.DEPLOY_TIMESTAMP }}"
+          LOG_FILE="/var/lib/soar/deploy/logs/${DEPLOY_ID}.log"
+          STATUS_FILE="/var/lib/soar/deploy/status/${DEPLOY_ID}.status"
+
           echo "Executing deployment script for production..."
-          ssh soar@glider.flights "sudo /usr/local/bin/soar-deploy production $DEPLOY_DIR"
+          echo "Deployment ID: $DEPLOY_ID"
+          echo "Log file: $LOG_FILE"
+
+          # Run deployment in background with nohup to survive SSH disconnection
+          # The script writes a status file on completion that we poll for
+          ssh soar@glider.flights "sudo mkdir -p /var/lib/soar/deploy/logs /var/lib/soar/deploy/status && sudo chown -R soar:soar /var/lib/soar/deploy && nohup sudo /usr/local/bin/soar-deploy production $DEPLOY_DIR > $LOG_FILE 2>&1 &"
+
+          # Give the background process a moment to start
+          sleep 3
+
+          echo "Deployment started in background, polling for completion..."
+
+          # Poll for completion (check for status file every 10 seconds, timeout after 30 minutes)
+          MAX_WAIT=1800
+          ELAPSED=0
+          POLL_INTERVAL=10
+
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            # Check if status file exists
+            if ssh soar@glider.flights "test -f $STATUS_FILE" 2>/dev/null; then
+              echo "Deployment completed, fetching results..."
+
+              # Get the exit code from status file
+              EXIT_CODE=$(ssh soar@glider.flights "cat $STATUS_FILE")
+              echo "Deployment exit code: $EXIT_CODE"
+
+              # Show the deployment log
+              echo ""
+              echo "=== Deployment Log ==="
+              ssh soar@glider.flights "cat $LOG_FILE" || echo "(Failed to retrieve log)"
+              echo "=== End Deployment Log ==="
+              echo ""
+
+              # Exit with the same code as the deployment
+              exit $EXIT_CODE
+            fi
+
+            # Show progress
+            if [ $((ELAPSED % 60)) -eq 0 ] && [ $ELAPSED -gt 0 ]; then
+              echo "Still waiting for deployment... (${ELAPSED}s elapsed)"
+              # Show last few lines of log if available
+              ssh soar@glider.flights "tail -5 $LOG_FILE 2>/dev/null" || true
+            fi
+
+            sleep $POLL_INTERVAL
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
+          done
+
+          echo "Deployment timed out after ${MAX_WAIT} seconds"
+          echo "Deployment may still be running on the server"
+          echo "Check: ssh soar@glider.flights 'cat $LOG_FILE'"
+          exit 1
 
       - name: Cleanup SSH
         if: always()

--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -29,6 +29,10 @@ set -e
 set -u
 set -o pipefail
 
+# Deployment log and status directory
+DEPLOY_LOG_DIR="/var/lib/soar/deploy/logs"
+DEPLOY_STATUS_DIR="/var/lib/soar/deploy/status"
+
 # Color codes for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -73,6 +77,32 @@ if [ ! -d "$DEPLOY_DIR" ]; then
     exit 1
 fi
 
+# Create log and status directories
+mkdir -p "$DEPLOY_LOG_DIR"
+mkdir -p "$DEPLOY_STATUS_DIR"
+chown -R soar:soar /var/lib/soar/deploy
+
+# Generate a unique deployment ID based on the deploy directory name and environment
+# This allows the caller to predict the status file path
+DEPLOY_DIR_BASENAME=$(basename "$DEPLOY_DIR")
+DEPLOY_ID="${ENVIRONMENT}-${DEPLOY_DIR_BASENAME}"
+STATUS_FILE="$DEPLOY_STATUS_DIR/$DEPLOY_ID.status"
+
+# Write status file on exit (success or failure)
+write_status() {
+    local exit_code=$?
+    echo "$exit_code" > "$STATUS_FILE"
+    if [ $exit_code -eq 0 ]; then
+        log_info "Deployment completed successfully (exit code: $exit_code)"
+    else
+        log_error "Deployment failed (exit code: $exit_code)"
+    fi
+    log_info "Status written to: $STATUS_FILE"
+}
+trap write_status EXIT
+
+log_info "Deployment ID: $DEPLOY_ID"
+log_info "Status file: $STATUS_FILE"
 log_info "Starting SOAR deployment for $ENVIRONMENT from: $DEPLOY_DIR"
 
 # Self-update: Check if deployment script itself has changed
@@ -1179,6 +1209,11 @@ ls -t "$BACKUP_DIR"/soar.backup.* 2>/dev/null | tail -n +6 | xargs rm -f || true
 # Clean up old deployment directories (keep last 3)
 log_info "Cleaning up old deployment directories (keeping last 3)..."
 ls -td /tmp/soar/deploy/* 2>/dev/null | tail -n +4 | xargs rm -rf || true
+
+# Clean up old deployment logs and status files (keep last 10)
+log_info "Cleaning up old deployment logs and status files (keeping last 10)..."
+ls -t "$DEPLOY_LOG_DIR"/*.log 2>/dev/null | tail -n +11 | xargs rm -f || true
+ls -t "$DEPLOY_STATUS_DIR"/*.status 2>/dev/null | tail -n +11 | xargs rm -f || true
 
 if [ "$ALL_HEALTHY" = true ]; then
     log_info "${GREEN}Deployment completed successfully!${NC}"


### PR DESCRIPTION
## Summary

- Fix deployment script getting killed (SIGHUP) when SSH connections drop during long-running migrations
- Run `soar-deploy` via `nohup` in background, fully detached from the SSH session
- CI polls for a status file to determine completion and retrieve exit code

## Problem

Deployments were failing at exactly the same point:
```
[INFO] Starting database migrations via systemd service...
[INFO] This allows migrations to continue if SSH connection is lost
client_loop: send disconnect: Broken pipe
Error: Process completed with exit code 255.
```

When the SSH connection dropped, the deployment script received SIGHUP and died, leaving `soar-run` stopped and services not restarted.

## Solution

1. **Detached execution**: Deployment now runs via `nohup sudo /usr/local/bin/soar-deploy ... > LOG_FILE 2>&1 &`
2. **Status tracking**: Script writes exit code to `/var/lib/soar/deploy/status/<deploy-id>.status` on completion
3. **Log preservation**: Full output written to `/var/lib/soar/deploy/logs/<deploy-id>.log`
4. **CI polling**: GitHub Actions polls for status file every 10 seconds (30 min timeout), then displays full log

## Test plan

- [ ] Merge to main and observe next staging deployment
- [ ] Verify deployment completes even if the log shows SSH timeouts during polling
- [ ] Check logs are written to `/var/lib/soar/deploy/logs/` on server
- [ ] Verify old logs are cleaned up (keeps last 10)