### PR TITLE
Fix pg_dump parallel backup format

### DIFF
--- a/scripts/backup/base-backup
+++ b/scripts/backup/base-backup
@@ -208,7 +208,7 @@ main() {
     log INFO "=========================================="
     log INFO "Database: ${PGUSER}@${PGHOST}:${PGPORT}/${PGDATABASE}"
     log INFO "Destination: ${BACKUP_REMOTE_PATH}"
-    log INFO "Method: pg_dump (custom format with zstd compression)"
+    log INFO "Method: pg_dump (directory format with zstd compression)"
     log INFO "Parallel jobs: $PARALLEL_JOBS"
 
     # Check database connectivity
@@ -231,9 +231,9 @@ main() {
     log INFO "Creating database backup with pg_dump..."
     mkdir -p "$BACKUP_LOCAL_DIR"
 
-    # Use custom format (-Fc) which is compressed and supports parallel restore
-    # Use parallel jobs for faster dump of large databases
-    local dump_file="$BACKUP_LOCAL_DIR/database.dump"
+    # Use directory format (-Fd) which supports parallel dump and restore
+    # Each table gets its own file in the directory
+    local dump_dir="$BACKUP_LOCAL_DIR/database"
 
     log INFO "Using $PARALLEL_JOBS parallel jobs"
 
@@ -242,10 +242,10 @@ main() {
         -p "$PGPORT" \
         -U "$PGUSER" \
         -d "$PGDATABASE" \
-        -Fc \
+        -Fd \
         -Z zstd:3 \
         -j "$PARALLEL_JOBS" \
-        -f "$dump_file" \
+        -f "$dump_dir" \
         -v; then
         log ERROR "pg_dump failed"
         exit 1
@@ -254,7 +254,7 @@ main() {
     log INFO "Database backup completed successfully"
 
     # Get backup size
-    local backup_size=$(du -sb "$dump_file" | cut -f1)
+    local backup_size=$(du -sb "$dump_dir" | cut -f1)
     log INFO "Backup size: $(numfmt --to=iec-i --suffix=B "$backup_size")"
 
     # Upload to Wasabi S3 using rclone
@@ -292,7 +292,7 @@ main() {
   "backup_date": "$BACKUP_DATE",
   "backup_timestamp": "$BACKUP_TIMESTAMP",
   "backup_type": "pg_dump",
-  "backup_format": "custom",
+  "backup_format": "directory",
   "database": "$PGDATABASE",
   "database_size_bytes": $db_size,
   "backup_size_bytes": $backup_size,

--- a/scripts/backup/restore
+++ b/scripts/backup/restore
@@ -223,10 +223,10 @@ download_backup() {
         exit 1
     fi
 
-    # Verify download - check for pg_dump format
-    if [[ ! -f "$DOWNLOAD_DIR/database.dump" ]]; then
-        log ERROR "Backup is incomplete (missing database.dump)"
-        log ERROR "This restore script requires pg_dump format backups."
+    # Verify download - check for pg_dump directory format
+    if [[ ! -d "$DOWNLOAD_DIR/database" ]]; then
+        log ERROR "Backup is incomplete (missing database directory)"
+        log ERROR "This restore script requires pg_dump directory format backups."
         log ERROR "Found files: $(ls -la "$DOWNLOAD_DIR/")"
         exit 1
     fi
@@ -244,7 +244,7 @@ download_backup() {
 
 # Function to restore database
 restore_database() {
-    local dump_file="$DOWNLOAD_DIR/database.dump"
+    local dump_dir="$DOWNLOAD_DIR/database"
 
     log INFO "Dropping existing database: $PGDATABASE"
 
@@ -282,7 +282,7 @@ restore_database() {
         -d "$PGDATABASE" \
         -j "$PARALLEL_JOBS" \
         -v \
-        "$dump_file" \
+        "$dump_dir" \
         2>&1 | tee -a "$LOG_DIR/restore.log"; then
         # pg_restore returns non-zero on warnings too, check if database is accessible
         if ! psql -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -d "$PGDATABASE" -c "SELECT 1" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Fix backup failure: `pg_dump: error: parallel backup only supported by the directory format`
- Change pg_dump from custom format (`-Fc`) to directory format (`-Fd`) to enable parallel jobs
- Update restore script to handle directory-based backups

## Changes
- `scripts/backup/base-backup`: Use `-Fd` instead of `-Fc`, output to `database/` directory
- `scripts/backup/restore`: Check for and restore from `database/` directory

## Test plan
- [ ] Run `soar-base-backup` manually and verify it completes without error
- [ ] Verify backup is uploaded to S3 with `database/` directory structure
- [ ] Test restore from new backup format works correctly