### PR TITLE
Fix docker-compose to docker compose in provision-pelias

### DIFF
--- a/scripts/provision-pelias
+++ b/scripts/provision-pelias
@@ -465,7 +465,7 @@ if [ -f "$PLACEHOLDER_DB" ]; then
     echo -e "${BLUE}Placeholder data already built (skipping)${NC}"
 else
     echo -e "${BLUE}Building Placeholder database from Who's on First data...${NC}"
-    su - pelias -c "cd /opt/pelias/docker && docker-compose run --rm placeholder npm run build"
+    su - pelias -c "cd /opt/pelias/docker && docker compose run --rm placeholder npm run build"
     echo -e "${GREEN}Placeholder database built${NC}"
 fi
 


### PR DESCRIPTION
## Summary
- Use the modern `docker compose` command instead of the legacy `docker-compose` which is no longer installed by default

## Test plan
- [x] Verified no other `docker-compose` command invocations remain in the script
- [x] Idempotency already handled (checks for existing placeholder database before building)