### PR TITLE
Fix Beast/SBS latency histogram buckets and disable APRS on staging

### DIFF
--- a/infrastructure/systemd/soar-ingest-staging.service
+++ b/infrastructure/systemd/soar-ingest-staging.service
@@ -1,12 +1,11 @@
 [Unit]
-Description=SOAR Unified Ingest (Staging) - Combined OGN and ADS-B Message Queue Service
+Description=SOAR Unified Ingest (Staging) - Beast ADS-B Message Queue Service
 Documentation=https://github.com/hut8/soar
 After=network-online.target
 Wants=network-online.target
-# This unified service ingests from multiple sources: OGN (APRS), Beast (ADS-B), and SBS (BaseStation)
-# It is designed to run independently from the main processing service
+# This service ingests ADS-B data via Beast protocol from radar
+# OGN/APRS ingestion is currently disabled on staging
 # Uses persistent queues to buffer messages when soar-run is unavailable
-# Metrics are exported in aggregate (all sources combined) and individually per source
 
 [Service]
 Type=simple
@@ -14,12 +13,11 @@ User=soar
 Group=soar
 WorkingDirectory=/var/lib/soar
 SyslogIdentifier=soar-ingest-staging
-# Example: ExecStart=/usr/local/bin/soar-staging ingest --ogn-server aprs.glidernet.org --beast radar:41365
-# Customize parameters based on deployment needs:
+# Beast-only configuration (APRS disabled)
 # - Add --ogn-server, --ogn-port, --ogn-callsign, --ogn-filter for OGN/APRS ingestion
 # - Add --beast <server:port> for Beast format ADS-B (can specify multiple times)
 # - Add --sbs <server:port> for SBS (BaseStation) format (can specify multiple times)
-ExecStart=/usr/local/bin/soar-staging ingest --ogn-server aprs.glidernet.org --beast radar:30005
+ExecStart=/usr/local/bin/soar-staging ingest --beast radar:30005
 ExecReload=/bin/kill -s HUP $MAINPID
 
 # Environment variables (staging environment)

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -188,20 +188,27 @@ pub fn init_metrics(component: Option<&str>) -> PrometheusHandle {
         )
         .expect("failed to set buckets for flight_tracker.coalesce.rejected.gap_hours")
         // Configure Beast message processing latency histogram with millisecond buckets
-        // Buckets: 1ms, 2ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1000ms
+        // Buckets: 1ms to 30s to capture slow processing and identify bottlenecks
         .set_buckets_for_metric(
             metrics_exporter_prometheus::Matcher::Full(
                 "beast.run.message_processing_latency_ms".to_string(),
             ),
-            &[1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0],
+            &[
+                1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2000.0, 5000.0,
+                10000.0, 30000.0,
+            ],
         )
         .expect("failed to set buckets for beast.run.message_processing_latency_ms")
         // Configure SBS message processing latency histogram with millisecond buckets
+        // Buckets: 1ms to 30s to capture slow processing and identify bottlenecks
         .set_buckets_for_metric(
             metrics_exporter_prometheus::Matcher::Full(
                 "sbs.run.message_processing_latency_ms".to_string(),
             ),
-            &[1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0],
+            &[
+                1.0, 2.0, 5.0, 10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2000.0, 5000.0,
+                10000.0, 30000.0,
+            ],
         )
         .expect("failed to set buckets for sbs.run.message_processing_latency_ms")
         .install_recorder()


### PR DESCRIPTION
## Summary
- Extend histogram buckets from 1s max to 30s max for `beast.run.message_processing_latency_ms` and `sbs.run.message_processing_latency_ms` metrics
- The previous 1s max bucket caused p95/p99 percentiles to appear capped at exactly 1 second in Grafana
- Disable OGN/APRS ingestion on staging, keeping only Beast ADS-B from radar

## Test plan
- [x] Service restarted on staging and running with Beast-only configuration
- [ ] After deploy, verify Grafana shows latency values above 1s when they occur