### PR TITLE
Add URL bounds parameters to operations page and disable 3D Globe links

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -42,7 +42,7 @@
 	const base = resolve('/');
 	const clubsPath = resolve('/clubs');
 	const operationsPath = resolve('/operations');
-	const globePath = resolve('/globe');
+	// const globePath = resolve('/globe'); // temporarily disabled
 	const aircraftPath = resolve('/aircraft');
 	const receiversPath = resolve('/receivers');
 	const airportsPath = resolve('/airports');
@@ -293,9 +293,11 @@
 						<a href={operationsPath} class="btn preset-filled-primary-500 btn-sm">
 							<Radar /> Operations
 						</a>
+						<!-- 3D Globe link temporarily disabled
 						<a href={globePath} class="btn preset-filled-primary-500 btn-sm">
 							<Globe /> 3D Globe
 						</a>
+						-->
 					</nav>
 
 					<!-- Backend Toggle (Dev Only) -->
@@ -425,6 +427,7 @@
 				>
 					<Radar size={16} /> Operations
 				</a>
+				<!-- 3D Globe link temporarily disabled
 				<a
 					href={globePath}
 					class="btn w-full justify-start preset-filled-primary-500"
@@ -432,6 +435,7 @@
 				>
 					<Globe size={16} /> 3D Globe
 				</a>
+				-->
 				<a
 					href={aircraftPath}
 					class="btn w-full justify-start preset-filled-primary-500"

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
-	import { Users, Radar, Radio, Antenna, MapPin, Plane, Camera, Globe } from '@lucide/svelte';
+	import { Users, Radar, Radio, Antenna, MapPin, Plane, Camera } from '@lucide/svelte';
+	// import { Globe } from '@lucide/svelte'; // temporarily disabled
 	import { auth } from '$lib/stores/auth';
 
 	const clubsPath = resolve('/clubs');
@@ -10,7 +11,7 @@
 	const airportsPath = resolve('/airports');
 	const flightsPath = resolve('/flights');
 	const arPath = resolve('/ar');
-	const globePath = resolve('/globe');
+	// const globePath = resolve('/globe'); // temporarily disabled
 
 	// Reactive club operations path
 	let clubOpsPath = $derived(
@@ -194,7 +195,7 @@
 					</div>
 				</a>
 
-				<!-- 3D Globe Button -->
+				<!-- 3D Globe Button - temporarily disabled
 				<a
 					href={globePath}
 					class="group flex w-64 items-center justify-center border border-white/30 bg-white/20 p-8 backdrop-blur-md transition-all duration-200 hover:bg-white/30 hover:shadow-xl"
@@ -212,6 +213,7 @@
 						</div>
 					</div>
 				</a>
+				-->
 			</div>
 		</div>
 	</section>


### PR DESCRIPTION
## Summary
- Temporarily disable 3D Globe links in navigation and homepage (code preserved)
- Add `north`, `south`, `west`, `east` URL query parameters to operations page
- URL automatically updates when map pans or zooms
- Page loads to correct view when bounds are present in URL

## Test plan
- [ ] Verify 3D Globe links are hidden in desktop nav, mobile menu, and homepage
- [ ] Pan/zoom on operations page and verify URL updates with bounds
- [ ] Copy URL with bounds, open in new tab, verify map shows same view
- [ ] Verify legacy `lat`/`lng`/`zoom` parameters still work