### PR TITLE
Add frame pointers to CI release builds for Pyroscope profiling

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -100,7 +100,9 @@ jobs:
           SKIP_WEB_BUILD: "1"  # Frontend already built via downloaded artifacts
           # CRITICAL: tokio_unstable is required for tokio-console support
           # Without this flag, --enable-tokio-console will cause exit code 101 with no output
-          RUSTFLAGS: "--cfg tokio_unstable -C target-feature=+crt-static -C link-arg=-static"
+          # CRITICAL: force-frame-pointers=yes is required for Pyroscope profiling
+          # Without frame pointers, flame graphs show unhelpful "[unknown]" frames
+          RUSTFLAGS: "--cfg tokio_unstable -C target-feature=+crt-static -C link-arg=-static -C force-frame-pointers=yes"
         run: cross build --release --target aarch64-unknown-linux-musl --features bundled-postgres
 
       - name: Verify static linking

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,7 +464,9 @@ jobs:
           SKIP_WEB_BUILD: "1"  # Frontend already built via downloaded artifacts
           # CRITICAL: tokio_unstable is required for tokio-console support
           # Without this flag, --enable-tokio-console will cause exit code 101 with no output
-          RUSTFLAGS: "--cfg tokio_unstable -C target-feature=+crt-static -C link-arg=-static"
+          # CRITICAL: force-frame-pointers=yes is required for Pyroscope profiling
+          # Without frame pointers, flame graphs show unhelpful "[unknown]" frames
+          RUSTFLAGS: "--cfg tokio_unstable -C target-feature=+crt-static -C link-arg=-static -C force-frame-pointers=yes"
         run: cross build --release --target x86_64-unknown-linux-musl --features bundled-postgres
 
       - name: Verify static linking


### PR DESCRIPTION
## Summary
- Add `-C force-frame-pointers=yes` to RUSTFLAGS in CI release builds
- Fixes flame graphs showing "[unknown]" frames instead of function names

## Problem
The CI workflows were overriding `RUSTFLAGS` as an environment variable, which replaced the settings from `.cargo/config.toml`. This caused CI builds to be missing frame pointers, even though the config file had them set correctly for musl targets.

## Test plan
- [ ] CI builds complete successfully
- [ ] After deployment, verify flame graphs in Grafana show actual function names