### PR TITLE
Improve Grafana dashboards and fix location geocoding metrics

### DIFF
--- a/infrastructure/grafana-dashboard-ingest.json
+++ b/infrastructure/grafana-dashboard-ingest.json
@@ -1005,8 +1005,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_raw_message_received_server_total{component=\"ingest\",environment=~\"$environment\"}[1m]) * 60",
-          "legendFormat": "Server Messages/min",
+          "expr": "rate(aprs_raw_message_received_server_total{component=\"ingest\",environment=~\"$environment\"}[1m])",
+          "legendFormat": "Server Messages/sec",
           "range": true,
           "refId": "A"
         },
@@ -1016,13 +1016,24 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_raw_message_received_aprs_total{component=\"ingest\",environment=~\"$environment\"}[1m]) * 60",
-          "legendFormat": "APRS Messages/min",
+          "expr": "rate(aprs_raw_message_received_aprs_total{component=\"ingest\",environment=~\"$environment\"}[1m])",
+          "legendFormat": "APRS Messages/sec",
           "range": true,
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "aprs_message_rate{component=\"ingest\",environment=\"$environment\"}",
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "C"
         }
       ],
-      "title": "Messages Received per Minute",
+      "title": "Messages Received per Second",
       "type": "timeseries"
     },
     {
@@ -1113,8 +1124,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_raw_message_queued_server_total{component=\"ingest\",environment=~\"$environment\"}[1m]) * 60",
-          "legendFormat": "Server Messages/min",
+          "expr": "rate(aprs_raw_message_queued_server_total{component=\"ingest\",environment=~\"$environment\"}[1m])",
+          "legendFormat": "Server Messages/sec",
           "range": true,
           "refId": "A"
         },
@@ -1124,110 +1135,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(aprs_raw_message_queued_aprs_total{component=\"ingest\",environment=~\"$environment\"}[1m]) * 60",
-          "legendFormat": "APRS Messages/min",
+          "expr": "rate(aprs_raw_message_queued_aprs_total{component=\"ingest\",environment=~\"$environment\"}[1m])",
+          "legendFormat": "APRS Messages/sec",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Messages Queued per Minute",
+      "title": "Messages Queued per Second",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "msg/s",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 71
-      },
-      "id": 15,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "12.2.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "aprs_message_rate{component=\"ingest\",environment=\"$environment\"}",
-          "legendFormat": "Message Rate (msg/s)",
-          "refId": "A"
-        }
-      ],
-      "title": "APRS Message Rate",
-      "type": "timeseries",
-      "description": "Current APRS message ingestion rate (messages per second)"
     },
     {
       "collapsed": false,
@@ -2355,13 +2270,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "ingest_queue_depth{type=\"disk\",environment=~\"$environment\"}",
-          "legendFormat": "{{source}} disk",
+          "expr": "ingest_queue_depth_bytes{type=\"data\",component=\"ingest\",environment=~\"$environment\"}",
+          "legendFormat": "{{source}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Disk Queue Depth (by Source)",
+      "title": "Disk Queue Size (by Source)",
       "type": "timeseries"
     },
     {

--- a/infrastructure/grafana-dashboard-run-geocoding.json
+++ b/infrastructure/grafana-dashboard-run-geocoding.json
@@ -206,9 +206,12 @@
       "id": 4,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
           "showLegend": true
         },
         "tooltip": {
@@ -459,10 +462,21 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_location_created_total{component=\"run\",environment=\"$environment\",type=\"start_takeoff\"}[$__rate_interval])",
-          "legendFormat": "Start (Takeoff)",
+          "expr": "rate(flight_tracker_location_created_total{component=\"run\",environment=\"$environment\",type=\"start_no_airport_location\"}[$__rate_interval])",
+          "legendFormat": "Start (No Airport Location)",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(flight_tracker_location_created_total{component=\"run\",environment=\"$environment\",type=\"start_no_airport\"}[$__rate_interval])",
+          "legendFormat": "Start (No Airport)",
+          "range": true,
+          "refId": "B"
         },
         {
           "datasource": {
@@ -473,7 +487,7 @@
           "expr": "rate(flight_tracker_location_created_total{component=\"run\",environment=\"$environment\",type=\"start_airborne\"}[$__rate_interval])",
           "legendFormat": "Start (Airborne)",
           "range": true,
-          "refId": "B"
+          "refId": "C"
         },
         {
           "datasource": {
@@ -481,10 +495,21 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_location_created_total{component=\"run\",environment=\"$environment\",type=\"end_landing\"}[$__rate_interval])",
-          "legendFormat": "End (Landing)",
+          "expr": "rate(flight_tracker_location_created_total{component=\"run\",environment=\"$environment\",type=\"end_no_airport_location\"}[$__rate_interval])",
+          "legendFormat": "End (No Airport Location)",
           "range": true,
-          "refId": "C"
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(flight_tracker_location_created_total{component=\"run\",environment=\"$environment\",type=\"end_no_airport\"}[$__rate_interval])",
+          "legendFormat": "End (No Airport)",
+          "range": true,
+          "refId": "E"
         },
         {
           "datasource": {
@@ -495,7 +520,7 @@
           "expr": "rate(flight_tracker_location_created_total{component=\"run\",environment=\"$environment\",type=\"end_timeout\"}[$__rate_interval])",
           "legendFormat": "End (Timeout)",
           "range": true,
-          "refId": "D"
+          "refId": "F"
         }
       ],
       "title": "Locations Created by Type",

--- a/infrastructure/grafana-dashboard-run.json
+++ b/infrastructure/grafana-dashboard-run.json
@@ -4783,105 +4783,6 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 1972,
-        "w": 24,
-        "h": 8
-      },
-      "id": 1039,
-      "options": {
-        "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "12.2.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "rate(flight_tracker_timeouts_detected_total{component=\"run\",environment=\"$environment\"}[5m])",
-          "legendFormat": "Timeouts/sec",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Flight Tracker - Timeouts",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "x": 0,
         "y": 1997,
         "w": 24,
         "h": 8
@@ -4912,7 +4813,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_flight_ended_landed_total{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "increase(flight_tracker_flight_ended_landed_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Landed",
           "range": true,
           "refId": "A"
@@ -4923,13 +4824,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(flight_tracker_flight_ended_timed_out_total{component=\"run\",environment=\"$environment\"}[5m])",
+          "expr": "increase(flight_tracker_flight_ended_timed_out_total{component=\"run\",environment=\"$environment\"}[5m])",
           "legendFormat": "Timed Out",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Flight Ends",
+      "title": "Flight Ends (5m)",
       "type": "timeseries"
     },
     {
@@ -5547,7 +5448,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(flight_tracker_flight_created_takeoff_total{component=\"run\",environment=\"$environment\"}[5m])) or vector(0)",
+          "expr": "sum(increase(flight_tracker_flight_created_takeoff_total{component=\"run\",environment=\"$environment\"}[5m])) or vector(0)",
           "legendFormat": "Takeoff",
           "range": true,
           "refId": "A"
@@ -5558,13 +5459,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(flight_tracker_flight_created_airborne_total{component=\"run\",environment=\"$environment\"}[5m])) or vector(0)",
+          "expr": "sum(increase(flight_tracker_flight_created_airborne_total{component=\"run\",environment=\"$environment\"}[5m])) or vector(0)",
           "legendFormat": "Airborne",
           "range": true,
           "refId": "B"
         }
       ],
-      "title": "Flight Creation",
+      "title": "Flight Creation (5m)",
       "type": "timeseries"
     }
   ],

--- a/src/flight_tracker/flight_lifecycle.rs
+++ b/src/flight_tracker/flight_lifecycle.rs
@@ -98,7 +98,11 @@ pub(crate) async fn create_flight_fast(
     );
 
     // Spawn background task to enrich flight with runway/location data (SLOW operations)
-    if !skip_airport_runway_lookup {
+    if skip_airport_runway_lookup {
+        // Airborne flight - just geocode the start location
+        spawn_flight_enrichment_airborne(ctx, fix.clone(), flight_id);
+    } else {
+        // Takeoff flight - full enrichment including runway detection
         spawn_flight_enrichment_on_creation(ctx, fix.clone(), aircraft, flight_id);
     }
 
@@ -168,7 +172,7 @@ fn spawn_flight_enrichment_on_creation(
                             &locations_repo,
                             fix.latitude,
                             fix.longitude,
-                            "start (takeoff)",
+                            "start (no airport location)",
                         )
                         .await
                     }
@@ -178,7 +182,7 @@ fn spawn_flight_enrichment_on_creation(
                     &locations_repo,
                     fix.latitude,
                     fix.longitude,
-                    "start (takeoff)",
+                    "start (no airport)",
                 )
                 .await
             };
@@ -213,6 +217,52 @@ fn spawn_flight_enrichment_on_creation(
 
             debug!(
                 "Enriched flight {} with runway/location data in background",
+                flight_id
+            );
+        }
+        .instrument(span),
+    );
+}
+
+/// Spawn background task to enrich airborne flight with start location only
+/// This is a simpler version for flights that started mid-air (no runway detection needed)
+fn spawn_flight_enrichment_airborne(ctx: &FlightProcessorContext<'_>, fix: Fix, flight_id: Uuid) {
+    let flights_repo = ctx.flights_repo.clone();
+    let locations_repo = ctx.locations_repo.clone();
+
+    // Create a new root span to prevent trace accumulation
+    let span = info_span!(parent: None, "flight_enrichment_airborne", %flight_id);
+    let _ = span.set_parent(opentelemetry::Context::new());
+
+    tokio::spawn(
+        async move {
+            let start = std::time::Instant::now();
+
+            // SLOW: Create location via geocoding (HTTP API call to Pelias)
+            let start_location_id = create_start_end_location(
+                &locations_repo,
+                fix.latitude,
+                fix.longitude,
+                "start (airborne)",
+            )
+            .await;
+
+            // Update flight with start location
+            if let Err(e) = flights_repo
+                .update_flight_start_location(flight_id, start_location_id)
+                .await
+            {
+                error!(
+                    "Failed to update airborne flight {} with start location: {}",
+                    flight_id, e
+                );
+            }
+
+            metrics::histogram!("flight_tracker.enrich_flight_airborne.latency_ms")
+                .record(start.elapsed().as_micros() as f64 / 1000.0);
+
+            debug!(
+                "Enriched airborne flight {} with start location in background",
                 flight_id
             );
         }

--- a/src/flight_tracker/location.rs
+++ b/src/flight_tracker/location.rs
@@ -257,9 +257,11 @@ pub(crate) async fn create_start_end_location(
 
                     // Track location creation by type
                     let metric_type = match context {
-                        "start (takeoff)" => "start_takeoff",
+                        "start (no airport location)" => "start_no_airport_location",
+                        "start (no airport)" => "start_no_airport",
                         "start (airborne)" => "start_airborne",
-                        "end (landing)" => "end_landing",
+                        "end (no airport location)" => "end_no_airport_location",
+                        "end (no airport)" => "end_no_airport",
                         "end (timeout)" => "end_timeout",
                         _ => "unknown",
                     };

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -547,6 +547,7 @@ pub fn initialize_run_metrics() {
     metrics::histogram!("flight_tracker.complete_flight_fast.latency_ms").record(0.0);
     metrics::histogram!("flight_tracker.enrich_flight_on_creation.latency_ms").record(0.0);
     metrics::histogram!("flight_tracker.enrich_flight_on_completion.latency_ms").record(0.0);
+    metrics::histogram!("flight_tracker.enrich_flight_airborne.latency_ms").record(0.0);
 
     // Flight coalescing metrics
     metrics::counter!("flight_tracker.coalesce.resumed_total").absolute(0);
@@ -671,11 +672,16 @@ pub fn initialize_run_metrics() {
         .absolute(0);
 
     // Flight location tracking metrics
-    metrics::counter!("flight_tracker.location.created_total", "type" => "start_takeoff")
+    metrics::counter!("flight_tracker.location.created_total", "type" => "start_no_airport_location")
+        .absolute(0);
+    metrics::counter!("flight_tracker.location.created_total", "type" => "start_no_airport")
         .absolute(0);
     metrics::counter!("flight_tracker.location.created_total", "type" => "start_airborne")
         .absolute(0);
-    metrics::counter!("flight_tracker.location.created_total", "type" => "end_landing").absolute(0);
+    metrics::counter!("flight_tracker.location.created_total", "type" => "end_no_airport_location")
+        .absolute(0);
+    metrics::counter!("flight_tracker.location.created_total", "type" => "end_no_airport")
+        .absolute(0);
     metrics::counter!("flight_tracker.location.created_total", "type" => "end_timeout").absolute(0);
     metrics::counter!("flight_tracker.location.created_total", "type" => "unknown").absolute(0);
 


### PR DESCRIPTION
## Summary
- Remove redundant dashboard panels and improve metric units/formatting
- Fix location geocoding metrics that were mislabeled or not being emitted
- Add geocoding for airborne flight starts (previously skipped entirely)

## Grafana Dashboard Changes
- Remove redundant "Flight Tracker - Timeouts" panel (data already in "Flight Ends")
- Change "Flight Creation" and "Flight Ends" from rate/sec to increase/5m for readability
- Convert ingest dashboard messages from per-minute to per-second
- Merge "APRS Message Rate" into "Messages Received per Second" panel as "Total"
- Fix "Disk Queue Size" to use correct metric (`ingest_queue_depth_bytes` with `type=data`)
- Move legend to right for "Geocoding Request Rate" panel

## Location Geocoding Metric Fixes
- Split start metrics into: `start_no_airport_location`, `start_no_airport`, `start_airborne`
- Split end metrics into: `end_no_airport_location`, `end_no_airport`, `end_timeout`
- Add geocoding for airborne flight starts (was completely skipped before)
- Fix end (landing) metrics that were using wrong context strings and falling through to "unknown"

## Test plan
- [ ] Verify Grafana dashboards load correctly after deployment
- [ ] Verify new location metrics appear in Prometheus after deployment
- [ ] Verify airborne flights now get start_location_id populated