### PR TITLE
Fix observability: pprof, metrics, and flight tracker state restoration

### DIFF
--- a/infrastructure/alloy-config.alloy
+++ b/infrastructure/alloy-config.alloy
@@ -150,6 +150,8 @@ discovery.relabel "soar_ingest_staging" {
 }
 
 // CPU profiling scraper - scrapes /debug/pprof/profile
+// SOAR services return pprof protobuf format with configurable duration via ?seconds=N
+// Default: 10 seconds profiling, so we need scrape timeout > 10s
 pyroscope.scrape "soar_cpu" {
   targets = concat(
     discovery.relabel.soar_run.output,
@@ -159,6 +161,10 @@ pyroscope.scrape "soar_cpu" {
   )
 
   forward_to = [pyroscope.write.endpoint.receiver]
+
+  // Scrape every 60 seconds with a 15s timeout (profile takes 10s by default)
+  scrape_interval = "60s"
+  scrape_timeout  = "15s"
 
   profiling_config {
     profile.process_cpu {

--- a/infrastructure/grafana-dashboard-analytics.json
+++ b/infrastructure/grafana-dashboard-analytics.json
@@ -176,7 +176,7 @@
           "editorMode": "code",
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT\n  date as time,\n  (SELECT COUNT(*) FROM flights f\n   JOIN aircraft d ON f.aircraft_id = d.id\n   WHERE f.takeoff_time::date = fad.date\n   AND d.aircraft_type_ogn = 'glider') as \"Glider Flights\",\n  tow_flight_count as \"Tow Flights\"\nFROM flight_analytics_daily fad\nWHERE date >= CURRENT_DATE - 30\nORDER BY date ASC",
+          "rawSql": "SELECT\n  date as time,\n  flight_count - tow_flight_count as \"Glider Flights\",\n  tow_flight_count as \"Tow Flights\"\nFROM flight_analytics_daily\nWHERE date >= CURRENT_DATE - 30\nORDER BY date ASC",
           "refId": "A",
           "sql": {
             "columns": [],
@@ -1040,6 +1040,13 @@
           ]
         },
         "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
         "tooltip": {
           "mode": "single",
           "sort": "none"
@@ -1054,7 +1061,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  flight_type,\n  COUNT(*) as count\nFROM (\n  SELECT\n    CASE\n      WHEN departure_airport_id IS NULL OR arrival_airport_id IS NULL THEN 'Truncated'\n      WHEN departure_airport_id = arrival_airport_id THEN 'Local'\n      ELSE 'Cross-Country'\n    END as flight_type\n  FROM flights\n  WHERE takeoff_time >= NOW() - INTERVAL '30 days'\n) AS categorized\nGROUP BY flight_type",
+          "rawSql": "SELECT\n  SUM(cross_country_count) as \"Cross-Country\",\n  SUM(flight_count - cross_country_count) as \"Local/Other\"\nFROM flight_analytics_daily\nWHERE date >= CURRENT_DATE - 30",
           "refId": "A",
           "sql": {
             "columns": [],

--- a/infrastructure/grafana-dashboard-run-elevation.json
+++ b/infrastructure/grafana-dashboard-run-elevation.json
@@ -171,45 +171,12 @@
           },
           "editorMode": "code",
           "expr": "rate(aprs_elevation_sync_processed_total{component=\"run\",environment=\"$environment\"}[5m])",
-          "legendFormat": "Sync Processed/sec",
+          "legendFormat": "Processed/sec",
           "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(aprs_elevation_processed_total{component=\"run\",environment=\"$environment\"}[5m]))",
-          "legendFormat": "Async Processed/sec",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(aprs_elevation_queued_total{component=\"run\",environment=\"$environment\"}[5m])",
-          "legendFormat": "Async Queued/sec",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(aprs_elevation_channel_closed_total{component=\"run\",environment=\"$environment\"}[5m])",
-          "legendFormat": "Async Channel Closed Errors/sec",
-          "range": true,
-          "refId": "E"
         }
       ],
-      "title": "Elevation Tasks (Sync + Async)",
+      "title": "Elevation Processing Rate",
       "type": "timeseries"
     },
     {
@@ -303,7 +270,7 @@
           },
           "editorMode": "code",
           "expr": "aprs_elevation_sync_duration_ms{component=\"run\",environment=\"$environment\",quantile=\"0.5\"}",
-          "legendFormat": "Sync P50",
+          "legendFormat": "P50",
           "range": true,
           "refId": "A"
         },
@@ -314,7 +281,7 @@
           },
           "editorMode": "code",
           "expr": "aprs_elevation_sync_duration_ms{component=\"run\",environment=\"$environment\",quantile=\"0.95\"}",
-          "legendFormat": "Sync P95",
+          "legendFormat": "P95",
           "range": true,
           "refId": "B"
         },
@@ -325,45 +292,12 @@
           },
           "editorMode": "code",
           "expr": "aprs_elevation_sync_duration_ms{component=\"run\",environment=\"$environment\",quantile=\"0.99\"}",
-          "legendFormat": "Sync P99",
+          "legendFormat": "P99",
           "range": true,
           "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "aprs_elevation_duration_ms{component=\"run\",environment=\"$environment\",quantile=\"0.5\"}",
-          "legendFormat": "Async P50",
-          "range": true,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "aprs_elevation_duration_ms{component=\"run\",environment=\"$environment\",quantile=\"0.95\"}",
-          "legendFormat": "Async P95",
-          "range": true,
-          "refId": "E"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "aprs_elevation_duration_ms{component=\"run\",environment=\"$environment\",quantile=\"0.99\"}",
-          "legendFormat": "Async P99",
-          "range": true,
-          "refId": "F"
         }
       ],
-      "title": "Elevation Processing Duration (Sync + Async)",
+      "title": "Elevation Processing Duration",
       "type": "timeseries"
     },
     {

--- a/infrastructure/grafana-dashboard-run.json
+++ b/infrastructure/grafana-dashboard-run.json
@@ -341,9 +341,20 @@
           },
           "editorMode": "code",
           "expr": "rate(socket_router_beast_routed_total{component=\"run\",environment=\"$environment\"}[5m])",
-          "legendFormat": "Beast/SBS (msg/s)",
+          "legendFormat": "Beast (msg/s)",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(socket_router_sbs_routed_total{component=\"run\",environment=\"$environment\"}[5m])",
+          "legendFormat": "SBS (msg/s)",
+          "range": true,
+          "refId": "C"
         }
       ],
       "title": "Message Routing Rates",
@@ -1902,7 +1913,7 @@
           },
           "editorMode": "code",
           "expr": "rate(beast_run_decode_success_total{component=\"run\",environment=\"$environment\"}[5m])",
-          "legendFormat": "Beast/SBS Decode Success/sec",
+          "legendFormat": "Beast Decode Success/sec",
           "range": true,
           "refId": "C"
         },
@@ -1913,9 +1924,31 @@
           },
           "editorMode": "code",
           "expr": "rate(beast_run_decode_failed_total{component=\"run\",environment=\"$environment\"}[5m])",
-          "legendFormat": "Beast/SBS Decode Failed/sec",
+          "legendFormat": "Beast Decode Failed/sec",
           "range": true,
           "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(sbs_run_decode_success_total{component=\"run\",environment=\"$environment\"}[5m])",
+          "legendFormat": "SBS Decode Success/sec",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(sbs_run_decode_failed_total{component=\"run\",environment=\"$environment\"}[5m])",
+          "legendFormat": "SBS Decode Failed/sec",
+          "range": true,
+          "refId": "F"
         }
       ],
       "title": "Parse Success/Failure Rate",

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -843,4 +843,9 @@ fn initialize_ingest_metrics() {
     metrics::gauge!("ingest.health.beast_connected").set(0.0);
     metrics::gauge!("ingest.health.sbs_connected").set(0.0);
     metrics::gauge!("ingest.health.socket_connected").set(0.0);
+
+    // Queue capacity pause metrics (backpressure events)
+    metrics::counter!("queue.capacity_pause_total", "queue" => "ogn").absolute(0);
+    metrics::counter!("queue.capacity_pause_total", "queue" => "beast").absolute(0);
+    metrics::counter!("queue.capacity_pause_total", "queue" => "sbs").absolute(0);
 }

--- a/src/flight_tracker/mod.rs
+++ b/src/flight_tracker/mod.rs
@@ -206,9 +206,10 @@ impl FlightTracker {
             }
 
             // Create aircraft state with the oldest fix first
+            // Use new_for_restore to preserve fix timestamps for timeout detection
             let first_fix = &fixes[fixes.len() - 1];
             let is_active = state_transitions::should_be_active(first_fix);
-            let mut state = aircraft_state::AircraftState::new(first_fix, is_active);
+            let mut state = aircraft_state::AircraftState::new_for_restore(first_fix, is_active);
 
             // Determine if this is an active or timed-out flight
             if flight.timed_out_at.is_some() {
@@ -223,9 +224,10 @@ impl FlightTracker {
             }
 
             // Add remaining fixes in chronological order (oldest to newest)
+            // Use add_fix_for_restore to preserve fix timestamps for timeout detection
             for fix in fixes.iter().rev().skip(1) {
                 let is_active = state_transitions::should_be_active(fix);
-                state.add_fix(fix, is_active);
+                state.add_fix_for_restore(fix, is_active);
             }
 
             // Insert into map


### PR DESCRIPTION
## Summary
- Fix pprof endpoints to be Pyroscope-compatible (pprof protobuf format instead of flamegraph SVG)
- Fix flight tracker timeout detection after restart (was using wall clock time instead of fix timestamps)
- Split Beast/SBS metrics to show separately in Grafana dashboard
- Add histogram bucket config for Beast/SBS message processing latency

## Changes

### Pyroscope/Profiling
- Update `/debug/pprof/profile` and `/debug/pprof/heap` endpoints to return pprof protobuf format
- Accept `?seconds=N` query parameter (default 10s, max 60s)
- Configure Alloy with `scrape_interval=60s` and `scrape_timeout=15s`

### Flight Tracker State Restoration
- Add `AircraftState::new_for_restore()` and `add_fix_for_restore()` methods that use fix timestamps instead of `Utc::now()`
- Fix `initialize_from_database()` to use these methods
- This ensures timeout detection works correctly after restart (previously all flights appeared "fresh" because `last_update_time` was set to startup time)

### Metrics
- Add histogram bucket config for `beast.run.message_processing_latency_ms` and `sbs.run.message_processing_latency_ms`
- Add SBS metric initializations (decode success/failed, routing, etc.)
- Add `socket.router.sbs_routed_total` metric

### Grafana Dashboard
- Split "Beast/SBS" into separate series in "Message Routing Rates" panel
- Split "Beast/SBS Decode Success/Failed" into separate Beast and SBS series in "Parse Success/Failure Rate" panel

## Test plan
- [ ] Verify Pyroscope shows SOAR service profiles after deploy
- [ ] Verify flight tracker timeouts resume after restart
- [ ] Verify Beast Processing Latency panel shows data
- [ ] Verify Beast and SBS metrics appear separately in dashboard