### PR TITLE
Fix compass rotation direction and move map toggle button

### DIFF
--- a/web/src/routes/operations/+page.svelte
+++ b/web/src/routes/operations/+page.svelte
@@ -2375,16 +2375,14 @@
 			</button>
 		{/if}
 
+		<!-- Map Type Toggle Button -->
+		<button class="location-btn" onclick={toggleMapType} title="Toggle Map Type">
+			<span class="text-sm font-medium">{mapType === 'satellite' ? 'Map' : 'Satellite'}</span>
+		</button>
+
 		<!-- Settings Button -->
 		<button class="location-btn" onclick={() => (showSettingsModal = true)} title="Settings">
 			<Settings size={20} />
-		</button>
-	</div>
-
-	<!-- Map Type Toggle Button -->
-	<div class="absolute bottom-4 left-4 z-10">
-		<button class="location-btn" onclick={toggleMapType} title="Toggle Map Type">
-			<span class="text-sm font-medium">{mapType === 'satellite' ? 'Map' : 'Satellite'}</span>
 		</button>
 	</div>
 


### PR DESCRIPTION
## Summary
- Fix compass on operations page rotating in wrong direction (was rotating with phone instead of counter-rotating to point north)
- Move map/satellite toggle button from bottom-left to top-left control group, before the settings button

## Test plan
- [ ] On mobile device, verify compass counter-rotates when phone rotates (N should always point north)
- [ ] Verify map/satellite toggle button appears to the left of the settings gear button