### PR TITLE
Remove rawPacket from fixes, add raw message endpoint

### DIFF
--- a/src/actions/flights.rs
+++ b/src/actions/flights.rs
@@ -12,7 +12,7 @@ use crate::actions::{
 };
 use crate::aircraft_repo::AircraftRepository;
 use crate::airports_repo::AirportsRepository;
-use crate::fixes::FixWithRawPacket;
+use crate::fixes::Fix;
 use crate::fixes_repo::FixesRepository;
 use crate::flights::{Flight, haversine_distance};
 use crate::flights_repo::FlightsRepository;
@@ -714,7 +714,7 @@ pub async fn get_nearby_flights(
 }
 
 /// Calculate average climb rate from a slice of fixes
-fn calculate_avg_climb_rate(fixes: &[FixWithRawPacket]) -> Option<i32> {
+fn calculate_avg_climb_rate(fixes: &[Fix]) -> Option<i32> {
     if fixes.len() < 2 {
         return None;
     }

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -11,6 +11,7 @@ pub mod coverage;
 pub mod fixes;
 pub mod flights;
 pub mod pilots;
+pub mod raw_messages;
 pub mod receivers;
 pub mod status;
 pub mod user_fixes;

--- a/src/actions/raw_messages.rs
+++ b/src/actions/raw_messages.rs
@@ -1,0 +1,34 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Json},
+};
+use uuid::Uuid;
+
+use crate::actions::{DataResponse, json_error};
+use crate::raw_messages_repo::RawMessagesRepository;
+use crate::web::AppState;
+
+/// Get a raw message by ID
+/// Returns the raw message with proper encoding based on source type:
+/// - APRS: UTF-8 text
+/// - ADS-B/Beast: hex-encoded binary
+pub async fn get_raw_message(
+    Path(id): Path<Uuid>,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    let repo = RawMessagesRepository::new(state.pool.clone());
+
+    match repo.get_message_response_by_id(id).await {
+        Ok(Some(message)) => Json(DataResponse { data: message }).into_response(),
+        Ok(None) => json_error(StatusCode::NOT_FOUND, "Raw message not found").into_response(),
+        Err(e) => {
+            tracing::error!("Failed to get raw message {}: {}", id, e);
+            json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to get raw message",
+            )
+            .into_response()
+        }
+    }
+}

--- a/src/fixes.rs
+++ b/src/fixes.rs
@@ -74,28 +74,13 @@ pub struct Fix {
     pub time_gap_seconds: Option<i32>,
 }
 
-/// Extended Fix struct that includes raw packet data from aprs_messages table
-/// Used for API responses where raw packet data is needed
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FixWithRawPacket {
-    #[serde(flatten)]
-    pub fix: Fix,
-
-    /// Raw APRS packet data (joined from aprs_messages table)
-    pub raw_packet: Option<String>,
-}
-
-/// Extended Fix struct that includes both raw packet and aircraft information
+/// Extended Fix struct that includes aircraft information
 /// Used for receiver fixes API where aircraft details need to be displayed
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FixWithAircraftInfo {
     #[serde(flatten)]
     pub fix: Fix,
-
-    /// Raw APRS packet data (joined from aprs_messages table)
-    pub raw_packet: Option<String>,
 
     /// Full aircraft information (joined from aircraft table)
     pub aircraft: Option<crate::actions::views::AircraftView>,
@@ -114,39 +99,10 @@ pub struct FixWithFlightInfo {
     pub flight: Option<crate::flights::Flight>,
 }
 
-impl FixWithRawPacket {
-    /// Create a FixWithRawPacket from a Fix and optional raw packet string
-    pub fn new(fix: Fix, raw_packet: Option<String>) -> Self {
-        Self { fix, raw_packet }
-    }
-}
-
 impl FixWithAircraftInfo {
-    /// Create a FixWithAircraftInfo from a Fix, raw packet, and aircraft information
-    pub fn new(
-        fix: Fix,
-        raw_packet: Option<String>,
-        aircraft: Option<crate::actions::views::AircraftView>,
-    ) -> Self {
-        Self {
-            fix,
-            raw_packet,
-            aircraft,
-        }
-    }
-}
-
-impl std::ops::Deref for FixWithRawPacket {
-    type Target = Fix;
-
-    fn deref(&self) -> &Self::Target {
-        &self.fix
-    }
-}
-
-impl std::ops::DerefMut for FixWithRawPacket {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.fix
+    /// Create a FixWithAircraftInfo from a Fix and aircraft information
+    pub fn new(fix: Fix, aircraft: Option<crate::actions::views::AircraftView>) -> Self {
+        Self { fix, aircraft }
     }
 }
 

--- a/src/flights.rs
+++ b/src/flights.rs
@@ -414,8 +414,6 @@ impl Flight {
             let start_time = self.takeoff_time.unwrap_or(self.created_at);
             let end_time = self.landing_time.unwrap_or(self.last_fix_at);
 
-            // get_fixes_for_aircraft_with_time_range returns Vec<FixWithRawPacket>
-            // Extract just the Fix objects
             fixes_repo
                 .get_fixes_for_aircraft_with_time_range(
                     &self.aircraft_id.unwrap_or(Uuid::nil()),
@@ -424,9 +422,6 @@ impl Flight {
                     None,
                 )
                 .await?
-                .into_iter()
-                .map(|fix_with_packet| fix_with_packet.fix)
-                .collect()
         };
 
         if fixes.len() < 2 {
@@ -531,8 +526,6 @@ impl Flight {
             let start_time = self.takeoff_time.unwrap_or(self.created_at);
             let end_time = self.landing_time.unwrap_or(self.last_fix_at);
 
-            // get_fixes_for_aircraft_with_time_range returns Vec<FixWithRawPacket>
-            // Extract just the Fix objects
             fixes_repo
                 .get_fixes_for_aircraft_with_time_range(
                     &self.aircraft_id.unwrap_or(Uuid::nil()),
@@ -541,9 +534,6 @@ impl Flight {
                     None,
                 )
                 .await?
-                .into_iter()
-                .map(|fix_with_packet| fix_with_packet.fix)
-                .collect()
         };
 
         if fixes.is_empty() {

--- a/src/web.rs
+++ b/src/web.rs
@@ -654,6 +654,10 @@ pub async fn start_web_server(interface: String, port: u16, pool: PgPool) -> Res
         )
         .route("/fixes", get(actions::search_fixes))
         .route("/fixes/live", get(actions::fixes_live_websocket))
+        .route(
+            "/raw-messages/{id}",
+            get(actions::raw_messages::get_raw_message),
+        )
         .route("/flights", get(actions::search_flights))
         .route("/flights/{id}", get(actions::get_flight_by_id))
         .route("/flights/{id}/device", get(actions::get_flight_device))

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -195,10 +195,18 @@ export interface FixWithExtras extends Fix {
 	deviceAddressHex?: string; // Legacy field, prefer aircraftId with proper join
 	registration?: string; // Aircraft registration (joined, not in Rust Fix)
 	model?: string; // Aircraft model (joined, not in Rust Fix)
-	rawPacket?: string; // Raw APRS packet data (joined from aprs_messages table)
 	flight?: Flight; // Full flight information if part of an active flight (from websocket)
 	aprsType?: string; // APRS message type (from sourceMetadata, used in WebSocket)
 	via?: string[]; // APRS via path (from sourceMetadata, used in WebSocket)
+}
+
+// Raw message response from /data/raw-messages/{id} endpoint
+export interface RawMessageResponse {
+	id: string;
+	rawMessage: string; // UTF-8 for APRS, hex-encoded for ADS-B
+	source: 'aprs' | 'adsb';
+	receivedAt: string;
+	receiverId: string | null;
 }
 
 // User authentication and profile (now includes pilot fields)


### PR DESCRIPTION
## Summary

- Remove `rawPacket` from fix responses because BEAST messages are binary and cannot be properly UTF-8 encoded
- Add new `GET /data/raw-messages/{id}` endpoint for on-demand raw message fetching
- Return hex-encoded strings for ADS-B/BEAST messages, UTF-8 text for APRS messages
- Frontend now fetches raw messages lazily when "Show raw" is toggled

## Test plan

- [ ] Verify fixes endpoint no longer includes rawPacket field
- [ ] Test `/data/raw-messages/{id}` endpoint with APRS message ID (should return UTF-8 text)
- [ ] Test `/data/raw-messages/{id}` endpoint with ADS-B message ID (should return hex string)
- [ ] Test "Show raw" checkbox on FixesList component loads raw messages on demand
- [ ] Test "Show raw" checkbox on receiver details page works correctly
- [ ] Verify 404 response for non-existent raw message ID