### PR TITLE
Configure LogTape meta logger to suppress info message

### DIFF
--- a/web/src/lib/logging.ts
+++ b/web/src/lib/logging.ts
@@ -27,6 +27,11 @@ export async function configureLogging(): Promise<void> {
 		},
 		loggers: [
 			{
+				category: ['logtape', 'meta'],
+				lowestLevel: 'warning',
+				sinks: ['console']
+			},
+			{
 				category: ['soar'],
 				lowestLevel: 'debug',
 				sinks: ['console']


### PR DESCRIPTION
## Summary
- Configure LogTape's meta logger with `lowestLevel: 'warning'` to suppress the auto-configuration info message
- This silences the console message about meta logger auto-configuration while still capturing any warnings/errors from LogTape itself

## Test plan
- [x] Verified lint and type checks pass
- [ ] Verify the console message no longer appears in browser dev tools