### PR TITLE
Fix queue message loss and performance issues

### DIFF
--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -283,19 +283,9 @@ pub async fn handle_ingest(config: IngestConfig) -> Result<()> {
             || sbs_socket_client.is_connected();
     }
 
-    // Connect consumers to queues
-    ogn_queue
-        .connect_consumer("ogn-publisher".to_string())
-        .await
-        .expect("Failed to connect OGN consumer to queue");
-    beast_queue
-        .connect_consumer("beast-publisher".to_string())
-        .await
-        .expect("Failed to connect Beast consumer to queue");
-    sbs_queue
-        .connect_consumer("sbs-publisher".to_string())
-        .await
-        .expect("Failed to connect SBS consumer to queue");
+    // Queues start in Disconnected state and auto-connect on first recv().
+    // This ensures all messages are persisted to disk until a consumer
+    // is actually ready to process them, preventing message loss on restart.
 
     // Spawn OGN publisher task: reads from queue → sends to socket
     if ogn_enabled {

--- a/src/main.rs
+++ b/src/main.rs
@@ -801,36 +801,36 @@ async fn main() -> Result<()> {
     // Create separate filter for fmt_layer (console output)
     // Use RUST_LOG if set, otherwise default based on environment
     // Note: async_nats is set to warn to suppress "slow consumers" INFO logs during high load
-    // Note: log=warn,pprof=warn suppresses pprof library's INFO logs during CPU profiling
+    // Note: pprof=off suppresses pprof library's "starting/stopping cpu profiler" logs
     let fmt_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         if is_production {
-            EnvFilter::new("warn,hyper_util=info,rustls=info,async_nats=warn,log=warn,pprof=warn")
+            EnvFilter::new("warn,hyper_util=info,rustls=info,async_nats=warn,pprof=off")
         } else if is_staging {
-            EnvFilter::new("info,hyper_util=info,rustls=info,async_nats=warn,log=warn,pprof=warn")
+            EnvFilter::new("info,hyper_util=info,rustls=info,async_nats=warn,pprof=off")
         } else {
             // Development: debug by default, but suppress noisy OpenTelemetry internals
             EnvFilter::new(
-                "debug,hyper_util=info,rustls=info,async_nats=warn,log=warn,pprof=warn,opentelemetry_sdk=info,opentelemetry_otlp=info,opentelemetry_http=info",
+                "debug,hyper_util=info,rustls=info,async_nats=warn,pprof=off,opentelemetry_sdk=info,opentelemetry_otlp=info,opentelemetry_http=info",
             )
         }
     });
 
     // Create filter for tokio-console layer (needs tokio=trace,runtime=trace for task visibility)
-    let console_filter = EnvFilter::new("warn,tokio=trace,runtime=trace,log=warn,pprof=warn");
+    let console_filter = EnvFilter::new("warn,tokio=trace,runtime=trace,pprof=off");
 
     // Create filter for OpenTelemetry layer - exclude tokio runtime internals to prevent
     // trace bloat from waker.clone/waker.drop events being attached to every span
-    let otel_filter = EnvFilter::new("info,tokio=off,runtime=off,log=warn,pprof=warn");
+    let otel_filter = EnvFilter::new("info,tokio=off,runtime=off,pprof=off");
 
     // Create filter for OpenTelemetry logs layer (Loki export)
     // - Production: info level only (no debug logs to Loki)
     // - Staging/Dev: debug for soar::* packages, info for external packages
     // This filters at the source to avoid sending logs that would be dropped anyway
     let logs_filter = if is_production {
-        EnvFilter::new("info,tokio=off,runtime=off,log=warn,pprof=warn")
+        EnvFilter::new("info,tokio=off,runtime=off,pprof=off")
     } else {
         // Allow debug from soar crate, info from everything else
-        EnvFilter::new("info,soar=debug,tokio=off,runtime=off,log=warn,pprof=warn")
+        EnvFilter::new("info,soar=debug,tokio=off,runtime=off,pprof=off")
     };
 
     // Helper to create logs layer - bridges tracing events to OpenTelemetry logs for Loki export


### PR DESCRIPTION
## Summary

- Fix potential message loss when process restarts before consumption begins
- Fix 100% CPU usage caused by filesystem thrashing in `is_at_capacity()`
- Add IPv4 filtering and random server selection for APRS/Beast connections
- Add new metrics for connection monitoring and backpressure detection
- Suppress noisy pprof log messages

## Changes

### Queue Auto-Connect on recv()
Queue now stays in `Disconnected` state until `recv()` is actually called. This ensures all messages are buffered to disk until consumption begins, preventing loss if the process restarts before a consumer starts.

### Performance Fix for is_at_capacity()
Added 250ms cache for `data_size_bytes()` calculation. Previously, this was being called on every message (~400/sec), causing directory reads and file opens that resulted in 100% CPU usage.

### Connection Improvements
- Filter DNS results to IPv4 only (with fallback), randomly shuffle for load balancing
- New metrics:
  - `aprs.connection.server_closed_total` / `beast.connection.server_closed_total`
  - `aprs.connection.duration_seconds` / `beast.connection.duration_seconds`
  - `aprs.raw_channel.depth/capacity/utilization_percent`
  - `beast.raw_channel.depth/capacity/utilization_percent`
- Fixed metric name mismatch: `aprs.operation_failed_total` → `aprs.connection.operation_failed_total`

### Logging
- Suppress pprof "starting/stopping cpu profiler" messages (`pprof=off` in tracing filters)

## Test plan
- [x] All 260 unit tests pass
- [x] `cargo check` passes
- [ ] Deploy to staging and verify:
  - CPU usage is significantly reduced
  - Queue metrics show expected behavior
  - APRS connections use IPv4 and rotate between servers
  - New metrics appear in Prometheus/Grafana