### PR TITLE
Disable netdata otel plugin in provision script

### DIFF
--- a/scripts/provision
+++ b/scripts/provision
@@ -628,7 +628,7 @@ echo -e "${GREEN}Alloy configured${NC}"
 NETDATA_CONF="/etc/netdata/netdata.conf"
 if [ -f "$NETDATA_CONF" ]; then
     echo -e "${BLUE}Configuring netdata to disable otel plugin (conflicts with Alloy)...${NC}"
-    if grep -q "^\[plugins\]" "$NETDATA_CONF" && grep -q "otel.*=.*no" "$NETDATA_CONF"; then
+    if grep -q "^\[plugins\]" "$NETDATA_CONF" && grep -q "^[[:space:]]*otel[[:space:]]*=[[:space:]]*no" "$NETDATA_CONF"; then
         echo -e "${BLUE}netdata otel plugin already disabled${NC}"
     else
         # Add [plugins] section with otel = no if not already present
@@ -636,9 +636,9 @@ if [ -f "$NETDATA_CONF" ]; then
             echo "" >> "$NETDATA_CONF"
             echo "[plugins]" >> "$NETDATA_CONF"
         fi
-        if ! grep -q "otel.*=.*no" "$NETDATA_CONF"; then
-            # Add otel = no after [plugins] section
-            sed -i '/^\[plugins\]/a\    otel = no' "$NETDATA_CONF"
+        if ! grep -q "^[[:space:]]*otel[[:space:]]*=[[:space:]]*no" "$NETDATA_CONF"; then
+            # Add otel = no after [plugins] section (use tab for netdata config style)
+            sed -i '/^\[plugins\]/a\\totel = no' "$NETDATA_CONF"
             echo -e "${GREEN}Disabled netdata otel plugin${NC}"
             # Restart netdata if it's running to apply the change
             if systemctl is-active --quiet netdata; then


### PR DESCRIPTION
## Summary
- Disable netdata's otel-plugin in the provision script to prevent port conflicts with Alloy

## Problem
The netdata otel-plugin binds to port 4317, which conflicts with Alloy's OTLP receiver. This caused:
1. Alloy's OTLP receiver to fail to start on boot
2. Neither port 4317 (gRPC) nor 4318 (HTTP) were handled by Alloy
3. SOAR services logging continuous `BatchSpanProcessor.ExportError` errors when trying to send traces to `localhost:4318`

## Solution
Add configuration to the provision script that:
1. Checks if `/etc/netdata/netdata.conf` exists
2. Adds `[plugins]` section if not present
3. Adds `otel = no` to disable the otel plugin
4. Restarts netdata if it's running to apply the change

## Test plan
- [ ] Verify provision script runs without errors on a fresh system
- [ ] Verify netdata otel plugin is disabled after provisioning
- [ ] Verify Alloy successfully binds to ports 4317 and 4318
- [ ] Verify no OpenTelemetry export errors in SOAR service logs