### PR TITLE
Add PostgreSQL h3 extension to provision script

### DIFF
--- a/scripts/provision
+++ b/scripts/provision
@@ -206,7 +206,7 @@ echo -e "${GREEN}APT repositories configured${NC}"
 
 # Install PostgreSQL 18
 echo -e "${BLUE}Installing PostgreSQL 18...${NC}"
-sudo apt-get install -y postgresql-18 postgresql-client-18 postgresql-18-postgis-3 postgresql-18-partman uuid-runtime
+sudo apt-get install -y postgresql-18 postgresql-client-18 postgresql-18-postgis-3 postgresql-18-partman postgresql-18-h3 uuid-runtime
 
 echo -e "${GREEN}PostgreSQL 18 installed successfully${NC}"
 
@@ -866,6 +866,11 @@ echo -e "${BLUE}Enabling pg_partman extension on '$DB_NAME' database...${NC}"
 sudo -u postgres psql -d "$DB_NAME" -c "CREATE SCHEMA IF NOT EXISTS partman;"
 sudo -u postgres psql -d "$DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS pg_partman SCHEMA partman;"
 echo -e "${GREEN}pg_partman enabled on '$DB_NAME' database${NC}"
+
+# Enable h3 extension on database
+echo -e "${BLUE}Enabling h3 extension on '$DB_NAME' database...${NC}"
+sudo -u postgres psql -d "$DB_NAME" -c "CREATE EXTENSION IF NOT EXISTS h3;"
+echo -e "${GREEN}h3 enabled on '$DB_NAME' database${NC}"
 
 echo -e "${GREEN}Database setup complete!${NC}"
 echo


### PR DESCRIPTION
## Summary
- Install `postgresql-18-h3` package during server provisioning
- Enable the h3 extension on the database after other extensions

## Test plan
- [ ] Run provision script on a fresh server or verify package availability with `apt-cache show postgresql-18-h3`
- [ ] Verify extension can be created with `CREATE EXTENSION IF NOT EXISTS h3;`