### PR TITLE
Format ICAO/OGN addresses as hex in log messages

### DIFF
--- a/src/aircraft.rs
+++ b/src/aircraft.rs
@@ -1012,7 +1012,7 @@ impl AircraftFetcher {
                         AircraftSource::Flarmnet => "FLARM",
                     };
                     warn!(
-                        "Aircraft conflict for ID {}: using {} data: {} (over {})",
+                        "Aircraft conflict for ID {:06X}: using {} data: {} (over {})",
                         glidernet_device.address,
                         better_label,
                         registration.as_deref().unwrap_or("(none)"),

--- a/src/flight_tracker/flight_lifecycle.rs
+++ b/src/flight_tracker/flight_lifecycle.rs
@@ -568,7 +568,7 @@ async fn complete_flight_in_background(
             }
 
             warn!(
-                "Spurious flight {} detected for aircraft {} - reasons: [{}]. Deleting.",
+                "Spurious flight {} detected for aircraft {:06X} - reasons: [{}]. Deleting.",
                 flight_id,
                 device.address,
                 reasons.join(", ")


### PR DESCRIPTION
## Summary
- Display device addresses as 6-character uppercase hex (e.g., `FE5D6E`) instead of decimal in warning messages
- Fixes spurious flight and aircraft conflict warnings showing confusing decimal addresses like `16663790` instead of `FE5D6E`

## Changed files
- `src/flight_tracker/flight_lifecycle.rs` - Spurious flight detection warning
- `src/aircraft.rs` - Aircraft conflict warning

## Test plan
- [x] Code compiles
- [x] Verified format matches existing hex formatting pattern (`{:06X}`)