### PR TITLE
Add OTLP log export to Loki via Alloy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -142,7 +142,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2219,7 +2219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3365,7 +3365,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3866,7 +3866,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4084,6 +4084,18 @@ dependencies = [
  "pin-project-lite",
  "thiserror 2.0.17",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4580,7 +4592,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -5242,7 +5254,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5848,6 +5860,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "opentelemetry",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
@@ -6239,7 +6252,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7145,7 +7158,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ opentelemetry = { version = "0.31", features = ["trace", "metrics", "logs"] }
 opentelemetry-otlp = { version = "0.31", features = ["trace", "metrics", "logs", "grpc-tonic"] }
 opentelemetry_sdk = { version = "0.31", features = ["trace", "metrics", "logs", "rt-tokio"] }
 opentelemetry-semantic-conventions = "0.31"
+opentelemetry-appender-tracing = "0.31"
 tracing-opentelemetry = "0.32"
 postgis_diesel = { version = "3.1.0", features = ["serde", "serde_geojson"] }
 rust_decimal = { version = "1.39", default-features = false, features = ["std", "serde", "borsh"] }


### PR DESCRIPTION
## Summary
- Fix Loki not receiving any logs in Grafana on staging
- Add `opentelemetry-appender-tracing` crate to bridge tracing events to OpenTelemetry logs
- Create a real `LoggerProvider` with OTLP HTTP export to Alloy
- Add `OpenTelemetryTracingBridge` layer to the tracing subscriber in all command branches

## Root Cause
The SOAR application was exporting **traces** to Tempo via OTLP, but **logs** were only going to stdout (captured by systemd journal). The `init_logger_provider` function was a no-op that just logged a message about logs appearing as "span events in Tempo."

Alloy was configured to receive OTLP logs on port 4318 and forward them to Loki, but the application wasn't sending any OTLP logs.

## Solution
- Implement actual OTLP log export using `opentelemetry-appender-tracing`
- The `OpenTelemetryTracingBridge` converts tracing events (info!, warn!, error!, etc.) to OpenTelemetry LogRecords
- These are batched and exported via OTLP HTTP to Alloy, which forwards to Loki
- Uses the same `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable as traces

## Test plan
- [ ] Deploy to staging and verify logs appear in Grafana Loki
- [ ] Check Alloy metrics for `otelcol_receiver_accepted_log_records_total`
- [ ] Query Loki with `{service_name="run"}` to see logs