### PR TITLE
Fix Tempo startup failure on servers with only public IPs

### DIFF
--- a/infrastructure/tempo-config.yml
+++ b/infrastructure/tempo-config.yml
@@ -4,6 +4,12 @@ server:
   grpc_listen_address: 127.0.0.1
   grpc_listen_port: 9096
 
+# Explicitly bind memberlist to localhost for single-node setup
+# This prevents the "no private IP address found" error on servers with only public IPs
+memberlist:
+  bind_addr:
+    - 127.0.0.1
+
 distributor:
   receivers:
     otlp:


### PR DESCRIPTION
## Summary
- Add explicit `memberlist.bind_addr: [127.0.0.1]` to Tempo config
- Fixes the "no private IP address found" error that occurs on servers with only public IPs
- Already deployed to production and verified working

## Context
After a server reboot, Tempo 2.9.0 failed to start because it couldn't auto-detect a private IP address for its memberlist module. The production server only has a public IP (65.109.20.111), causing the auto-detection to fail.

## Test plan
- [x] Config deployed to production
- [x] Tempo service restarted successfully
- [x] Verified `/ready` endpoint returns "ready"
- [ ] Verify Grafana Traces Drilldown works