### PR TITLE
Add debug format to raw message endpoint and fix message source types

### DIFF
--- a/migrations/2026-01-19-000000-0000_fix_message_source_enum/down.sql
+++ b/migrations/2026-01-19-000000-0000_fix_message_source_enum/down.sql
@@ -1,0 +1,35 @@
+-- Revert message_source enum: aprs->ogn, beast->adsb, remove sbs
+
+-- Step 1: Create old enum type (without sbs)
+CREATE TYPE message_source_old AS ENUM ('ogn', 'adsb');
+
+-- Step 2: Add temporary column with old enum type
+ALTER TABLE raw_messages ADD COLUMN source_old message_source_old;
+
+-- Step 3: Migrate data back from new enum to old enum
+-- Note: Any 'sbs' rows will be converted to 'adsb' (data loss)
+UPDATE raw_messages
+SET source_old = CASE
+    WHEN source = 'aprs' THEN 'ogn'::message_source_old
+    WHEN source = 'beast' THEN 'adsb'::message_source_old
+    WHEN source = 'sbs' THEN 'adsb'::message_source_old
+END;
+
+-- Step 4: Make old column NOT NULL
+ALTER TABLE raw_messages ALTER COLUMN source_old SET NOT NULL;
+
+-- Step 5: Drop new column and enum
+ALTER TABLE raw_messages DROP COLUMN source;
+DROP TYPE message_source;
+
+-- Step 6: Rename old column and enum back
+ALTER TABLE raw_messages RENAME COLUMN source_old TO source;
+ALTER TYPE message_source_old RENAME TO message_source;
+
+-- Step 7: Set default back to 'ogn'
+ALTER TABLE raw_messages ALTER COLUMN source SET DEFAULT 'ogn'::message_source;
+
+-- Step 8: Recreate index on source column
+CREATE INDEX idx_raw_messages_source ON raw_messages (source);
+
+COMMENT ON COLUMN raw_messages.source IS 'Protocol source: ogn or adsb';

--- a/migrations/2026-01-19-000000-0000_fix_message_source_enum/up.sql
+++ b/migrations/2026-01-19-000000-0000_fix_message_source_enum/up.sql
@@ -1,0 +1,38 @@
+-- Fix message_source enum: rename ogn->aprs, adsb->beast, and add sbs
+--
+-- The previous migration incorrectly renamed the values. This migration:
+-- - Renames 'ogn' back to 'aprs' (OGN uses APRS protocol)
+-- - Renames 'adsb' to 'beast' (Beast is the binary protocol format)
+-- - Adds 'sbs' (SBS-1 BaseStation CSV format)
+
+-- Step 1: Create new enum type with correct values
+CREATE TYPE message_source_new AS ENUM ('aprs', 'beast', 'sbs');
+
+-- Step 2: Add temporary column with new enum type
+ALTER TABLE raw_messages ADD COLUMN source_new message_source_new;
+
+-- Step 3: Migrate data from old enum to new enum
+UPDATE raw_messages
+SET source_new = CASE
+    WHEN source = 'ogn' THEN 'aprs'::message_source_new
+    WHEN source = 'adsb' THEN 'beast'::message_source_new
+END;
+
+-- Step 4: Make new column NOT NULL
+ALTER TABLE raw_messages ALTER COLUMN source_new SET NOT NULL;
+
+-- Step 5: Drop old column and enum
+ALTER TABLE raw_messages DROP COLUMN source;
+DROP TYPE message_source;
+
+-- Step 6: Rename new column and enum to original names
+ALTER TABLE raw_messages RENAME COLUMN source_new TO source;
+ALTER TYPE message_source_new RENAME TO message_source;
+
+-- Step 7: Set default for new rows to 'aprs' (most common)
+ALTER TABLE raw_messages ALTER COLUMN source SET DEFAULT 'aprs'::message_source;
+
+-- Step 8: Recreate index on source column
+CREATE INDEX idx_raw_messages_source ON raw_messages (source);
+
+COMMENT ON COLUMN raw_messages.source IS 'Protocol source: aprs (APRS/OGN text), beast (ADS-B Beast binary), or sbs (SBS-1 BaseStation CSV)';

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -14,7 +14,7 @@ use soar::packet_processors::{
     AircraftPositionProcessor, GenericProcessor, PacketRouter, ReceiverPositionProcessor,
     ReceiverStatusProcessor, ServerStatusProcessor,
 };
-use soar::raw_messages_repo::{NewBeastMessage, RawMessagesRepository};
+use soar::raw_messages_repo::{NewBeastMessage, NewSbsMessage, RawMessagesRepository};
 use soar::receiver_repo::ReceiverRepository;
 use soar::receiver_status_repo::ReceiverStatusRepository;
 use soar::server_messages_repo::ServerMessagesRepository;
@@ -403,10 +403,9 @@ async fn process_sbs_message(
         }
     };
 
-    // Store raw SBS message in database (stored as UTF-8 bytes with 'adsb' source)
-    // SBS and Beast are both ADS-B data, just different wire formats
+    // Store raw SBS message in database (stored as UTF-8 bytes with 'sbs' source)
     let raw_message_id = match sbs_repo
-        .insert_beast(NewBeastMessage::new(
+        .insert_sbs(NewSbsMessage::new(
             csv_bytes.to_vec(),
             received_at,
             None, // receiver_id - SBS has no receiver concept

--- a/web/src/lib/components/FixesList.svelte
+++ b/web/src/lib/components/FixesList.svelte
@@ -86,7 +86,8 @@
 		content?: string;
 		loading: boolean;
 		error?: string;
-		source?: 'aprs' | 'adsb';
+		source?: 'aprs' | 'beast' | 'sbs';
+		debugFormat?: string;
 	} {
 		const cached = rawMessagesCache.get(rawMessageId);
 		if (!cached) {
@@ -96,7 +97,8 @@
 			content: cached.data?.rawMessage,
 			loading: cached.loading,
 			error: cached.error,
-			source: cached.data?.source
+			source: cached.data?.source,
+			debugFormat: cached.data?.debugFormat
 		};
 	}
 
@@ -340,7 +342,12 @@
 										<span class="text-surface-400" title="Source: {rawDisplay.source}">
 											[{rawDisplay.source?.toUpperCase()}]
 										</span>
-										{rawDisplay.content}
+										{#if rawDisplay.debugFormat}
+											<pre class="mt-1 text-xs whitespace-pre-wrap">{rawDisplay.content}
+{rawDisplay.debugFormat}</pre>
+										{:else}
+											{rawDisplay.content}
+										{/if}
 									{:else}
 										<span class="text-surface-400">No raw message available</span>
 									{/if}
@@ -433,7 +440,13 @@
 							{:else if rawDisplay.error}
 								<div class="text-xs text-error-500">Error: {rawDisplay.error}</div>
 							{:else if rawDisplay.content}
-								<div class="overflow-x-auto font-mono text-xs">{rawDisplay.content}</div>
+								{#if rawDisplay.debugFormat}
+									<pre
+										class="overflow-x-auto font-mono text-xs whitespace-pre-wrap">{rawDisplay.content}
+{rawDisplay.debugFormat}</pre>
+								{:else}
+									<div class="overflow-x-auto font-mono text-xs">{rawDisplay.content}</div>
+								{/if}
 							{:else}
 								<div class="text-xs text-surface-400">No raw message available</div>
 							{/if}

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -211,10 +211,11 @@ export interface FixWithExtras extends Fix {
 // Raw message response from /data/raw-messages/{id} endpoint
 export interface RawMessageResponse {
 	id: string;
-	rawMessage: string; // UTF-8 for APRS, hex-encoded for ADS-B
-	source: 'aprs' | 'adsb';
+	rawMessage: string; // UTF-8 for APRS/SBS, hex-encoded for Beast
+	source: 'aprs' | 'beast' | 'sbs';
 	receivedAt: string;
 	receiverId: string | null;
+	debugFormat?: string; // Pretty-printed Rust debug format of parsed message
 }
 
 // User authentication and profile (now includes pilot fields)

--- a/web/src/routes/receivers/[id]/+page.svelte
+++ b/web/src/routes/receivers/[id]/+page.svelte
@@ -168,7 +168,7 @@
 		content?: string;
 		loading: boolean;
 		error?: string;
-		source?: 'aprs' | 'adsb';
+		source?: 'aprs' | 'beast' | 'sbs';
 	} {
 		const cached = fixRawMessagesCache.get(rawMessageId);
 		if (!cached) {


### PR DESCRIPTION
## Summary
- Add pretty-printed Rust debug format output to `/data/raw-messages/:id` endpoint
- Fix `message_source` enum values: rename `ogn`→`aprs`, `adsb`→`beast`, add `sbs`
- All message types (APRS, Beast, SBS) now return parsed debug format along with raw message

## Changes
- **Database migration**: Fixes enum values to properly distinguish wire formats (Beast binary, SBS CSV) from protocols (ADS-B)
- **Backend**: Added `NewSbsMessage` struct and `insert_sbs()` method for proper SBS message storage
- **API response**: `debugFormat` field shows pretty-printed Rust debug output of parsed message
- **Frontend**: `FixesList` component displays raw message + debug format in `<pre>` element

## Test plan
- [x] SBS parser tests pass (9 tests)
- [x] Rust compilation passes
- [x] Frontend linting passes
- [ ] Verify APRS messages show parsed `AprsPacket` debug output
- [ ] Verify Beast messages show decoded `rs1090::Message` debug output
- [ ] Verify SBS messages show parsed `SbsMessage` debug output