### PR TITLE
Add debug format to raw message endpoint and fix message source types

### DIFF
--- a/migrations/2026-01-19-000000-0000_fix_message_source_enum/down.sql
+++ b/migrations/2026-01-19-000000-0000_fix_message_source_enum/down.sql
@@ -1,35 +1,20 @@
 -- Revert message_source enum: aprs->ogn, beast->adsb, remove sbs
+--
+-- WARNING: This down migration cannot remove the 'sbs' enum value because
+-- PostgreSQL does not support DROP VALUE from enums. The 'sbs' value will
+-- remain in the enum but should not be used after rollback.
+--
+-- If there are any rows with source='sbs', this migration will fail.
+-- You must first update or delete those rows before rolling back.
 
--- Step 1: Create old enum type (without sbs)
-CREATE TYPE message_source_old AS ENUM ('ogn', 'adsb');
+-- Rename values back (instant - metadata only)
+ALTER TYPE message_source RENAME VALUE 'aprs' TO 'ogn';
+ALTER TYPE message_source RENAME VALUE 'beast' TO 'adsb';
 
--- Step 2: Add temporary column with old enum type
-ALTER TABLE raw_messages ADD COLUMN source_old message_source_old;
+-- Note: Cannot remove 'sbs' from enum - PostgreSQL limitation
+-- The value will remain but be unused
 
--- Step 3: Migrate data back from new enum to old enum
--- Note: Any 'sbs' rows will be converted to 'adsb' (data loss)
-UPDATE raw_messages
-SET source_old = CASE
-    WHEN source = 'aprs' THEN 'ogn'::message_source_old
-    WHEN source = 'beast' THEN 'adsb'::message_source_old
-    WHEN source = 'sbs' THEN 'adsb'::message_source_old
-END;
-
--- Step 4: Make old column NOT NULL
-ALTER TABLE raw_messages ALTER COLUMN source_old SET NOT NULL;
-
--- Step 5: Drop new column and enum
-ALTER TABLE raw_messages DROP COLUMN source;
-DROP TYPE message_source;
-
--- Step 6: Rename old column and enum back
-ALTER TABLE raw_messages RENAME COLUMN source_old TO source;
-ALTER TYPE message_source_old RENAME TO message_source;
-
--- Step 7: Set default back to 'ogn'
+-- Update default back
 ALTER TABLE raw_messages ALTER COLUMN source SET DEFAULT 'ogn'::message_source;
-
--- Step 8: Recreate index on source column
-CREATE INDEX idx_raw_messages_source ON raw_messages (source);
 
 COMMENT ON COLUMN raw_messages.source IS 'Protocol source: ogn or adsb';

--- a/migrations/2026-01-19-000000-0000_fix_message_source_enum/up.sql
+++ b/migrations/2026-01-19-000000-0000_fix_message_source_enum/up.sql
@@ -4,35 +4,18 @@
 -- - Renames 'ogn' back to 'aprs' (OGN uses APRS protocol)
 -- - Renames 'adsb' to 'beast' (Beast is the binary protocol format)
 -- - Adds 'sbs' (SBS-1 BaseStation CSV format)
+--
+-- Using ALTER TYPE ... RENAME VALUE (PostgreSQL 10+) for instant metadata-only changes.
+-- No data migration needed - this is O(1) regardless of table size.
 
--- Step 1: Create new enum type with correct values
-CREATE TYPE message_source_new AS ENUM ('aprs', 'beast', 'sbs');
+-- Rename existing values (instant - metadata only)
+ALTER TYPE message_source RENAME VALUE 'ogn' TO 'aprs';
+ALTER TYPE message_source RENAME VALUE 'adsb' TO 'beast';
 
--- Step 2: Add temporary column with new enum type
-ALTER TABLE raw_messages ADD COLUMN source_new message_source_new;
+-- Add new value (instant - metadata only)
+ALTER TYPE message_source ADD VALUE 'sbs';
 
--- Step 3: Migrate data from old enum to new enum
-UPDATE raw_messages
-SET source_new = CASE
-    WHEN source = 'ogn' THEN 'aprs'::message_source_new
-    WHEN source = 'adsb' THEN 'beast'::message_source_new
-END;
-
--- Step 4: Make new column NOT NULL
-ALTER TABLE raw_messages ALTER COLUMN source_new SET NOT NULL;
-
--- Step 5: Drop old column and enum
-ALTER TABLE raw_messages DROP COLUMN source;
-DROP TYPE message_source;
-
--- Step 6: Rename new column and enum to original names
-ALTER TABLE raw_messages RENAME COLUMN source_new TO source;
-ALTER TYPE message_source_new RENAME TO message_source;
-
--- Step 7: Set default for new rows to 'aprs' (most common)
+-- Update default for new rows
 ALTER TABLE raw_messages ALTER COLUMN source SET DEFAULT 'aprs'::message_source;
-
--- Step 8: Recreate index on source column
-CREATE INDEX idx_raw_messages_source ON raw_messages (source);
 
 COMMENT ON COLUMN raw_messages.source IS 'Protocol source: aprs (APRS/OGN text), beast (ADS-B Beast binary), or sbs (SBS-1 BaseStation CSV)';

--- a/src/raw_messages_repo.rs
+++ b/src/raw_messages_repo.rs
@@ -147,14 +147,20 @@ pub struct NewSbsMessage {
     pub id: Uuid,
     pub raw_message: Vec<u8>, // UTF-8 encoded SBS CSV line
     pub received_at: DateTime<Utc>,
-    pub receiver_id: Option<Uuid>, // NULL for SBS - no receiver concept
+    pub receiver_id: Option<Uuid>, // Should always be None for SBS (no receiver concept in SBS protocol)
     pub unparsed: Option<String>,
     pub raw_message_hash: Vec<u8>,
 }
 
 impl NewSbsMessage {
-    /// Create a new SBS message with computed hash
-    /// receiver_id should be None for SBS messages (no receiver concept)
+    /// Create a new SBS message with computed hash.
+    ///
+    /// # Arguments
+    /// * `raw_message` - UTF-8 encoded SBS CSV line
+    /// * `received_at` - Timestamp when the message was received
+    /// * `receiver_id` - Should be `None` for SBS messages since the SBS-1 BaseStation
+    ///   protocol doesn't have a receiver concept (unlike APRS which has receiver callsigns)
+    /// * `unparsed` - Optional unparsed portion of the message
     pub fn new(
         raw_message: Vec<u8>, // UTF-8 encoded SBS CSV line
         received_at: DateTime<Utc>,

--- a/web/src/lib/components/FixesList.svelte
+++ b/web/src/lib/components/FixesList.svelte
@@ -344,6 +344,7 @@
 										</span>
 										{#if rawDisplay.debugFormat}
 											<pre class="mt-1 text-xs whitespace-pre-wrap">{rawDisplay.content}
+─── Parsed ───
 {rawDisplay.debugFormat}</pre>
 										{:else}
 											{rawDisplay.content}
@@ -443,6 +444,7 @@
 								{#if rawDisplay.debugFormat}
 									<pre
 										class="overflow-x-auto font-mono text-xs whitespace-pre-wrap">{rawDisplay.content}
+─── Parsed ───
 {rawDisplay.debugFormat}</pre>
 								{:else}
 									<div class="overflow-x-auto font-mono text-xs">{rawDisplay.content}</div>


### PR DESCRIPTION
## Summary
- Add pretty-printed Rust debug format output to /data/raw-messages/:id endpoint
- Fix message_source enum: rename ogn->aprs, adsb->beast, add sbs
- APRS messages show parsed AprsPacket debug output
- Beast messages show decoded rs1090::Message debug output
- SBS messages show parsed SbsMessage debug output
- Add NewSbsMessage struct and insert_sbs() method for proper SBS storage
- Update frontend FixesList to display debug format in <pre> element
- Update TypeScript types to reflect new source values

## Migration Performance Fix
**IMPORTANT**: The enum migration now uses `ALTER TYPE ... RENAME VALUE` and `ALTER TYPE ... ADD VALUE` instead of recreating the enum and migrating all data. This is an O(1) metadata-only operation that completes instantly regardless of table size (~348M rows in raw_messages).

## Test plan
- [ ] Verify migration runs instantly on staging
- [ ] Verify raw message endpoint returns debug format
- [ ] Verify frontend displays debug output correctly