### PR TITLE
Remove JetStream from NATS server configuration

### DIFF
--- a/infrastructure/nats-server.service
+++ b/infrastructure/nats-server.service
@@ -1,14 +1,11 @@
 [Unit]
-Description=NATS Server with JetStream
+Description=NATS Server
 After=network-online.target
 
 [Service]
 PrivateTmp=true
 Type=simple
-# Enable JetStream with file-based storage for durable message queues
-# Note: Create /var/lib/nats/jetstream directory and set ownership to daemon:daemon
-# mkdir -p /var/lib/nats/jetstream && chown daemon:daemon /var/lib/nats/jetstream
-ExecStart=/usr/local/bin/nats-server --jetstream --store_dir=/var/lib/nats/jetstream --addr 127.0.0.1:4222 --http_addr 127.0.0.1:8222
+ExecStart=/usr/local/bin/nats-server --addr 127.0.0.1 --port 4222 --http_port 8222
 ExecReload=/bin/kill -s HUP $MAINPID
 
 # The nats-server uses SIGUSR2 to trigger Lame Duck Mode (LDM) shutdown


### PR DESCRIPTION
## Summary
- Remove JetStream configuration from NATS systemd service (no longer needed)
- Simplify ExecStart to use separate `--addr`, `--port`, and `--http_port` flags

## Test plan
- [ ] Deploy updated service file to server
- [ ] Verify NATS server starts correctly without JetStream