### PR TITLE
perf: increase aircraft queue size from 1,000 to 5,000

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 const NATS_INTAKE_QUEUE_SIZE: usize = 5000;
 const BEAST_INTAKE_QUEUE_SIZE: usize = 1000;
 const SBS_INTAKE_QUEUE_SIZE: usize = 1000;
-const AIRCRAFT_QUEUE_SIZE: usize = 1000;
+const AIRCRAFT_QUEUE_SIZE: usize = 5000;
 const RECEIVER_STATUS_QUEUE_SIZE: usize = 50;
 const RECEIVER_POSITION_QUEUE_SIZE: usize = 50;
 const SERVER_STATUS_QUEUE_SIZE: usize = 50;


### PR DESCRIPTION
## Summary

Increase `AIRCRAFT_QUEUE_SIZE` from 1,000 to 5,000 to reduce backpressure during peak traffic.

## Background

Performance analysis showed the aircraft queue blocking at up to 903 ops/sec during peak traffic. The queue was the smallest in the pipeline:

| Queue | Before | After |
|-------|--------|-------|
| Router internal | 10,000 | 10,000 |
| NATS intake | 5,000 | 5,000 |
| Envelope intake | 5,000 | 5,000 |
| **Aircraft** | **1,000** | **5,000** |

## Expected Impact

- Reduces `queue.send_blocked_total{queue="aircraft"}` rate
- Provides more buffer for traffic bursts
- Allows 80 aircraft workers more headroom to process fixes

## Test Plan

- [x] `cargo check` passes
- [x] Pre-commit hooks pass
- [ ] CI passes
- [ ] Monitor queue blocked rate after deployment