### PR TITLE
Enable ADS-B in production soar-run service

### DIFF
--- a/infrastructure/systemd/soar-run.service
+++ b/infrastructure/systemd/soar-run.service
@@ -13,7 +13,7 @@ User=soar
 Group=soar
 WorkingDirectory=/var/lib/soar
 SyslogIdentifier=soar-run
-ExecStart=/usr/local/bin/soar run --archive --no-adsb
+ExecStart=/usr/local/bin/soar run --archive
 ExecReload=/bin/kill -s HUP $MAINPID
 
 # Environment variables


### PR DESCRIPTION
## Summary
- Remove `--no-adsb` flag from production soar-run systemd service to enable ADS-B data processing

## Test plan
- [x] Service file syntax is valid
- [ ] Verify soar-run restarts successfully with ADS-B enabled