### PR TITLE
Fix future incompatibility warning from quick-xml 0.17.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,8 +2322,6 @@ version = "0.5.0"
 source = "git+https://github.com/hut8/flarmnet-rs#2273c5228783e5b363641ac1072769af0ca4f622"
 dependencies = [
  "encoding_rs",
- "minidom",
- "quick-xml 0.38.4",
  "thiserror 1.0.69",
 ]
 
@@ -3760,15 +3758,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minidom"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe549115a674f5ec64c754d85e37d6f42664bd0ef4ffb62b619489ad99c6cb1a"
-dependencies = [
- "quick-xml 0.17.2",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4757,15 +4746,6 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe1e430bdcf30c9fdc25053b9c459bb1a4672af4617b6c783d7d91dc17c6bbb0"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
@@ -4778,15 +4758,6 @@ name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ flume = { version = "0.12", features = ["async"] }
 sitemap-rs = "0.4.0"
 metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
-flarmnet = { git = "https://github.com/hut8/flarmnet-rs", features = ["xcsoar"] }
+flarmnet = { git = "https://github.com/hut8/flarmnet-rs", default-features = false, features = ["xcsoar"] }
 pprof = { version = "0.15", features = ["flamegraph", "protobuf-codec"] }
 lru = "0.16"
 moka = { version = "0.12", features = ["future", "sync"] }


### PR DESCRIPTION
## Summary
- Add `default-features = false` to flarmnet dependency to exclude the unused `lx` feature
- This removes `minidom 0.12.0` → `quick-xml 0.17.2` from the dependency tree
- Fixes: `warning: the following packages contain code that will be rejected by a future version of Rust: quick-xml v0.17.2`

## Details
The `lx` feature in flarmnet pulls in `minidom 0.12.0`, which depends on `quick-xml 0.17.2`. That version has trailing semicolons in macros (Rust issue #79813) that will become a hard error in future Rust versions.

Since we only use the `xcsoar` feature, disabling default features removes this unused dependency chain.

## Test plan
- [x] `cargo check` passes without the future incompatibility warning
- [x] `quick-xml 0.17.2` no longer in dependency tree