### PR TITLE
Fix aircraft marker vertical positioning on operations map

### DIFF
--- a/web/src/lib/services/markers/AircraftMarkerManager.ts
+++ b/web/src/lib/services/markers/AircraftMarkerManager.ts
@@ -441,9 +441,14 @@ export class AircraftMarkerManager {
 			scale = 0.9 + Math.min(zoom - 12, 6) * 0.0167; // 0.9 to 1.0 max
 		}
 
-		// Apply transform to the entire marker content
-		// Use 'center top' origin so scaling preserves the aircraft icon position at the geographic coordinate
-		markerContent.style.transform = `scale(${scale})`;
+		// Apply transform to the entire marker content.
+		// The AdvancedMarkerElement positions markers with the bottom-center of the content
+		// at the geographic point. To align the aircraft ICON center with the fix point,
+		// we translate down by the distance from icon center to marker bottom (~53px).
+		// Using scale() first means translateY is in scaled coordinates, which automatically
+		// adjusts the offset proportionally at different zoom levels.
+		// Transform origin 'center top' ensures scaling keeps the icon horizontally centered.
+		markerContent.style.transform = `scale(${scale}) translateY(53px)`;
 		markerContent.style.transformOrigin = 'center top';
 	}
 

--- a/web/src/routes/operations/+page.svelte
+++ b/web/src/routes/operations/+page.svelte
@@ -1103,15 +1103,17 @@
 		align-items: center;
 		pointer-events: auto;
 		cursor: pointer;
-		/* Offset the marker so the aircraft icon center aligns with the geographic position.
-		   The icon is 24px tall (center at 12px from top). Without offset, the anchor is at
-		   the center of the entire marker (icon + label), causing misalignment with the trail. */
+		/* The AdvancedMarkerElement anchor is at the bottom-center of the content.
+		   Vertical positioning (translateY) is applied via JS in updateMarkerScale() to
+		   align the aircraft icon center with the geographic fix point. */
 		transform-origin: center top;
 		transition: all 0.2s ease;
 	}
 
 	:global(.aircraft-marker:hover) {
-		transform: scale(1.15);
+		/* Note: This may be overridden by inline styles from JS. The translateY(53px)
+		   offset must match the JS value to maintain icon-to-fix alignment on hover. */
+		transform: scale(1.15) translateY(53px);
 	}
 
 	:global(.aircraft-icon) {
@@ -1123,8 +1125,8 @@
 		color: #1e293b;
 		transition: all 0.2s ease;
 		position: relative;
-		/* Position the icon so its center is at the marker's anchor point (top of .aircraft-marker).
-		   The icon is 24px tall, so we shift it up by 12px to center it on the anchor. */
+		/* Negative margin allows the icon to overlap with content above (if any) and
+		   reduces the marker's total height for a more compact appearance. */
 		margin-top: -12px;
 	}
 


### PR DESCRIPTION
## Summary
Fixes the aircraft icon positioning on the operations page map. The center of the aircraft icon now aligns directly with the geographic fix point.

## Problem
The Google Maps `AdvancedMarkerElement` positions markers with the **bottom-center** of the content element at the geographic coordinate. Since the marker structure has the aircraft icon on top and the label below, the bottom of the label was being placed at the fix point instead of the icon center—causing aircraft to appear visually offset above their actual position.

## Solution
Added `translateY(53px)` offset to the marker transform to shift the visual content so the icon center aligns with the fix point. The 53px accounts for:
- Half icon height offset from margin: 12px
- Gap between icon and label: 6px
- Label height: ~35px

By applying `scale()` before `translateY()`, the translation is in scaled coordinates, so the offset automatically adjusts proportionally at different zoom levels.

## Test plan
- [ ] Load the operations page
- [ ] Verify aircraft icons appear centered over their trail dots
- [ ] Test at various zoom levels to confirm alignment is maintained