### PR TITLE
Fix pgbouncer auth to use 'any' with forced backend user

### DIFF
--- a/infrastructure/pgbouncer.ini
+++ b/infrastructure/pgbouncer.ini
@@ -3,13 +3,14 @@
 
 [databases]
 ; Production database - soar user connects to soar database
-soar = host=127.0.0.1 port=5432 dbname=soar
+; user= forces the backend connection to use 'soar' user
+soar = host=127.0.0.1 port=5432 dbname=soar user=soar
 
 ; Staging database - soar user connects to soar_staging database
-soar_staging = host=127.0.0.1 port=5432 dbname=soar_staging
+soar_staging = host=127.0.0.1 port=5432 dbname=soar_staging user=soar
 
 ; Development database - soar user connects to soar_dev database
-soar_dev = host=127.0.0.1 port=5432 dbname=soar_dev
+soar_dev = host=127.0.0.1 port=5432 dbname=soar_dev user=soar
 
 [pgbouncer]
 ; Connection settings
@@ -18,9 +19,9 @@ listen_port = 6432
 unix_socket_dir = /var/run/postgresql
 
 ; Authentication
-; Use trust auth since PostgreSQL is configured with trust for local soar user
-auth_type = trust
-auth_file = /etc/pgbouncer/userlist.txt
+; Use 'any' auth since we only listen on localhost and force the backend user
+; This is safe because listen_addr is 127.0.0.1 only
+auth_type = any
 
 ; Pool settings
 ; transaction - release connection after each transaction (good for web apps)


### PR DESCRIPTION
## Summary
Fix pgbouncer authentication that was failing with "no such user: soar" errors.

## Changes
- Changed `auth_type` from `trust` to `any`
- Added `user=soar` to database definitions to force backend connection user
- Removed `auth_file` requirement since `any` doesn't need it

## Why
The `trust` auth type with empty passwords in userlist.txt wasn't working correctly - pgbouncer couldn't find the user. Using `any` with forced users is safe because pgbouncer only listens on `127.0.0.1`.

## Test plan
- [x] Tested on production - connections now work correctly