### PR TITLE
Improve provision script efficiency and add GitHub CLI

### DIFF
--- a/scripts/provision
+++ b/scripts/provision
@@ -99,8 +99,22 @@ fi
 echo -e "${BLUE}Setting up APT repositories...${NC}"
 
 # Install prerequisites for adding repositories
-sudo apt-get update
-sudo apt-get install -y wget ca-certificates lsb-release gnupg curl
+# Only update if prerequisites are missing (more efficient on subsequent runs)
+NEED_PREREQ_INSTALL=false
+for pkg in wget ca-certificates lsb-release gnupg curl; do
+    if ! dpkg-query -W -f='${Status}' "$pkg" 2>/dev/null | grep -q 'install ok installed'; then
+        NEED_PREREQ_INSTALL=true
+        break
+    fi
+done
+
+if [ "$NEED_PREREQ_INSTALL" = true ]; then
+    echo -e "${BLUE}Installing prerequisites for repository setup...${NC}"
+    sudo apt-get update
+    sudo apt-get install -y wget ca-certificates lsb-release gnupg curl
+else
+    echo -e "${BLUE}Prerequisites already installed${NC}"
+fi
 
 # Create keyrings directories
 sudo mkdir -p /etc/apt/keyrings


### PR DESCRIPTION
## Summary
- Add consolidated APT repository setup section with existence checks for all repos (PostgreSQL, TimescaleDB, Grafana, Caddy, GitHub CLI)
- Run `apt-get update` only once after all repos are added instead of after each one
- Add GitHub CLI (`gh`) repository and installation
- Fix Loki config path from `infrastructure/loki.yaml` to `infrastructure/loki-config.yml`

## Test plan
- [ ] Run provision script on a fresh Debian/Ubuntu system
- [ ] Verify all repositories are added only if not already present
- [ ] Verify GitHub CLI is installed and functional
- [ ] Verify Loki configuration is correctly copied