### PR TITLE
Consolidate aircraft position updates and simplify frontend fix handling

### DIFF
--- a/src/actions/views/aircraft.rs
+++ b/src/actions/views/aircraft.rs
@@ -151,8 +151,6 @@ pub struct AircraftView {
     /// Current fix (latest position data for this aircraft)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub current_fix: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub fixes: Option<Vec<crate::fixes::Fix>>,
 }
 
 impl AircraftView {
@@ -216,7 +214,6 @@ impl AircraftView {
             longitude: device.longitude,
             adsb_emitter_category: device.adsb_emitter_category,
             current_fix: device.current_fix,
-            fixes: None,
         }
     }
 
@@ -274,7 +271,6 @@ impl AircraftView {
             longitude: device_model.longitude,
             adsb_emitter_category: device_model.adsb_emitter_category,
             current_fix: device_model.current_fix,
-            fixes: None,
         }
     }
 }

--- a/src/fix_processor.rs
+++ b/src/fix_processor.rs
@@ -264,22 +264,11 @@ impl FixProcessor {
 
                 // Look up or create aircraft based on device_address
                 // When creating spontaneously, use address_type derived from tracker_device_type
-                // Use aircraft_for_fix to atomically update last_fix_at and cached location
-                let latitude = pos_packet.latitude.as_();
-                let longitude = pos_packet.longitude.as_();
-
                 let aircraft_lookup_start = std::time::Instant::now();
                 metrics::counter!("aprs.aircraft.stage_total", "stage" => "before_db").increment(1);
                 match self
                     .aircraft_repo
-                    .aircraft_for_fix(
-                        device_address,
-                        spontaneous_address_type,
-                        received_at,
-                        packet_fields,
-                        latitude,
-                        longitude,
-                    )
+                    .aircraft_for_fix(device_address, spontaneous_address_type, packet_fields)
                     .await
                 {
                     Ok(aircraft_model) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -801,35 +801,36 @@ async fn main() -> Result<()> {
     // Create separate filter for fmt_layer (console output)
     // Use RUST_LOG if set, otherwise default based on environment
     // Note: async_nats is set to warn to suppress "slow consumers" INFO logs during high load
+    // Note: log=warn suppresses pprof library's INFO logs during CPU profiling
     let fmt_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         if is_production {
-            EnvFilter::new("warn,hyper_util=info,rustls=info,async_nats=warn")
+            EnvFilter::new("warn,hyper_util=info,rustls=info,async_nats=warn,log=warn")
         } else if is_staging {
-            EnvFilter::new("info,hyper_util=info,rustls=info,async_nats=warn")
+            EnvFilter::new("info,hyper_util=info,rustls=info,async_nats=warn,log=warn")
         } else {
             // Development: debug by default, but suppress noisy OpenTelemetry internals
             EnvFilter::new(
-                "debug,hyper_util=info,rustls=info,async_nats=warn,opentelemetry_sdk=info,opentelemetry_otlp=info,opentelemetry_http=info",
+                "debug,hyper_util=info,rustls=info,async_nats=warn,log=warn,opentelemetry_sdk=info,opentelemetry_otlp=info,opentelemetry_http=info",
             )
         }
     });
 
     // Create filter for tokio-console layer (needs tokio=trace,runtime=trace for task visibility)
-    let console_filter = EnvFilter::new("warn,tokio=trace,runtime=trace");
+    let console_filter = EnvFilter::new("warn,tokio=trace,runtime=trace,log=warn");
 
     // Create filter for OpenTelemetry layer - exclude tokio runtime internals to prevent
     // trace bloat from waker.clone/waker.drop events being attached to every span
-    let otel_filter = EnvFilter::new("info,tokio=off,runtime=off");
+    let otel_filter = EnvFilter::new("info,tokio=off,runtime=off,log=warn");
 
     // Create filter for OpenTelemetry logs layer (Loki export)
     // - Production: info level only (no debug logs to Loki)
     // - Staging/Dev: debug for soar::* packages, info for external packages
     // This filters at the source to avoid sending logs that would be dropped anyway
     let logs_filter = if is_production {
-        EnvFilter::new("info,tokio=off,runtime=off")
+        EnvFilter::new("info,tokio=off,runtime=off,log=warn")
     } else {
         // Allow debug from soar crate, info from everything else
-        EnvFilter::new("info,soar=debug,tokio=off,runtime=off")
+        EnvFilter::new("info,soar=debug,tokio=off,runtime=off,log=warn")
     };
 
     // Helper to create logs layer - bridges tracing events to OpenTelemetry logs for Loki export

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -5,7 +5,7 @@ use std::net::SocketAddr;
 use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
-use tracing::{info, warn};
+use tracing::{info, trace, warn};
 
 static METRICS_HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
 
@@ -230,7 +230,7 @@ async fn profile_handler(
 ) -> impl IntoResponse {
     // Parse duration from query param, default to 10 seconds, max 60 seconds
     let duration_secs = params.seconds.unwrap_or(10).min(60);
-    info!("Starting CPU profiling for {} seconds", duration_secs);
+    trace!("Starting CPU profiling for {} seconds", duration_secs);
 
     // Create a profiler guard
     let guard = match pprof::ProfilerGuardBuilder::default()
@@ -272,7 +272,7 @@ async fn profile_handler(
                             Vec::new(),
                         );
                     }
-                    info!(
+                    trace!(
                         "CPU profiling completed, generated pprof ({} bytes)",
                         body.len()
                     );

--- a/web/src/lib/components/cesium/AircraftLayer.svelte
+++ b/web/src/lib/components/cesium/AircraftLayer.svelte
@@ -191,9 +191,8 @@
 					if (isAircraftItem(item)) {
 						const aircraft = item.data;
 
-						// Get latest fix from currentFix or fall back to fixes array
-						// currentFix is JsonValue, fixes array contains Fix objects
-						const latestFix = aircraft.fixes?.[0] || aircraft.currentFix;
+						// Get latest fix from currentFix (API data has currentFix, not latestFix)
+						const latestFix = aircraft.currentFix;
 
 						// Skip if no fix data available
 						if (!latestFix) continue;
@@ -430,26 +429,16 @@
 				return;
 			}
 
-			// Add fix to fixes array
-			if (aircraft.fixes) {
-				aircraft.fixes.unshift(fix);
-				// Limit to 100 fixes
-				if (aircraft.fixes.length > 100) {
-					aircraft.fixes = aircraft.fixes.slice(0, 100);
-				}
-			} else {
-				aircraft.fixes = [fix];
-			}
-
-			// Update aircraft entity
+			// Update aircraft entity with the new fix
+			// The latestFix is tracked by the AircraftRegistry
 			updateAircraftPosition(aircraft, fix);
 		} else if (event.type === 'aircraft_received') {
-			// Full aircraft data with recent fixes
+			// Full aircraft data
 			const aircraft = event.aircraft;
 			aircraftData.set(aircraft.id, aircraft);
 
-			// Update entity if aircraft has currentFix or fixes
-			const latestFix = aircraft.fixes?.[0] || aircraft.currentFix;
+			// Update entity if aircraft has currentFix
+			const latestFix = aircraft.currentFix;
 			if (latestFix) {
 				updateAircraftPosition(aircraft, latestFix as Fix);
 			}

--- a/web/src/lib/components/cesium/TimelineController.svelte
+++ b/web/src/lib/components/cesium/TimelineController.svelte
@@ -194,8 +194,7 @@
 				latitude: null,
 				longitude: null,
 				adsbEmitterCategory: null,
-				currentFix: null,
-				fixes: null
+				currentFix: null
 			},
 			fix
 		);

--- a/web/src/lib/services/markers/AircraftMarkerManager.ts
+++ b/web/src/lib/services/markers/AircraftMarkerManager.ts
@@ -1,8 +1,8 @@
 /**
- * AircraftMarkerManager - Manages aircraft markers and trails on a Google Map
+ * AircraftMarkerManager - Manages aircraft markers on a Google Map
  *
  * Handles creating, updating, and clearing aircraft markers with automatic
- * scaling based on zoom level. Also manages position trails for aircraft.
+ * scaling based on zoom level. Stores only the current fix per aircraft.
  */
 
 import { SvelteMap } from 'svelte/reactivity';
@@ -24,18 +24,11 @@ export interface AircraftMarkerManagerOptions {
 	onAircraftClick?: (aircraft: Aircraft) => void;
 }
 
-interface TrailData {
-	polylines: google.maps.Polyline[];
-	dots: google.maps.Circle[];
-}
-
 export class AircraftMarkerManager {
 	private map: google.maps.Map | null = null;
 	private markers = new SvelteMap<string, google.maps.marker.AdvancedMarkerElement>();
-	private latestFixes = new SvelteMap<string, Fix>();
-	private trails = new SvelteMap<string, TrailData>();
+	private currentFixes = new SvelteMap<string, Fix>();
 	private options: AircraftMarkerManagerOptions;
-	private positionFixWindow: number = 8; // hours
 
 	constructor(options: AircraftMarkerManagerOptions = {}) {
 		this.options = options;
@@ -56,17 +49,10 @@ export class AircraftMarkerManager {
 	}
 
 	/**
-	 * Get the latest fixes map (for external access)
+	 * Get the current fixes map (for external access)
 	 */
-	getLatestFixes(): SvelteMap<string, Fix> {
-		return this.latestFixes;
-	}
-
-	/**
-	 * Set the position fix window for trails (in hours)
-	 */
-	setPositionFixWindow(hours: number): void {
-		this.positionFixWindow = hours;
+	getCurrentFixes(): SvelteMap<string, Fix> {
+		return this.currentFixes;
 	}
 
 	/**
@@ -77,35 +63,28 @@ export class AircraftMarkerManager {
 
 		// Use currentFix if available (it's a full Fix object stored as JSONB)
 		if (aircraft.currentFix) {
-			const currentFix = aircraft.currentFix as unknown as Fix;
-			this.updateMarkerFromDevice(aircraft, currentFix);
+			const fix = aircraft.currentFix as unknown as Fix;
+			this.updateMarker(aircraft, fix);
 		} else {
-			// Fallback to using fixes array if present
-			const fixes = aircraft.fixes || [];
-			const latestFix = fixes.length > 0 ? fixes[0] : null;
-			if (latestFix) {
-				this.updateMarkerFromDevice(aircraft, latestFix);
-			} else {
-				logger.debug('[MARKER] No position data available for aircraft: {id}', {
-					id: aircraft.id
-				});
-			}
+			logger.debug('[MARKER] No position data available for aircraft: {id}', {
+				id: aircraft.id
+			});
 		}
 	}
 
 	/**
-	 * Update or create an aircraft marker from device and fix data
+	 * Update or create an aircraft marker from aircraft and fix data
 	 */
-	updateMarkerFromDevice(aircraft: Aircraft, latestFix: Fix): void {
-		logger.debug('[MARKER] updateMarkerFromDevice called: {params}', {
+	updateMarker(aircraft: Aircraft, fix: Fix): void {
+		logger.debug('[MARKER] updateMarker called: {params}', {
 			params: {
-				deviceId: aircraft.id,
+				aircraftId: aircraft.id,
 				registration: aircraft.registration,
-				latestFix: {
-					lat: latestFix.latitude,
-					lng: latestFix.longitude,
-					alt: latestFix.altitudeMslFeet,
-					timestamp: latestFix.timestamp
+				fix: {
+					lat: fix.latitude,
+					lng: fix.longitude,
+					alt: fix.altitudeMslFeet,
+					timestamp: fix.timestamp
 				},
 				mapExists: !!this.map
 			}
@@ -118,21 +97,21 @@ export class AircraftMarkerManager {
 
 		const aircraftKey = aircraft.id;
 		if (!aircraftKey) {
-			logger.warn('[MARKER] No device ID available');
+			logger.warn('[MARKER] No aircraft ID available');
 			return;
 		}
 
-		// Update latest fix for this device
-		this.latestFixes.set(aircraftKey, latestFix);
-		logger.debug('[MARKER] Updated latest fix for aircraft: {key}', { key: aircraftKey });
+		// Update current fix for this aircraft
+		this.currentFixes.set(aircraftKey, fix);
+		logger.debug('[MARKER] Updated current fix for aircraft: {key}', { key: aircraftKey });
 
 		// Get or create marker for this aircraft
 		let marker = this.markers.get(aircraftKey);
 
 		if (!marker) {
 			logger.debug('[MARKER] Creating new marker for aircraft: {key}', { key: aircraftKey });
-			// Create new aircraft marker with device info
-			marker = this.createMarker(aircraft, latestFix);
+			// Create new aircraft marker
+			marker = this.createMarker(aircraft, fix);
 			this.markers.set(aircraftKey, marker);
 			logger.debug('[MARKER] New marker created and stored. Total markers: {count}', {
 				count: this.markers.size
@@ -142,11 +121,8 @@ export class AircraftMarkerManager {
 				key: aircraftKey
 			});
 			// Update existing marker position and info
-			this.updateMarkerPosition(marker, aircraft, latestFix);
+			this.updateMarkerPosition(marker, aircraft, fix);
 		}
-
-		// Update trail for this aircraft
-		this.updateTrail(aircraft);
 	}
 
 	/**
@@ -165,16 +141,7 @@ export class AircraftMarkerManager {
 	}
 
 	/**
-	 * Update all aircraft trails (e.g., when position fix window changes)
-	 */
-	updateAllTrails(activeDevices: Aircraft[]): void {
-		activeDevices.forEach((device) => {
-			this.updateTrail(device);
-		});
-	}
-
-	/**
-	 * Clear all aircraft markers and trails
+	 * Clear all aircraft markers
 	 */
 	clear(): void {
 		logger.debug('[MARKER] Clearing all aircraft markers. Count: {count}', {
@@ -184,9 +151,8 @@ export class AircraftMarkerManager {
 			marker.map = null;
 		});
 		this.markers.clear();
-		this.latestFixes.clear();
-		this.clearAllTrails();
-		logger.debug('[MARKER] All aircraft markers and trails cleared');
+		this.currentFixes.clear();
+		logger.debug('[MARKER] All aircraft markers cleared');
 	}
 
 	/**
@@ -203,7 +169,7 @@ export class AircraftMarkerManager {
 	private createMarker(aircraft: Aircraft, fix: Fix): google.maps.marker.AdvancedMarkerElement {
 		logger.debug('[MARKER] Creating marker for aircraft: {params}', {
 			params: {
-				deviceId: aircraft.id,
+				aircraftId: aircraft.id,
 				registration: aircraft.registration,
 				address: aircraft.address,
 				position: { lat: fix.latitude, lng: fix.longitude },
@@ -240,10 +206,10 @@ export class AircraftMarkerManager {
 		infoLabel.style.background = markerColor.replace('rgb', 'rgba').replace(')', ', 0.75)');
 		infoLabel.style.borderColor = markerColor;
 
-		// Use proper device registration, fallback to address
+		// Use proper aircraft registration, fallback to address
 		const tailNumber = aircraft.registration || aircraft.address || 'Unknown';
 		const { altitudeText, isOld } = formatAltitudeWithTime(fix.altitudeMslFeet, fix.timestamp);
-		// Use aircraftModel string from device, or detailed model name if available
+		// Use aircraftModel string from aircraft
 		const aircraftModel = aircraft.aircraftModel || null;
 
 		logger.debug('[MARKER] Aircraft info: {info}', {
@@ -334,7 +300,7 @@ export class AircraftMarkerManager {
 	): void {
 		logger.debug('[MARKER] Updating existing marker position: {params}', {
 			params: {
-				deviceId: aircraft.id,
+				aircraftId: aircraft.id,
 				oldPosition: marker.position,
 				newPosition: { lat: fix.latitude, lng: fix.longitude }
 			}
@@ -366,10 +332,10 @@ export class AircraftMarkerManager {
 			}
 
 			if (tailDiv && altDiv) {
-				// Use proper device registration, fallback to address
+				// Use proper aircraft registration, fallback to address
 				const tailNumber = aircraft.registration || aircraft.address || 'Unknown';
 				const { altitudeText, isOld } = formatAltitudeWithTime(fix.altitudeMslFeet, fix.timestamp);
-				// Use aircraftModel string from device
+				// Use aircraftModel string from aircraft
 				const aircraftModel = aircraft.aircraftModel || null;
 
 				// Include aircraft model after tail number if available
@@ -445,104 +411,5 @@ export class AircraftMarkerManager {
 		// Use 'center top' origin so scaling preserves the aircraft icon position at the geographic coordinate
 		markerContent.style.transform = `scale(${scale})`;
 		markerContent.style.transformOrigin = 'center top';
-	}
-
-	/**
-	 * Update trail for an aircraft
-	 */
-	private updateTrail(aircraft: Aircraft): void {
-		if (!this.map || this.positionFixWindow === 0) {
-			// Remove trail if disabled
-			this.clearTrailForAircraft(aircraft.id);
-			return;
-		}
-
-		const fixes = aircraft.fixes || []; // Get all fixes from device
-
-		// Filter fixes to those within the position fix window
-		const cutoffTime = dayjs().subtract(this.positionFixWindow, 'hour');
-		const trailFixes = fixes.filter((fix) => dayjs(fix.timestamp).isAfter(cutoffTime));
-
-		if (trailFixes.length < 2) {
-			// Need at least 2 points to draw a trail
-			this.clearTrailForAircraft(aircraft.id);
-			return;
-		}
-
-		// Clear existing trail
-		this.clearTrailForAircraft(aircraft.id);
-
-		// Create polyline segments with progressive transparency
-		const polylines: google.maps.Polyline[] = [];
-		for (let i = 0; i < trailFixes.length - 1; i++) {
-			// Calculate opacity: newest segment (i=0) = 0.7, oldest = 0.2
-			const segmentOpacity = 0.7 - (i / (trailFixes.length - 2)) * 0.5;
-
-			// Use color based on active status and altitude from the newer fix in the segment
-			const segmentColor = getMarkerColor(trailFixes[i].active, trailFixes[i].altitudeMslFeet);
-
-			const segment = new google.maps.Polyline({
-				path: [
-					{ lat: trailFixes[i].latitude, lng: trailFixes[i].longitude },
-					{ lat: trailFixes[i + 1].latitude, lng: trailFixes[i + 1].longitude }
-				],
-				geodesic: true,
-				strokeColor: segmentColor,
-				strokeOpacity: segmentOpacity,
-				strokeWeight: 2,
-				map: this.map
-			});
-
-			polylines.push(segment);
-		}
-
-		// Create dots at each fix position
-		const dots: google.maps.Circle[] = [];
-		trailFixes.forEach((fix, index) => {
-			// Calculate opacity: newest (index 0) = 0.7, oldest = 0.2
-			const opacity = 0.7 - (index / (trailFixes.length - 1)) * 0.5;
-
-			// Use color based on active status and altitude for each dot
-			const dotColor = getMarkerColor(fix.active, fix.altitudeMslFeet);
-
-			const dot = new google.maps.Circle({
-				center: { lat: fix.latitude, lng: fix.longitude },
-				radius: 10, // 10 meters radius
-				strokeColor: dotColor,
-				strokeOpacity: opacity,
-				strokeWeight: 1,
-				fillColor: dotColor,
-				fillOpacity: opacity * 0.5,
-				map: this.map
-			});
-
-			dots.push(dot);
-		});
-
-		// Store trail data
-		this.trails.set(aircraft.id, { polylines, dots });
-	}
-
-	/**
-	 * Clear trail for a specific aircraft
-	 */
-	private clearTrailForAircraft(aircraftId: string): void {
-		const trail = this.trails.get(aircraftId);
-		if (trail) {
-			trail.polylines.forEach((polyline) => polyline.setMap(null));
-			trail.dots.forEach((dot) => dot.setMap(null));
-			this.trails.delete(aircraftId);
-		}
-	}
-
-	/**
-	 * Clear all trails
-	 */
-	private clearAllTrails(): void {
-		this.trails.forEach((trail) => {
-			trail.polylines.forEach((polyline) => polyline.setMap(null));
-			trail.dots.forEach((dot) => dot.setMap(null));
-		});
-		this.trails.clear();
 	}
 }

--- a/web/src/lib/types/generated/Aircraft.ts
+++ b/web/src/lib/types/generated/Aircraft.ts
@@ -2,7 +2,6 @@
 import type { JsonValue } from '../../../../../bindings/serde_json/JsonValue';
 import type { AdsbEmitterCategory } from './AdsbEmitterCategory';
 import type { AircraftType } from './AircraftType';
-import type { Fix } from './Fix';
 
 /**
  * Complete aircraft information with device and latest fix
@@ -51,5 +50,4 @@ export type Aircraft = {
 	 * Current fix (latest position data for this aircraft)
 	 */
 	currentFix: JsonValue | null;
-	fixes: Array<Fix> | null;
 };

--- a/web/src/lib/types/generated/AircraftView.ts
+++ b/web/src/lib/types/generated/AircraftView.ts
@@ -2,7 +2,6 @@
 import type { JsonValue } from '../../../../../bindings/serde_json/JsonValue';
 import type { AdsbEmitterCategory } from './AdsbEmitterCategory';
 import type { AircraftType } from './AircraftType';
-import type { Fix } from './Fix';
 
 export type AircraftView = {
 	id: string;
@@ -47,5 +46,4 @@ export type AircraftView = {
 	 * Current fix (latest position data for this aircraft)
 	 */
 	currentFix: JsonValue | null;
-	fixes: Array<Fix> | null;
 };

--- a/web/src/routes/ar/+page.svelte
+++ b/web/src/routes/ar/+page.svelte
@@ -18,6 +18,7 @@
 		ARScreenPosition
 	} from '$lib/ar/types';
 	import type { BulkAreaSubscriptionMessage } from '$lib/services/FixFeed';
+	import type { Fix } from '$lib/types';
 	import AircraftMarker from '$lib/components/ar/AircraftMarker.svelte';
 	import CompassOverlay from '$lib/components/ar/CompassOverlay.svelte';
 	import ARControls from '$lib/components/ar/ARControls.svelte';
@@ -128,7 +129,7 @@
 
 	// Handle aircraft registry events
 	const unsubscribeRegistry = aircraftRegistry.subscribe((event) => {
-		if (event.type === 'fix_added' || event.type === 'aircraft_updated') {
+		if (event.type === 'fix_received' || event.type === 'aircraft_updated') {
 			updateAircraftProjections();
 		}
 	});
@@ -173,7 +174,7 @@
 		>();
 
 		for (const aircraft of allAircraft) {
-			const currentFix = aircraft.fixes?.[0];
+			const currentFix = aircraft.currentFix as Fix | null;
 			if (!currentFix) continue;
 
 			const arPosition = fixToARPosition(currentFix, userPosition, aircraft.registration);

--- a/web/src/routes/operations/+page.svelte
+++ b/web/src/routes/operations/+page.svelte
@@ -262,14 +262,14 @@
 				if (map) {
 					aircraftMarkerManager.updateMarkerFromAircraft(event.aircraft);
 				}
-			} else if (event.type === 'fix_added') {
-				logger.debug('Fix added to aircraft: {aircraftId} {fix}', {
+			} else if (event.type === 'fix_received') {
+				logger.debug('Fix received for aircraft: {aircraftId} {fix}', {
 					aircraftId: event.aircraft.id,
 					fix: event.fix
 				});
-				// Update the aircraft marker immediately when a new fix is added
+				// Update the aircraft marker immediately when a new fix is received
 				if (map && event.fix) {
-					aircraftMarkerManager.updateMarkerFromDevice(event.aircraft, event.fix);
+					aircraftMarkerManager.updateMarker(event.aircraft, event.fix);
 				}
 			}
 		});


### PR DESCRIPTION
## Summary
- Consolidate aircraft position updates (latitude, longitude, last_fix_at) into fixes_repo.insert() for consistency across all data sources (APRS, Beast, SBS)
- Simplify frontend AircraftRegistry to use aircraft.currentFix instead of storing separate fixes arrays - no more trail storage on frontend
- Rename latestFix to currentFix throughout codebase for consistency

## Test plan
- [ ] Verify aircraft markers appear on operations page map
- [ ] Verify aircraft positions update in real-time via WebSocket
- [ ] Verify AR mode shows aircraft with correct positions
- [ ] Verify Cesium globe shows aircraft with correct positions