### PR TITLE
Add RDP-compressed flight path endpoint for trail rendering

### DIFF
--- a/src/geometry/mod.rs
+++ b/src/geometry/mod.rs
@@ -1,1 +1,2 @@
+pub mod rdp;
 pub mod spline;

--- a/src/geometry/rdp.rs
+++ b/src/geometry/rdp.rs
@@ -1,0 +1,187 @@
+//! Ramer-Douglas-Peucker algorithm for polyline simplification
+//!
+//! This module implements the RDP algorithm to reduce the number of points
+//! in a path while preserving the overall shape within a given tolerance.
+
+use super::spline::GeoPoint;
+
+/// Calculate the perpendicular distance from a point to a line segment in 3D
+///
+/// Uses geographic distance for horizontal component and direct altitude
+/// difference for vertical, with altitude scaled to be comparable to
+/// horizontal distance (1 degree ≈ 111km, so we scale altitude accordingly).
+fn point_to_line_distance(point: &GeoPoint, line_start: &GeoPoint, line_end: &GeoPoint) -> f64 {
+    // If start and end are the same point, return distance to that point
+    let line_length = line_start.distance_to(line_end);
+    if line_length < 0.001 {
+        // Less than 1mm
+        return point.distance_3d_to(line_start);
+    }
+
+    // Project point onto the line using parameter t
+    // We work in a local coordinate system where distances are in meters
+
+    // Calculate vectors (using meter-based distances)
+    let start_to_end_lat = line_end.latitude - line_start.latitude;
+    let start_to_end_lng = line_end.longitude - line_start.longitude;
+    let start_to_point_lat = point.latitude - line_start.latitude;
+    let start_to_point_lng = point.longitude - line_start.longitude;
+
+    // Calculate t parameter for projection onto line
+    let dot_product = start_to_point_lat * start_to_end_lat + start_to_point_lng * start_to_end_lng;
+    let line_length_sq = start_to_end_lat * start_to_end_lat + start_to_end_lng * start_to_end_lng;
+
+    let t = if line_length_sq > 0.0 {
+        (dot_product / line_length_sq).clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+
+    // Find the closest point on the line
+    let closest_lat = line_start.latitude + t * start_to_end_lat;
+    let closest_lng = line_start.longitude + t * start_to_end_lng;
+
+    // Interpolate altitude if available
+    let closest_alt = match (line_start.altitude_meters, line_end.altitude_meters) {
+        (Some(alt1), Some(alt2)) => Some(alt1 + t * (alt2 - alt1)),
+        _ => None,
+    };
+
+    let closest_point = match closest_alt {
+        Some(alt) => GeoPoint::new_with_altitude(closest_lat, closest_lng, alt),
+        None => GeoPoint::new(closest_lat, closest_lng),
+    };
+
+    // Return 3D distance from point to closest point on line
+    point.distance_3d_to(&closest_point)
+}
+
+/// Simplify a path using the Ramer-Douglas-Peucker algorithm
+///
+/// # Arguments
+/// * `points` - The input path as a slice of GeoPoints
+/// * `epsilon` - The maximum allowed perpendicular distance in meters
+///
+/// # Returns
+/// A simplified path containing only the essential points
+pub fn simplify_path(points: &[GeoPoint], epsilon: f64) -> Vec<GeoPoint> {
+    let indices = simplify_path_indices(points, epsilon);
+    indices.into_iter().map(|i| points[i]).collect()
+}
+
+/// Simplify a path and return the indices of kept points
+///
+/// # Arguments
+/// * `points` - The input path as a slice of GeoPoints
+/// * `epsilon` - The maximum allowed perpendicular distance in meters
+///
+/// # Returns
+/// Indices of the points to keep from the original path
+pub fn simplify_path_indices(points: &[GeoPoint], epsilon: f64) -> Vec<usize> {
+    if points.is_empty() {
+        return vec![];
+    }
+    if points.len() <= 2 {
+        return (0..points.len()).collect();
+    }
+
+    let mut keep = vec![false; points.len()];
+    rdp_recursive(points, 0, points.len() - 1, epsilon, &mut keep);
+
+    // Always keep first and last
+    keep[0] = true;
+    keep[points.len() - 1] = true;
+
+    keep.iter()
+        .enumerate()
+        .filter_map(|(i, &k)| if k { Some(i) } else { None })
+        .collect()
+}
+
+/// Recursive helper for RDP that marks points to keep
+#[allow(clippy::needless_range_loop)] // We need the index for keep[] and recursive calls
+fn rdp_recursive(points: &[GeoPoint], start: usize, end: usize, epsilon: f64, keep: &mut [bool]) {
+    if end <= start + 1 {
+        return;
+    }
+
+    let first = &points[start];
+    let last = &points[end];
+
+    // Find the point with maximum distance from the line
+    let mut max_distance = 0.0;
+    let mut max_index = start;
+
+    for i in (start + 1)..end {
+        let distance = point_to_line_distance(&points[i], first, last);
+        if distance > max_distance {
+            max_distance = distance;
+            max_index = i;
+        }
+    }
+
+    // If max distance is greater than epsilon, keep this point and recurse
+    if max_distance > epsilon {
+        keep[max_index] = true;
+        rdp_recursive(points, start, max_index, epsilon, keep);
+        rdp_recursive(points, max_index, end, epsilon, keep);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simplify_straight_line() {
+        // Points along a straight line should collapse to 2 points
+        let points = vec![
+            GeoPoint::new(0.0, 0.0),
+            GeoPoint::new(0.5, 0.5),
+            GeoPoint::new(1.0, 1.0),
+            GeoPoint::new(1.5, 1.5),
+            GeoPoint::new(2.0, 2.0),
+        ];
+
+        let simplified = simplify_path(&points, 100.0); // 100m tolerance
+        assert_eq!(simplified.len(), 2);
+    }
+
+    #[test]
+    fn test_simplify_preserves_corners() {
+        // A sharp corner should be preserved
+        let points = vec![
+            GeoPoint::new(0.0, 0.0),
+            GeoPoint::new(1.0, 0.0), // Corner point
+            GeoPoint::new(1.0, 1.0),
+        ];
+
+        let simplified = simplify_path(&points, 100.0);
+        // The corner should be preserved because perpendicular distance is large
+        assert!(simplified.len() >= 2);
+    }
+
+    #[test]
+    fn test_simplify_with_altitude() {
+        // Climbing path should preserve altitude changes
+        let points = vec![
+            GeoPoint::new_with_altitude(0.0, 0.0, 0.0),
+            GeoPoint::new_with_altitude(0.001, 0.001, 500.0),
+            GeoPoint::new_with_altitude(0.002, 0.002, 1000.0),
+        ];
+
+        // With small epsilon, altitude change should cause preservation
+        let simplified = simplify_path(&points, 10.0);
+        assert!(simplified.len() >= 2);
+    }
+
+    #[test]
+    fn test_simplify_empty_and_small() {
+        assert_eq!(simplify_path(&[], 100.0).len(), 0);
+        assert_eq!(simplify_path(&[GeoPoint::new(0.0, 0.0)], 100.0).len(), 1);
+        assert_eq!(
+            simplify_path(&[GeoPoint::new(0.0, 0.0), GeoPoint::new(1.0, 1.0)], 100.0).len(),
+            2
+        );
+    }
+}

--- a/src/web.rs
+++ b/src/web.rs
@@ -663,6 +663,7 @@ pub async fn start_web_server(interface: String, port: u16, pool: PgPool) -> Res
         .route("/flights/{id}/device", get(actions::get_flight_device))
         .route("/flights/{id}/kml", get(actions::get_flight_kml))
         .route("/flights/{id}/fixes", get(actions::get_flight_fixes))
+        .route("/flights/{id}/path", get(actions::get_flight_path))
         .route("/flights/{id}/gaps", get(actions::get_flight_gaps))
         .route(
             "/flights/{id}/spline-path",

--- a/web/src/lib/components/SettingsModal.svelte
+++ b/web/src/lib/components/SettingsModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Switch, Slider } from '@skeletonlabs/skeleton-svelte';
+	import { Switch } from '@skeletonlabs/skeleton-svelte';
 	import { X, Trash2 } from '@lucide/svelte';
 	import { browser } from '$app/environment';
 	import { onMount } from 'svelte';
@@ -21,9 +21,6 @@
 		showReceiverMarkers?: boolean;
 		showAirspaceMarkers?: boolean;
 		showRunwayOverlays?: boolean;
-		positionFixWindow?: number;
-		// Legacy support for old settings
-		trailLength?: number[];
 	}
 
 	// Settings state
@@ -32,7 +29,6 @@
 	let showReceiverMarkers = $state(true);
 	let showAirspaceMarkers = $state(true);
 	let showRunwayOverlays = $state(false);
-	let positionFixWindow = $state(8); // Hours - default 8 hours
 
 	// Settings persistence functions
 	async function loadSettings() {
@@ -54,10 +50,6 @@
 					showReceiverMarkers = backendSettings.showReceiverMarkers ?? true;
 					showAirspaceMarkers = backendSettings.showAirspaceMarkers ?? true;
 					showRunwayOverlays = backendSettings.showRunwayOverlays ?? false;
-					// Use positionFixWindow, or fallback to trailLength for legacy support
-					positionFixWindow =
-						backendSettings.positionFixWindow ??
-						(backendSettings.trailLength ? backendSettings.trailLength[0] : 8);
 					return;
 				}
 			} catch (e) {
@@ -77,15 +69,9 @@
 				showReceiverMarkers = settings.showReceiverMarkers ?? true;
 				showAirspaceMarkers = settings.showAirspaceMarkers ?? true;
 				showRunwayOverlays = settings.showRunwayOverlays ?? false;
-				// Use positionFixWindow, or fallback to trailLength for legacy support
-				positionFixWindow =
-					settings.positionFixWindow ?? (settings.trailLength ? settings.trailLength[0] : 8);
 			} catch (e) {
 				logger.warn('Failed to load settings from localStorage: {error}', { error: e });
-				positionFixWindow = 8;
 			}
-		} else {
-			positionFixWindow = 8;
 		}
 	}
 
@@ -97,8 +83,7 @@
 			showAirportMarkers,
 			showReceiverMarkers,
 			showAirspaceMarkers,
-			showRunwayOverlays,
-			positionFixWindow
+			showRunwayOverlays
 		};
 
 		// Always save to localStorage for offline support
@@ -129,8 +114,7 @@
 				showAirportMarkers,
 				showReceiverMarkers,
 				showAirspaceMarkers,
-				showRunwayOverlays,
-				positionFixWindow
+				showRunwayOverlays
 			});
 		}
 	}
@@ -145,8 +129,7 @@
 					showAirportMarkers,
 					showReceiverMarkers,
 					showAirspaceMarkers,
-					showRunwayOverlays,
-					positionFixWindow
+					showRunwayOverlays
 				});
 			}
 		}
@@ -272,47 +255,6 @@
 							</Switch.Control>
 							<Switch.HiddenInput name="runways-toggle" />
 						</Switch>
-					</div>
-				</section>
-
-				<!-- Position Fix Window -->
-				<section>
-					<h3 class="mb-3 text-lg font-semibold">Position Fix Window</h3>
-					<p class="mb-3 text-sm text-surface-600 dark:text-surface-400">
-						Only show aircraft that have been seen within this time window
-					</p>
-					<div class="space-y-4">
-						<div class="text-sm font-medium">
-							Duration: {positionFixWindow === 0
-								? 'None'
-								: positionFixWindow < 1
-									? `${Math.round(positionFixWindow * 60)} minutes`
-									: `${positionFixWindow} hours`}
-						</div>
-						<Slider
-							value={[positionFixWindow]}
-							onValueChange={(details) => {
-								positionFixWindow = details.value[0];
-								saveSettings();
-							}}
-							min={0}
-							max={24}
-							step={1}
-						>
-							<Slider.Control>
-								<Slider.Track>
-									<Slider.Range />
-								</Slider.Track>
-								<Slider.Thumb index={0}>
-									<Slider.HiddenInput />
-								</Slider.Thumb>
-							</Slider.Control>
-						</Slider>
-						<div class="flex justify-between text-xs text-surface-500 dark:text-surface-400">
-							<span>None</span>
-							<span>12h</span>
-							<span>24h</span>
-						</div>
 					</div>
 				</section>
 

--- a/web/src/lib/services/markers/AircraftMarkerManager.ts
+++ b/web/src/lib/services/markers/AircraftMarkerManager.ts
@@ -219,9 +219,8 @@ export class AircraftMarkerManager {
 		const aircraftIcon = document.createElement('div');
 		aircraftIcon.className = 'aircraft-icon';
 
-		// Calculate color based on active status and altitude
+		// Calculate color based on active status and altitude (used for label)
 		const markerColor = getMarkerColor(fix.active, fix.altitudeMslFeet);
-		aircraftIcon.style.background = markerColor;
 
 		// Create SVG airplane icon that's more visible and oriented correctly
 		aircraftIcon.innerHTML = `
@@ -358,7 +357,6 @@ export class AircraftMarkerManager {
 			if (aircraftIcon) {
 				const track = fix.trackDegrees || 0;
 				aircraftIcon.style.transform = `rotate(${track}deg)`;
-				aircraftIcon.style.background = markerColor;
 				logger.debug('[MARKER] Updated icon rotation to: {track} degrees', { track });
 			}
 

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -54,6 +54,14 @@ export interface Point {
 	longitude: number;
 }
 
+// Lightweight path point for flight trail rendering (from RDP-compressed /path endpoint)
+export interface PathPoint {
+	latitude: number;
+	longitude: number;
+	altitudeFeet: number | null;
+	speedKnots: number | null;
+}
+
 export interface Location {
 	id: string;
 	street1?: string;

--- a/web/src/routes/operations/+page.svelte
+++ b/web/src/routes/operations/+page.svelte
@@ -126,22 +126,8 @@
 		showAirportMarkers: true,
 		showReceiverMarkers: true,
 		showAirspaceMarkers: true,
-		showRunwayOverlays: false,
-		positionFixWindow: 8
+		showRunwayOverlays: false
 	});
-
-	// Debounced update for aircraft trails
-	let updateTrailsTimeout: ReturnType<typeof setTimeout> | null = null;
-	function debouncedUpdateAircraftTrails() {
-		if (updateTrailsTimeout) {
-			clearTimeout(updateTrailsTimeout);
-		}
-		updateTrailsTimeout = setTimeout(() => {
-			if (map) {
-				aircraftMarkerManager.updateAllTrails(activeDevices);
-			}
-		}, 300); // 300ms debounce
-	}
 
 	// Handle settings changes from SettingsModal
 	function handleSettingsChange(newSettings: {
@@ -150,18 +136,9 @@
 		showReceiverMarkers: boolean;
 		showAirspaceMarkers: boolean;
 		showRunwayOverlays: boolean;
-		positionFixWindow: number;
 	}) {
-		const previousFixWindow = currentSettings.positionFixWindow;
-
 		// Replace entire object to ensure Svelte 5 reactivity triggers
 		currentSettings = { ...newSettings };
-
-		// Update aircraft trails when position fix window changes
-		if (previousFixWindow !== newSettings.positionFixWindow) {
-			aircraftMarkerManager.setPositionFixWindow(newSettings.positionFixWindow);
-			debouncedUpdateAircraftTrails();
-		}
 	}
 
 	// Handle aircraft marker click
@@ -408,7 +385,6 @@
 		airspaceOverlayManager.setMap(map);
 		runwayOverlayManager.setMap(map);
 		aircraftMarkerManager.setMap(map);
-		aircraftMarkerManager.setPositionFixWindow(currentSettings.positionFixWindow);
 		clusterMarkerManager.setMap(map);
 		viewportController.setMap(map);
 
@@ -1108,29 +1084,21 @@
 	}
 
 	:global(.aircraft-icon) {
-		background: #ef4444;
-		border: 3px solid #ffffff;
-		border-radius: 50%;
-		width: 36px;
-		height: 36px;
+		width: 24px;
+		height: 24px;
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		color: white;
-		box-shadow: 0 3px 12px rgba(0, 0, 0, 0.5);
+		color: #1e293b;
 		transition: all 0.2s ease;
 		position: relative;
 	}
 
-	:global(.aircraft-marker:hover .aircraft-icon) {
-		box-shadow: 0 6px 20px rgba(0, 0, 0, 0.7);
-		border-width: 4px;
-	}
-
 	:global(.aircraft-icon svg) {
-		width: 20px;
-		height: 20px;
-		filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
+		width: 24px;
+		height: 24px;
+		filter: drop-shadow(0 1px 1px rgba(255, 255, 255, 0.9))
+			drop-shadow(0 0 3px rgba(255, 255, 255, 0.8));
 	}
 
 	:global(.aircraft-label) {


### PR DESCRIPTION
## Summary
- Add `/data/flights/{id}/path` endpoint returning lightweight `PathPoint` data (lat, lng, altitude, speed)
- Implement Ramer-Douglas-Peucker algorithm for path compression with configurable epsilon parameter (default 50m)
- Update flight map to use compressed path for polyline rendering, full fixes for charts/details
- Remove position fix window setting from operations settings modal
- Remove colored background styling from aircraft markers

## Test plan
- [ ] Verify `/data/flights/{id}/path` endpoint returns compressed path data
- [ ] Test epsilon parameter controls compression level (higher epsilon = fewer points)
- [ ] Confirm flight map trails render correctly from compressed path
- [ ] Verify altitude chart still works with full fixes data
- [ ] Check settings modal no longer shows position fix window option
- [ ] Confirm aircraft markers have no colored background