### PR TITLE
Fix Pyroscope profile scraping configuration

### DIFF
--- a/infrastructure/alloy-config.alloy
+++ b/infrastructure/alloy-config.alloy
@@ -24,8 +24,28 @@ otelcol.receiver.otlp "ingest" {
 // Batch for efficiency
 otelcol.processor.batch "pipeline" {
   output {
-    logs   = [otelcol.processor.attributes.loki_labels.input]
+    logs   = [otelcol.processor.filter.log_level.input]
     traces = [otelcol.exporter.otlphttp.tempo.input]
+  }
+}
+
+// Filter logs based on environment and severity:
+// - Production (deployment.environment = "production"): INFO and higher only
+// - Staging/Development: DEBUG and higher (all logs)
+// This reduces noise and cost for production while keeping detailed logs for debugging in staging
+otelcol.processor.filter "log_level" {
+  error_mode = "ignore"
+
+  logs {
+    // Drop DEBUG logs from production services
+    // OTTL severity_number: TRACE=1-4, DEBUG=5-8, INFO=9-12, WARN=13-16, ERROR=17-20, FATAL=21-24
+    log_record = [
+      "severity_number < 9 and resource.attributes[\"deployment.environment\"] == \"production\"",
+    ]
+  }
+
+  output {
+    logs = [otelcol.processor.attributes.loki_labels.input]
   }
 }
 

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -151,6 +151,14 @@ if compgen -G "infrastructure/grafana-dashboard-*.json" >/dev/null; then
     log_info "Grafana dashboards included: $DASHBOARD_COUNT"
 fi
 
+# Copy observability stack configuration files
+for config_file in tempo-config.yml loki-config.yml pyroscope-config.yml alloy-config.alloy; do
+    if [ -f "infrastructure/$config_file" ]; then
+        cp "infrastructure/$config_file" "$DEPLOY_PKG/"
+        log_info "Observability config included: $config_file"
+    fi
+done
+
 # Copy backup scripts directory
 if [ -d "scripts/backup" ]; then
     mkdir -p "$DEPLOY_PKG/scripts"

--- a/src/main.rs
+++ b/src/main.rs
@@ -820,8 +820,8 @@ async fn main() -> Result<()> {
     let otel_filter = EnvFilter::new("info,tokio=off,runtime=off");
 
     // Helper to create logs layer - bridges tracing events to OpenTelemetry logs for Loki export
-    // Note: We don't apply an additional filter here since the global subscriber filter already
-    // controls what events reach this layer
+    // Note: Log level filtering is handled in Alloy's otelcol.processor.filter component
+    // to allow configuration changes without code deployment
     let create_logs_layer = || {
         logger_provider
             .as_ref()


### PR DESCRIPTION
## Summary
Fix two issues causing SOAR profiles to not appear correctly in Pyroscope/Grafana:

1. **Wrong label name**: Changed `service` to `service_name` in discovery.relabel targets
   - Pyroscope requires `service_name` to identify services
   - Without it, all profiles were appearing under "unspecified"

2. **Unsupported profile types**: Explicitly disabled Go-specific profile types
   - Disabled: memory, block, goroutine, mutex
   - The Rust `pprof` crate only provides CPU profiling
   - These endpoints were causing 404 errors in Alloy logs

## Test plan
After deploying the updated Alloy config:
- [ ] Restart Alloy: `sudo systemctl restart alloy`
- [ ] Wait 1-2 minutes for new profiles to be scraped
- [ ] Check Pyroscope shows `soar-run-staging` service: Query `{service_name="soar-run-staging"}`
- [ ] Verify no more 404 errors in Alloy logs for pprof endpoints