### PR TITLE
Enable frame pointers for CPU profiling

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,7 +4,8 @@
 # Incremental compilation (enabled by default for dev, but explicit here)
 incremental = true
 # Enable tokio_unstable for tokio-console support
-rustflags = ["--cfg", "tokio_unstable"]
+# Enable frame pointers for profiling (pprof stack unwinding)
+rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes"]
 
 [target.x86_64-unknown-linux-gnu]
 # Using default linker (ld)
@@ -14,6 +15,7 @@ rustflags = ["--cfg", "tokio_unstable"]
 # Static linking configuration for musl
 rustflags = [
     "--cfg", "tokio_unstable",
+    "-C", "force-frame-pointers=yes",
     "-C", "target-feature=+crt-static",
     "-C", "link-arg=-static",
 ]
@@ -22,6 +24,7 @@ rustflags = [
 # Static linking configuration for musl (ARM64)
 rustflags = [
     "--cfg", "tokio_unstable",
+    "-C", "force-frame-pointers=yes",
     "-C", "target-feature=+crt-static",
     "-C", "link-arg=-static",
 ]


### PR DESCRIPTION
## Summary
- Enable frame pointers (`-C force-frame-pointers=yes`) for all Rust build targets
- Fixes Pyroscope/Grafana flame graphs showing only "total" with no function names
- Profile size increases from ~5KB to ~124KB with complete stack traces

## Root Cause
Without frame pointers, the pprof crate cannot unwind the stack during CPU profiling. This resulted in tiny profiles with no useful symbol information.

## Test plan
- [x] Rebuilt staging binary with frame pointers enabled
- [x] Verified profile size increased from ~5KB to ~124KB
- [x] Deployed to staging and confirmed Alloy is scraping larger profiles