### PR TITLE
perf: remove redundant lat/lng update from fix insert

### DIFF
--- a/src/fixes_repo.rs
+++ b/src/fixes_repo.rs
@@ -211,17 +211,14 @@ impl FixesRepository {
                         new_fix.longitude
                     );
 
-                    // Update aircraft's current_fix, latitude, and longitude columns with the new fix
-                    // The latitude/longitude columns are used to generate location_geom for spatial queries
+                    // Update aircraft's current_fix column with the complete fix data
+                    // Note: latitude/longitude are already updated by aircraft_for_fix() which is called
+                    // earlier in the pipeline, so we only need to update current_fix here
                     if let Ok(fix_json) = serde_json::to_value(&new_fix) {
                         use crate::schema::aircraft;
                         let _ = diesel::update(aircraft::table)
                             .filter(aircraft::id.eq(new_fix.aircraft_id))
-                            .set((
-                                aircraft::current_fix.eq(fix_json),
-                                aircraft::latitude.eq(new_fix.latitude),
-                                aircraft::longitude.eq(new_fix.longitude),
-                            ))
+                            .set(aircraft::current_fix.eq(fix_json))
                             .execute(&mut conn);
                     }
 


### PR DESCRIPTION
## Summary

- Remove redundant `latitude` and `longitude` columns from the UPDATE statement in `fixes_repo.insert()`
- These columns are already updated by `aircraft_for_fix()` earlier in the pipeline

## Background

During performance analysis of queue blocking (903 ops/sec on aircraft queue), I found that every fix insert was triggering two separate updates to the aircraft table:

1. `aircraft_for_fix()` updates: `last_fix_at`, `latitude`, `longitude`, and other fields
2. `fixes_repo.insert()` updates: `current_fix`, `latitude`, `longitude`

The lat/lng update in #2 is redundant since #1 already handles it.

## Changes

**Before**: Every fix insert triggered an UPDATE with 3 columns:
```sql
UPDATE aircraft SET current_fix = $1, latitude = $2, longitude = $3 WHERE id = $4
```

**After**: Only updates `current_fix`:
```sql
UPDATE aircraft SET current_fix = $1 WHERE id = $2
```

## Expected Impact

- **1-3ms improvement per fix at p95** due to:
  - Smaller UPDATE payload (fewer columns = less network/parsing overhead)
  - Fewer index updates (lat/lng changes trigger `location_geom` recalculation via trigger)

## Test Plan

- [x] `cargo check` passes
- [x] `cargo clippy` passes
- [ ] CI tests pass
- [ ] Monitor `aprs.aircraft.fix_db_insert_ms` metric after deployment