### PR TITLE
Enable local ADS-B ingestion from radar host in staging

### DIFF
--- a/infrastructure/systemd/soar-ingest-staging.service
+++ b/infrastructure/systemd/soar-ingest-staging.service
@@ -19,7 +19,7 @@ SyslogIdentifier=soar-ingest-staging
 # - Add --ogn-server, --ogn-port, --ogn-callsign, --ogn-filter for OGN/APRS ingestion
 # - Add --beast <server:port> for Beast format ADS-B (can specify multiple times)
 # - Add --sbs <server:port> for SBS (BaseStation) format (can specify multiple times)
-ExecStart=/usr/local/bin/soar-staging ingest --ogn-server aprs.glidernet.org
+ExecStart=/usr/local/bin/soar-staging ingest --ogn-server aprs.glidernet.org --beast radar:30005
 ExecReload=/bin/kill -s HUP $MAINPID
 
 # Environment variables (staging environment)


### PR DESCRIPTION
## Summary
- Add `--beast radar:30005` to staging ingest service to collect ADS-B data from the local radar host in Beast format

## Test plan
- [ ] Verify staging service restarts successfully after deployment
- [ ] Check metrics for incoming Beast/ADS-B data from radar host