### PR TITLE
Fix airspace toggle not respecting saved settings

### DIFF
--- a/web/src/lib/components/SettingsModal.svelte
+++ b/web/src/lib/components/SettingsModal.svelte
@@ -130,10 +130,10 @@
 		}
 	}
 
-	onMount(() => {
+	onMount(async () => {
 		if (browser) {
-			loadSettings();
-			// Notify parent of initial settings
+			await loadSettings();
+			// Notify parent of initial settings AFTER loading completes
 			if (onSettingsChange) {
 				onSettingsChange({
 					showCompassRose,


### PR DESCRIPTION
## Summary
- Fix race condition where settings were sent to parent before `loadSettings()` completed
- Airspace toggle now correctly respects saved user preference on page load

## Test plan
- [ ] Load the operations page with airspace toggle previously set to OFF
- [ ] Verify airspaces are not displayed
- [ ] Toggle airspaces ON, verify they appear when zoomed in
- [ ] Toggle airspaces OFF, verify they disappear