### PR TITLE
Improve coverage map and operations page

### DIFF
--- a/src/commands/run_aggregates.rs
+++ b/src/commands/run_aggregates.rs
@@ -218,6 +218,7 @@ async fn fetch_and_aggregate_fixes(
         // Use h3_latlng_to_cell() PostgreSQL function for efficient H3 conversion
         // All aggregation happens in the database - WAY faster than fetching + processing in Rust
         // Note: ST_MakePoint takes (longitude, latitude) in PostGIS (x, y order)
+        // Only include OGN/APRS fixes (those with receiver_id) - exclude ADS-B/Beast/SBS
         let coverage_data: Vec<AggregatedCoverage> = diesel::sql_query(
             r#"
             SELECT
@@ -234,6 +235,7 @@ async fn fetch_and_aggregate_fixes(
             WHERE received_at >= $1 AND received_at < $2
               AND latitude IS NOT NULL
               AND longitude IS NOT NULL
+              AND receiver_id IS NOT NULL
             GROUP BY h3_index, receiver_id, date
             ORDER BY h3_index, receiver_id, date
             "#,

--- a/src/fixes.rs
+++ b/src/fixes.rs
@@ -86,19 +86,6 @@ pub struct FixWithAircraftInfo {
     pub aircraft: Option<crate::actions::views::AircraftView>,
 }
 
-/// Extended Fix struct that includes flight metadata for WebSocket streaming
-/// Used when streaming fixes to include current flight information
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct FixWithFlightInfo {
-    #[serde(flatten)]
-    pub fix: Fix,
-
-    /// Current flight information (if fix is part of an active flight)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub flight: Option<crate::flights::Flight>,
-}
-
 impl FixWithAircraftInfo {
     /// Create a FixWithAircraftInfo from a Fix and aircraft information
     pub fn new(fix: Fix, aircraft: Option<crate::actions::views::AircraftView>) -> Self {
@@ -115,27 +102,6 @@ impl std::ops::Deref for FixWithAircraftInfo {
 }
 
 impl std::ops::DerefMut for FixWithAircraftInfo {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.fix
-    }
-}
-
-impl FixWithFlightInfo {
-    /// Create a FixWithFlightInfo from a Fix and optional Flight
-    pub fn new(fix: Fix, flight: Option<crate::flights::Flight>) -> Self {
-        Self { fix, flight }
-    }
-}
-
-impl std::ops::Deref for FixWithFlightInfo {
-    type Target = Fix;
-
-    fn deref(&self) -> &Self::Target {
-        &self.fix
-    }
-}
-
-impl std::ops::DerefMut for FixWithFlightInfo {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.fix
     }

--- a/src/live_fixes.rs
+++ b/src/live_fixes.rs
@@ -36,7 +36,7 @@ use crate::actions::views::Aircraft;
 #[serde(tag = "type")]
 pub enum WebSocketMessage {
     #[serde(rename = "fix")]
-    Fix(Box<crate::fixes::FixWithFlightInfo>),
+    Fix(Box<crate::fixes::Fix>),
 
     #[serde(rename = "aircraft")]
     Aircraft(Box<Aircraft>),
@@ -282,41 +282,39 @@ impl LiveFixService {
     async fn process_fix_message(
         msg: async_nats::Message,
         expected_device_id: &str,
-    ) -> Result<crate::fixes::FixWithFlightInfo> {
-        // Parse the full FixWithFlightInfo data from NATS
-        let fix_with_flight: crate::fixes::FixWithFlightInfo =
-            serde_json::from_slice(&msg.payload)?;
+    ) -> Result<crate::fixes::Fix> {
+        // Parse the Fix data from NATS
+        let fix: crate::fixes::Fix = serde_json::from_slice(&msg.payload)?;
 
         info!(
             "Processing live fix for device {} at ({}, {}) alt={}ft",
             expected_device_id,
-            fix_with_flight.latitude,
-            fix_with_flight.longitude,
-            fix_with_flight.altitude_msl_feet.unwrap_or(0)
+            fix.latitude,
+            fix.longitude,
+            fix.altitude_msl_feet.unwrap_or(0)
         );
 
-        Ok(fix_with_flight)
+        Ok(fix)
     }
 
     // Process a single fix message from area subscription
     async fn process_area_fix_message(
         msg: async_nats::Message,
         area_key: &str,
-    ) -> Result<crate::fixes::FixWithFlightInfo> {
-        // Parse the full FixWithFlightInfo data from NATS
-        let fix_with_flight: crate::fixes::FixWithFlightInfo =
-            serde_json::from_slice(&msg.payload)?;
+    ) -> Result<crate::fixes::Fix> {
+        // Parse the Fix data from NATS
+        let fix: crate::fixes::Fix = serde_json::from_slice(&msg.payload)?;
 
         info!(
             "Processing live fix from area {} for device {} at ({}, {}) alt={}ft",
             area_key,
-            fix_with_flight.aircraft_id,
-            fix_with_flight.latitude,
-            fix_with_flight.longitude,
-            fix_with_flight.altitude_msl_feet.unwrap_or(0)
+            fix.aircraft_id,
+            fix.latitude,
+            fix.longitude,
+            fix.altitude_msl_feet.unwrap_or(0)
         );
 
-        Ok(fix_with_flight)
+        Ok(fix)
     }
 
     // Unsubscribe from an aircraft - removes NATS subscription when no more clients

--- a/src/web.rs
+++ b/src/web.rs
@@ -652,6 +652,10 @@ pub async fn start_web_server(interface: String, port: u16, pool: PgPool) -> Res
             "/coverage/hexes/{h3_index}/fixes",
             get(actions::coverage::get_hex_fixes),
         )
+        .route(
+            "/coverage/hexes/{h3_index}/receivers",
+            get(actions::coverage::get_hex_receivers),
+        )
         .route("/fixes", get(actions::search_fixes))
         .route("/fixes/live", get(actions::fixes_live_websocket))
         .route(

--- a/web/src/lib/components/AircraftStatusModal.svelte
+++ b/web/src/lib/components/AircraftStatusModal.svelte
@@ -115,7 +115,7 @@
 
 			aircraftRegistration = registrationResponse?.data || null;
 			aircraftModel = modelResponse?.data || null;
-			currentFlight = selectedAircraft.currentFix?.flight || flightResponse?.data || null;
+			currentFlight = flightResponse?.data || null;
 		} catch (error) {
 			logger.warn('Failed to load aircraft data: {error}', { error });
 			aircraftRegistration = null;

--- a/web/src/lib/services/FixFeed.ts
+++ b/web/src/lib/services/FixFeed.ts
@@ -301,6 +301,9 @@ export class FixFeed {
 			return; // Already subscribed
 		}
 
+		// Add to set immediately to prevent duplicate subscriptions from concurrent calls
+		this.subscribedAircraft.add(aircraftId);
+
 		// Connect if not already connected
 		if (!this.websocket || this.websocket.readyState === WebSocket.CLOSED) {
 			this.connect();
@@ -311,7 +314,6 @@ export class FixFeed {
 
 		if (isConnected && this.websocket?.readyState === WebSocket.OPEN) {
 			this.sendSubscriptionMessage('subscribe', aircraftId);
-			this.subscribedAircraft.add(aircraftId);
 
 			this.notifySubscribers({
 				type: 'subscription_added',
@@ -321,6 +323,8 @@ export class FixFeed {
 			// Fetch aircraft info from API (currentFix will be included)
 			await this.aircraftRegistry.updateAircraftFromAPI(aircraftId);
 		} else {
+			// Remove from set if subscription failed
+			this.subscribedAircraft.delete(aircraftId);
 			logger.error('Failed to subscribe to aircraft {aircraftId}: WebSocket not connected', {
 				aircraftId
 			});

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -203,7 +203,6 @@ export interface FixWithExtras extends Fix {
 	deviceAddressHex?: string; // Legacy field, prefer aircraftId with proper join
 	registration?: string; // Aircraft registration (joined, not in Rust Fix)
 	model?: string; // Aircraft model (joined, not in Rust Fix)
-	flight?: Flight; // Full flight information if part of an active flight (from websocket)
 	aprsType?: string; // APRS message type (from sourceMetadata, used in WebSocket)
 	via?: string[]; // APRS via path (from sourceMetadata, used in WebSocket)
 }
@@ -419,6 +418,12 @@ export interface FixesInHexResponse {
 	total: number;
 	h3Index: string;
 	resolution: number;
+}
+
+// Hex receivers response - receivers that contributed to a coverage hex
+export interface HexReceiversResponse {
+	data: Receiver[];
+	h3Index: string;
 }
 
 // Browser API Extensions

--- a/web/src/lib/utils/mapStatePersistence.ts
+++ b/web/src/lib/utils/mapStatePersistence.ts
@@ -38,7 +38,7 @@ export interface LoadedMapState {
 	bounds?: MapBounds;
 }
 
-export type MapType = 'satellite' | 'roadmap';
+export type MapType = 'satellite' | 'roadmap' | 'terrain' | 'hybrid';
 
 /**
  * Save map state (center and zoom) to localStorage
@@ -233,7 +233,7 @@ export function loadMapType(): MapType {
 
 	try {
 		const saved = localStorage.getItem(MAP_TYPE_KEY);
-		if (saved === 'satellite' || saved === 'roadmap') {
+		if (saved === 'satellite' || saved === 'roadmap' || saved === 'terrain' || saved === 'hybrid') {
 			logger.debug('[MAP TYPE] Loaded saved map type: {saved}', { saved });
 			return saved;
 		}
@@ -244,3 +244,13 @@ export function loadMapType(): MapType {
 	logger.debug('[MAP TYPE] Using default: satellite');
 	return 'satellite';
 }
+
+/**
+ * Map type labels for UI display
+ */
+export const MAP_TYPE_LABELS: Record<MapType, string> = {
+	roadmap: 'Map',
+	satellite: 'Satellite',
+	terrain: 'Terrain',
+	hybrid: 'Hybrid'
+};

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -598,7 +598,7 @@
 			{@render children?.()}
 		</main>
 
-		{#if !page.route.id?.includes('operations') && !page.route.id?.includes('/flights/[id]/map')}
+		{#if !page.route.id?.includes('operations') && !page.route.id?.includes('/flights/[id]/map') && !page.route.id?.includes('receivers/coverage')}
 			<footer class="bg-surface-100-800-token p-4 text-center text-sm">
 				<p>&copy; 2025 Liam Bowen</p>
 			</footer>

--- a/web/src/routes/receivers/coverage/+page.svelte
+++ b/web/src/routes/receivers/coverage/+page.svelte
@@ -320,18 +320,16 @@
 						['linear'],
 						['get', 'fixCount'],
 						0,
-						'#440154', // Dark purple (no coverage)
-						maxFixCount * 0.25,
-						'#31688e', // Blue
-						maxFixCount * 0.5,
-						'#35b779', // Green
-						maxFixCount * 0.75,
-						'#fde724', // Yellow
+						'#3b82f6', // Blue (low coverage)
+						maxFixCount * 0.33,
+						'#22c55e', // Green
+						maxFixCount * 0.66,
+						'#eab308', // Yellow
 						maxFixCount,
-						'#ff0000' // Red (high coverage)
+						'#f97316' // Orange (high coverage)
 					],
-					'fill-opacity': 0.7,
-					'fill-outline-color': '#000000'
+					'fill-opacity': 0.35,
+					'fill-outline-color': 'rgba(0, 0, 0, 0.3)'
 				}
 			});
 
@@ -490,17 +488,17 @@
 	}
 </script>
 
-<div class="flex h-screen flex-col">
+<div class="fixed inset-x-0 top-[42px] bottom-0 flex w-full flex-col">
 	<!-- Header -->
-	<div class="bg-surface-800 p-4 shadow-md">
+	<div class="bg-surface-800 px-4 py-3 shadow-md">
 		<div class="flex items-center justify-between">
 			<div>
-				<h1 class="text-2xl font-bold text-white">Receiver Coverage Map</h1>
-				<p class="text-sm text-gray-300">
+				<h1 class="text-xl font-bold text-white">Receiver Coverage Map</h1>
+				<p class="text-xs text-gray-300">
 					Visualizing aircraft reception coverage using H3 hexagons
 				</p>
 			</div>
-			<a href={resolve('/receivers')} class="btn gap-2 preset-outlined">
+			<a href={resolve('/receivers')} class="btn gap-2 preset-outlined btn-sm">
 				<Radio class="h-4 w-4" />
 				View Receivers
 			</a>
@@ -508,7 +506,7 @@
 	</div>
 
 	<!-- Controls -->
-	<div class="bg-surface-700 p-4 shadow-sm">
+	<div class="bg-surface-700 px-4 py-2 shadow-sm">
 		<div class="flex flex-wrap gap-4">
 			<!-- Resolution selector -->
 			<div class="flex items-center gap-2">
@@ -697,28 +695,24 @@
 	<div bind:this={mapContainer} class="flex-1"></div>
 
 	<!-- Legend -->
-	<div class="bg-surface-700 p-4">
-		<div class="flex flex-wrap items-center gap-3">
-			<span class="text-sm font-medium text-gray-300">Fix Count:</span>
-			<div class="flex items-center gap-2">
-				<div class="h-4 w-8 rounded" style="background-color: #440154;"></div>
+	<div class="bg-surface-700 px-4 py-2">
+		<div class="flex flex-wrap items-center gap-4">
+			<span class="text-sm font-medium text-gray-300">Density:</span>
+			<div class="flex items-center gap-1">
+				<div class="h-3 w-6 rounded-sm" style="background-color: #3b82f6;"></div>
 				<span class="text-xs text-gray-400">Low</span>
 			</div>
-			<div class="flex items-center gap-2">
-				<div class="h-4 w-8 rounded" style="background-color: #31688e;"></div>
+			<div class="flex items-center gap-1">
+				<div class="h-3 w-6 rounded-sm" style="background-color: #22c55e;"></div>
 				<span class="text-xs text-gray-400">Medium</span>
 			</div>
-			<div class="flex items-center gap-2">
-				<div class="h-4 w-8 rounded" style="background-color: #35b779;"></div>
+			<div class="flex items-center gap-1">
+				<div class="h-3 w-6 rounded-sm" style="background-color: #eab308;"></div>
 				<span class="text-xs text-gray-400">High</span>
 			</div>
-			<div class="flex items-center gap-2">
-				<div class="h-4 w-8 rounded" style="background-color: #fde724;"></div>
+			<div class="flex items-center gap-1">
+				<div class="h-3 w-6 rounded-sm" style="background-color: #f97316;"></div>
 				<span class="text-xs text-gray-400">Very High</span>
-			</div>
-			<div class="flex items-center gap-2">
-				<div class="h-4 w-8 rounded" style="background-color: #ff0000;"></div>
-				<span class="text-xs text-gray-400">Maximum</span>
 			</div>
 		</div>
 	</div>
@@ -743,10 +737,9 @@
 		align-items: center;
 		pointer-events: auto;
 		cursor: pointer;
-		transition: transform 0.2s ease-in-out;
 	}
 
-	:global(.receiver-marker:hover) {
+	:global(.receiver-marker:hover .receiver-icon) {
 		transform: scale(1.1);
 	}
 
@@ -761,7 +754,11 @@
 		justify-content: center;
 		color: #374151;
 		box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-		transition: all 0.2s ease-in-out;
+		transition:
+			background 0.2s ease-in-out,
+			border-color 0.2s ease-in-out,
+			box-shadow 0.2s ease-in-out,
+			transform 0.2s ease-in-out;
 	}
 
 	@media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
- Add receivers list to hex details modal showing which receivers contributed coverage to a hexagon
- Add receiver column to position fixes table for better data visibility
- Improve coverage map UI with blue-orange color scale, reduced opacity, and full-width layout
- Replace map type toggle with dropdown supporting terrain and hybrid views
- Fix duplicate WebSocket subscriptions via debouncing and race condition fixes
- Remove unused flight loading from fix processing for cleaner code

## Test plan
- [ ] Verify coverage map displays hexagons with blue-orange color scale
- [ ] Verify clicking a hex shows the receivers that contributed to it
- [ ] Verify position fixes table includes receiver column
- [ ] Verify map type dropdown works with all 4 options
- [ ] Verify no duplicate WebSocket subscriptions when panning map