### PR TITLE
Enable frame-pointer feature in pprof for proper profiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ sitemap-rs = "0.4.0"
 metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
 flarmnet = { git = "https://github.com/hut8/flarmnet-rs", default-features = false, features = ["xcsoar"] }
-pprof = { version = "0.15", features = ["flamegraph", "protobuf-codec"] }
+pprof = { version = "0.15", features = ["flamegraph", "protobuf-codec", "frame-pointer"] }
 lru = "0.16"
 moka = { version = "0.12", features = ["future", "sync"] }
 sha2 = "0.10.9"


### PR DESCRIPTION
## Summary
- Add `frame-pointer` feature to pprof crate dependency
- Fixes empty/unhelpful flame graphs in Pyroscope

## Problem
The pprof crate was generating profiles with only memory addresses (no function names) because:
1. We compile with `-C force-frame-pointers=yes` (added in #894)
2. But the pprof crate needs the `frame-pointer` feature enabled to USE those frame pointers for stack unwinding
3. Without this feature, it falls back to DWARF-based unwinding which doesn't work well with musl-linked static binaries

## Test plan
- [ ] CI builds successfully
- [ ] After deployment, verify flame graphs in Grafana show actual function names instead of just memory addresses