### PR TITLE
Disable ADS-B ingestion in production and filter TRACE logs

### DIFF
--- a/infrastructure/alloy-config.alloy
+++ b/infrastructure/alloy-config.alloy
@@ -29,17 +29,20 @@ otelcol.processor.batch "pipeline" {
   }
 }
 
-// Filter logs based on environment and severity:
-// - Production (deployment.environment = "production"): INFO and higher only
-// - Staging/Development: DEBUG and higher (all logs)
-// This reduces noise and cost for production while keeping detailed logs for debugging in staging
+// Filter logs based on severity:
+// - TRACE logs (severity 1-4): Always dropped - too verbose for log aggregation
+// - DEBUG logs (severity 5-8): Dropped for production, kept for staging/dev
+// - INFO+ (severity 9+): Always kept
+// This reduces noise and storage costs while keeping useful logs
 otelcol.processor.filter "log_level" {
   error_mode = "ignore"
 
   logs {
-    // Drop DEBUG logs from production services
     // OTTL severity_number: TRACE=1-4, DEBUG=5-8, INFO=9-12, WARN=13-16, ERROR=17-20, FATAL=21-24
     log_record = [
+      // Always drop TRACE logs - they include tokio runtime internals and are too noisy
+      "severity_number <= 4",
+      // Drop DEBUG logs from production services (if deployment.environment is set)
       "severity_number < 9 and resource.attributes[\"deployment.environment\"] == \"production\"",
     ]
   }

--- a/infrastructure/systemd/soar-ingest.service
+++ b/infrastructure/systemd/soar-ingest.service
@@ -19,7 +19,7 @@ SyslogIdentifier=soar-ingest
 # - Add --ogn-server, --ogn-port, --ogn-callsign, --ogn-filter for OGN/APRS ingestion
 # - Add --beast <server:port> for Beast format ADS-B (can specify multiple times)
 # - Add --sbs <server:port> for SBS (BaseStation) format (can specify multiple times)
-ExecStart=/usr/local/bin/soar ingest --ogn-server aprs.glidernet.org --beast radar:41365
+ExecStart=/usr/local/bin/soar ingest --ogn-server aprs.glidernet.org
 ExecReload=/bin/kill -s HUP $MAINPID
 
 # Environment variables


### PR DESCRIPTION
## Summary
- Remove `--beast radar:41365` from production ingest service to only receive OGN/APRS data
- Update Alloy log filter to always drop TRACE level logs (severity <= 4) which were flooding Loki with noisy tokio runtime internals like `runtime::resource::poll_op` and `tokio::task::waker`

## Test plan
- [ ] Verify production ingest service only connects to OGN after deployment
- [ ] Confirm TRACE logs no longer appear in Loki