### PR TITLE
Unify ingest queue and capture timestamps at receive time

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -801,36 +801,37 @@ async fn main() -> Result<()> {
     // Create separate filter for fmt_layer (console output)
     // Use RUST_LOG if set, otherwise default based on environment
     // Note: async_nats is set to warn to suppress "slow consumers" INFO logs during high load
-    // Note: pprof=off suppresses pprof library's "starting/stopping cpu profiler" logs
+    // Note: log=warn suppresses INFO logs from crates using the `log` facade (e.g., pprof's
+    //       "starting/stopping cpu profiler" messages which appear with target "log:")
     let fmt_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         if is_production {
-            EnvFilter::new("warn,hyper_util=info,rustls=info,async_nats=warn,pprof=off")
+            EnvFilter::new("warn,hyper_util=info,rustls=info,async_nats=warn,log=warn")
         } else if is_staging {
-            EnvFilter::new("info,hyper_util=info,rustls=info,async_nats=warn,pprof=off")
+            EnvFilter::new("info,hyper_util=info,rustls=info,async_nats=warn,log=warn")
         } else {
             // Development: debug by default, but suppress noisy OpenTelemetry internals
             EnvFilter::new(
-                "debug,hyper_util=info,rustls=info,async_nats=warn,pprof=off,opentelemetry_sdk=info,opentelemetry_otlp=info,opentelemetry_http=info",
+                "debug,hyper_util=info,rustls=info,async_nats=warn,log=warn,opentelemetry_sdk=info,opentelemetry_otlp=info,opentelemetry_http=info",
             )
         }
     });
 
     // Create filter for tokio-console layer (needs tokio=trace,runtime=trace for task visibility)
-    let console_filter = EnvFilter::new("warn,tokio=trace,runtime=trace,pprof=off");
+    let console_filter = EnvFilter::new("warn,tokio=trace,runtime=trace,log=warn");
 
     // Create filter for OpenTelemetry layer - exclude tokio runtime internals to prevent
     // trace bloat from waker.clone/waker.drop events being attached to every span
-    let otel_filter = EnvFilter::new("info,tokio=off,runtime=off,pprof=off");
+    let otel_filter = EnvFilter::new("info,tokio=off,runtime=off,log=warn");
 
     // Create filter for OpenTelemetry logs layer (Loki export)
     // - Production: info level only (no debug logs to Loki)
     // - Staging/Dev: debug for soar::* packages, info for external packages
     // This filters at the source to avoid sending logs that would be dropped anyway
     let logs_filter = if is_production {
-        EnvFilter::new("info,tokio=off,runtime=off,pprof=off")
+        EnvFilter::new("info,tokio=off,runtime=off,log=warn")
     } else {
         // Allow debug from soar crate, info from everything else
-        EnvFilter::new("info,soar=debug,tokio=off,runtime=off,pprof=off")
+        EnvFilter::new("info,soar=debug,tokio=off,runtime=off,log=warn")
     };
 
     // Helper to create logs layer - bridges tracing events to OpenTelemetry logs for Loki export


### PR DESCRIPTION
## Summary
- Consolidate three separate queues (OGN, Beast, SBS) into single unified ingest queue storing pre-serialized protobuf Envelopes
- Capture timestamp at message receive time rather than drain time, fixing incorrect timestamps when queue backs up during soar-run downtime
- Suppress pprof "starting/stopping cpu profiler" logs by filtering log facade messages

## Changes
- **protocol.rs**: Add `create_serialized_envelope` helper and `new_envelope_with_timestamp`
- **socket_client.rs**: Add `send_serialized` method for pre-serialized envelope data
- **ingest.rs**: Replace three queues with single unified queue, single publisher task
- **aprs_client.rs**: Add `start_with_envelope_queue` method
- **beast/client.rs**: Add `start_with_envelope_queue` method  
- **sbs/client.rs**: Add `start_with_envelope_queue` method
- **main.rs**: Change `pprof=off` to `log=warn` in tracing filters

## Test plan
- [ ] Deploy to staging and verify ingest process starts correctly
- [ ] Verify messages from all three sources (OGN, Beast, SBS) are processed
- [ ] Check that timestamps are accurate even after queue backup/drain
- [ ] Confirm pprof log messages no longer appear