### PR TITLE
Add firehose ingest service and fix Prometheus metrics

### DIFF
--- a/infrastructure/prometheus.yml
+++ b/infrastructure/prometheus.yml
@@ -1,32 +1,66 @@
 # Prometheus configuration for SOAR metrics scraping
+# Uses static_configs (Prometheus 2.31 compatible)
 #
-# This file uses scrape_config_files to load complete scrape job configurations.
-# This allows you to manage SOAR service scrape jobs in separate files.
-#
-# To use this configuration:
-# 1. Copy infrastructure/prometheus-jobs/*.yml to /etc/prometheus/jobs/
-# 2. That's it! Prometheus will automatically load all .yml files from that directory
+# NOTE: scrape_config_files requires Prometheus 2.43+
+# When the server is upgraded, we can use infrastructure/prometheus-jobs/*.yml instead
 
 global:
-  scrape_interval: 15s      # Default scrape interval (can be overridden per job)
-  evaluation_interval: 15s  # Evaluate rules every 15 seconds
+  scrape_interval: 15s
+  evaluation_interval: 15s
 
-  # Attach these labels to all metrics scraped by this Prometheus instance
-  external_labels:
-    environment: 'production'
-    service: 'soar'
+scrape_configs:
+  - job_name: 'prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:9090']
 
-# Load all scrape job configurations from separate files
-scrape_config_files:
-  - '/etc/prometheus/jobs/*.yml'
+  - job_name: 'node'
+    static_configs:
+      - targets: ['localhost:9100']
 
-# Alerting configuration (optional)
-# alerting:
-#   alertmanagers:
-#     - static_configs:
-#         - targets:
-#             - 'localhost:9093'
+  - job_name: 'nats-jetstream'
+    metrics_path: '/metrics'
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['localhost:7777']
+        labels:
+          instance: 'soar'
+          component: 'nats-jetstream'
 
-# Rule files for alerting (optional)
-# rule_files:
-#   - 'rules/*.yml'
+  # SOAR Ingest (Staging) - NO metric_relabel_configs to preserve source labels
+  - job_name: 'soar-ingest-staging'
+    metrics_path: '/metrics'
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['localhost:9197']
+        labels:
+          instance: 'soar-staging'
+          component: 'ingest'
+          environment: 'staging'
+
+  # SOAR Run (Staging)
+  - job_name: 'soar-run-staging'
+    metrics_path: '/metrics'
+    scrape_interval: 1s
+    static_configs:
+      - targets: ['localhost:9192']
+        labels:
+          instance: 'soar-staging'
+          component: 'run'
+          environment: 'staging'
+
+  # SOAR Web (Staging)
+  - job_name: 'soar-web-staging'
+    metrics_path: '/data/metrics'
+    scrape_interval: 10s
+    static_configs:
+      - targets: ['localhost:61226']
+        labels:
+          instance: 'soar-web-staging'
+          component: 'web'
+          environment: 'staging'
+
+  # Production jobs (add when deploying to production)
+  # - job_name: 'soar-ingest'
+  # - job_name: 'soar-run'
+  # - job_name: 'soar-web'

--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -165,8 +165,15 @@ ACTIVE_SERVICES=(
 
 # Manually-deployed services (installed but not automatically started)
 # These services change infrequently and are deployed via the regular deployment process
-MANUAL_SERVICES=(
-)
+# The firehose service is staging-only and uses a fixed name (not ${SERVICE_SUFFIX})
+if [ "$ENVIRONMENT" = "staging" ]; then
+    MANUAL_SERVICES=(
+        "soar-ingest-firehose-staging.service"
+    )
+else
+    MANUAL_SERVICES=(
+    )
+fi
 
 # Timer-invoked services (only installed, not enabled or started)
 # Skip backup services for staging environment

--- a/infrastructure/systemd/soar-ingest-firehose-staging.service
+++ b/infrastructure/systemd/soar-ingest-firehose-staging.service
@@ -1,0 +1,49 @@
+[Unit]
+Description=SOAR Firehose Ingest (Staging) - ADSB.lol Firehose ADS-B Service
+Documentation=https://github.com/hut8/soar
+After=network-online.target
+Wants=network-online.target
+# This service ingests ADS-B data via Beast protocol from ADSB.lol firehose
+# Uses persistent queues to buffer messages when soar-run is unavailable
+# MANUAL SERVICE: Not enabled by default, start manually when needed
+# When started, this service will stop soar-ingest-staging.service
+Conflicts=soar-ingest-staging.service
+
+[Service]
+Type=simple
+User=soar
+Group=soar
+WorkingDirectory=/var/lib/soar
+SyslogIdentifier=soar-ingest-firehose-staging
+# Firehose configuration - connects to ADSB.lol firehose proxy on port 41365
+ExecStart=/usr/local/bin/soar-staging ingest --beast radar:41365
+ExecReload=/bin/kill -s HUP $MAINPID
+
+# Environment variables (staging environment)
+EnvironmentFile=/etc/soar/env-staging
+
+# Security settings
+NoNewPrivileges=yes
+
+# Graceful shutdown configuration
+# Allow 30 seconds for graceful shutdown (queue flush + connection cleanup)
+TimeoutStopSec=30
+# Send SIGTERM first, then SIGKILL after timeout
+KillMode=mixed
+KillSignal=SIGTERM
+
+# Restart configuration
+# Restart aggressively to minimize message loss during failures
+Restart=on-failure
+RestartSec=2
+StartLimitInterval=60s
+StartLimitBurst=5
+
+# Process limits
+LimitNOFILE=65536
+# Memory limit for firehose ingestion (may need more due to higher volume)
+MemoryMax=6G
+
+[Install]
+# Not enabled by default - start manually with: systemctl start soar-ingest-firehose-staging.service
+WantedBy=multi-user.target

--- a/infrastructure/systemd/soar-ingest.service
+++ b/infrastructure/systemd/soar-ingest.service
@@ -19,7 +19,7 @@ SyslogIdentifier=soar-ingest
 # - Add --ogn-server, --ogn-port, --ogn-callsign, --ogn-filter for OGN/APRS ingestion
 # - Add --beast <server:port> for Beast format ADS-B (can specify multiple times)
 # - Add --sbs <server:port> for SBS (BaseStation) format (can specify multiple times)
-ExecStart=/usr/local/bin/soar ingest --ogn-server aprs.glidernet.org
+ExecStart=/usr/local/bin/soar ingest --ogn-server aprs.glidernet.org --beast radar:30005
 ExecReload=/bin/kill -s HUP $MAINPID
 
 # Environment variables


### PR DESCRIPTION
## Summary

- Add `soar-ingest-firehose-staging.service` for ADSB.lol firehose ingestion (port 41365)
- Add `--beast radar:30005` to production `soar-ingest.service` for combined APRS + Beast ingestion
- Fix Prometheus config to preserve per-source metrics labels

## Details

### Firehose Service (Staging)
- Connects to radar:41365 (ADSB.lol firehose proxy)
- Uses `Conflicts=soar-ingest-staging.service` to stop regular ingest when started
- Deployed by soar-deploy but **not enabled by default** (manual start only)
- Higher memory limit (6G vs 4G) for increased data volume

### Production Ingest
- Now ingests both OGN/APRS and Beast ADS-B data

### Prometheus Fix
- Removed `metric_relabel_configs` that was overwriting `source` labels
- Previously all sources (Beast/OGN/SBS) were relabeled to `soar-aprs-ingest`
- This caused the "Disk Queue Size by Source" dashboard to show a sawtooth pattern
- Now correctly shows separate time series per source
- Uses `static_configs` (compatible with Prometheus 2.31)

## Test plan

- [x] Verified Prometheus metrics now show correct `source` labels (Beast, OGN, SBS)
- [x] Verified sawtooth pattern is gone in dashboard
- [ ] Manual test: start firehose service, verify it stops regular ingest