### PR TITLE
Fix queue drain corruption and improve logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5943,7 +5943,6 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
- "tracing-log",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "ts-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,8 +80,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["fs", "trace", "cors"] }
 ts-rs = { version = "11.1", features = ["chrono-impl", "uuid-impl", "serde-json-impl", "format"] }
 tracing = { version = "0.1" }
-tracing-log = "0.2"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "tracing-log"] }
 uuid = { version = "1.19", features = ["v4", "v7", "serde"] }
 zstd = "0.13"
 axum-tungstenite = "0.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -841,9 +841,8 @@ async fn main() -> Result<()> {
             .map(opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new)
     };
 
-    // Bridge `log` crate events to tracing so they respect our EnvFilter
-    // This makes `pprof=warn` filter work for the pprof crate's INFO logs
-    tracing_log::LogTracer::init().expect("Failed to initialize LogTracer");
+    // Note: tracing-subscriber's "tracing-log" feature automatically bridges
+    // `log` crate events to tracing, so `pprof=warn` filter works for pprof's INFO logs
 
     let registry = tracing_subscriber::registry();
 


### PR DESCRIPTION
## Summary

- **Fix profiler INFO log suppression**: Added `tracing-log` bridge so `pprof=warn` in EnvFilter now correctly suppresses pprof's "starting/stopping cpu profiler" INFO messages
- **Clarify "disk overflow" terminology**: Changed misleading "disk overflow" messages to "disk spillover" - messages spill FROM memory TO disk when the memory channel is full, not the disk overflowing
- **Fix data corruption from concurrent file access**: Added a `Mutex` to serialize file operations in `PersistentQueue`, preventing multiple async tasks (OGN, Beast, SBS clients) from racing to write to the same segment file

## Test plan

- [x] All 15 persistent_queue tests pass
- [x] `cargo clippy` passes with no warnings
- [x] Pre-commit hooks pass