### PR TITLE
Reduce max flight resume timeout from 18h to 8h

### DIFF
--- a/infrastructure/grafana-dashboard-run.json
+++ b/infrastructure/grafana-dashboard-run.json
@@ -5035,8 +5035,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_coalesce_rejected_hard_limit_18h_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
-          "legendFormat": "Rejected: 18h Hard Limit",
+          "expr": "rate(flight_tracker_coalesce_rejected_hard_limit_total{component=\"run\",environment=\"$environment\"}[$__rate_interval])",
+          "legendFormat": "Rejected: Hard Limit",
           "range": true,
           "refId": "F"
         },

--- a/src/flight_tracker/state_transitions.rs
+++ b/src/flight_tracker/state_transitions.rs
@@ -385,7 +385,7 @@ pub(crate) async fn process_state_transition(
 
                 let should_coalesce = callsign_matches && position_reasonable;
 
-                if should_coalesce && gap_hours < 18.0 {
+                if should_coalesce && gap_hours < 8.0 {
                     // Resume the flight
                     info!(
                         "Resuming timed-out flight {} after {:.1}h gap",
@@ -415,9 +415,9 @@ pub(crate) async fn process_state_transition(
                             .record(dist_km);
                     }
                     return Ok(fix);
-                } else if gap_hours >= 18.0 {
+                } else if gap_hours >= 8.0 {
                     // Too long - create new flight
-                    metrics::counter!("flight_tracker.coalesce.rejected.hard_limit_18h_total")
+                    metrics::counter!("flight_tracker.coalesce.rejected.hard_limit_total")
                         .increment(1);
                     metrics::histogram!("flight_tracker.coalesce.rejected.gap_hours")
                         .record(gap_hours);


### PR DESCRIPTION
## Summary
- Reduces the maximum time gap for resuming timed-out flights from 18 hours to 8 hours
- Simplifies metric name from `hard_limit_18h_total` to `hard_limit_total`
- Updates Grafana dashboard query and legend to match

## Test plan
- [ ] Verify code compiles with `cargo check`
- [ ] Confirm metric name change in Grafana dashboard is working after deployment