### PR TITLE
Improve aircraft markers and fix status modal position display

### DIFF
--- a/web/src/lib/services/markers/AircraftMarkerManager.ts
+++ b/web/src/lib/services/markers/AircraftMarkerManager.ts
@@ -185,12 +185,13 @@ export class AircraftMarkerManager {
 		const aircraftIcon = document.createElement('div');
 		aircraftIcon.className = 'aircraft-icon';
 
-		// Calculate color based on active status and altitude (used for label)
+		// Calculate color based on active status and altitude (used for icon and label)
 		const markerColor = getMarkerColor(fix.active, fix.altitudeMslFeet);
 
 		// Create SVG airplane icon that's more visible and oriented correctly
+		// Icon is doubled in size (48x48) and colored to match the label
 		aircraftIcon.innerHTML = `
-			<svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+			<svg width="48" height="48" viewBox="0 0 24 24" fill="${markerColor}">
 				<path d="M21 16v-2l-8-5V3.5c0-.83-.67-1.5-1.5-1.5S10 2.67 10 3.5V9l-8 5v2l8-2.5V19l-2 1.5V22l3.5-1 3.5 1v-1.5L13 19v-5.5l8 2.5z"/>
 			</svg>
 		`;
@@ -323,6 +324,11 @@ export class AircraftMarkerManager {
 			if (aircraftIcon) {
 				const track = fix.trackDegrees || 0;
 				aircraftIcon.style.transform = `rotate(${track}deg)`;
+				// Update icon color to match label
+				const svgElement = aircraftIcon.querySelector('svg');
+				if (svgElement) {
+					svgElement.setAttribute('fill', markerColor);
+				}
 				logger.debug('[MARKER] Updated icon rotation to: {track} degrees', { track });
 			}
 
@@ -410,11 +416,11 @@ export class AircraftMarkerManager {
 		// Apply transform to the entire marker content.
 		// The AdvancedMarkerElement positions markers with the bottom-center of the content
 		// at the geographic point. To align the aircraft ICON center with the fix point,
-		// we translate down by the distance from icon center to marker bottom (~53px).
+		// we translate down by the distance from icon center to marker bottom (~77px).
 		// Using scale() first means translateY is in scaled coordinates, which automatically
 		// adjusts the offset proportionally at different zoom levels.
 		// Transform origin 'center top' ensures scaling keeps the icon horizontally centered.
-		markerContent.style.transform = `scale(${scale}) translateY(53px)`;
+		markerContent.style.transform = `scale(${scale}) translateY(77px)`;
 		markerContent.style.transformOrigin = 'center top';
 	}
 }


### PR DESCRIPTION
## Summary
- Fix current position section in aircraft status modal (was blank due to using non-existent `fixes` array instead of `currentFix`)
- Make aircraft icons same color as labels (altitude-based red→blue gradient)
- Double icon size (24px → 48px) and increase label text size (12px → 16px for tail, 10px → 14px for altitude)
- Add debug panel on staging showing viewport bounds, area in sq miles, aircraft count, and zoom level
- Hide aircraft labels when viewport > 100,000 sq mi for better performance at wide zoom levels
- Add ICAO model code to aircraft information section in status modal

## Test plan
- [ ] Open operations page and verify aircraft icons are colored (red=low altitude, blue=high)
- [ ] Verify icons and labels are larger and more readable
- [ ] Click on an aircraft marker and verify "Current Position" section shows data
- [ ] On staging.glider.flights, verify debug panel appears in upper-right
- [ ] Zoom out significantly and verify labels hide but icons remain visible
- [ ] In status modal, verify ICAO model code appears in parentheses when available