### PR TITLE
Fix AR aircraft visibility and direction indicator

### DIFF
--- a/web/src/lib/services/arTracker.ts
+++ b/web/src/lib/services/arTracker.ts
@@ -181,9 +181,20 @@ export class ARTracker {
 			heading = (360 - (event.alpha ?? 0)) % 360;
 		}
 
+		// Convert device beta to AR pitch
+		// beta is the angle in degrees the device is tilted front-to-back:
+		//   - beta = 0°: phone flat on table, screen facing up
+		//   - beta = 90°: phone held vertically, screen facing user (portrait AR mode)
+		//   - beta = 180°/-180°: phone flat, screen facing down
+		// For AR, we want pitch = 0° when phone is held vertically (the typical AR pose).
+		// Tilting the phone up (looking at sky) = positive pitch
+		// Tilting the phone down (looking at ground) = negative pitch
+		const beta = event.beta ?? 0;
+		const arPitch = beta - 90;
+
 		this.currentOrientation = {
 			heading,
-			pitch: event.beta ?? 0,
+			pitch: arPitch,
 			roll: event.gamma ?? 0,
 			absolute: event.absolute || this.hasAbsoluteOrientation
 		};


### PR DESCRIPTION
## Summary

- Fix pitch calculation by subtracting 90° from device beta so holding the phone vertically (normal AR pose) equals 0° pitch. Previously, aircraft were never visible because adjusted elevation was always ~85° off.
- Add diagonal direction support (up-left, up-right, down-left, down-right) to DirectionIndicator for more accurate guidance.
- Use rotating arrow icon that points directly at the target aircraft instead of only cardinal direction chevrons.

## Test plan

- [ ] Open AR mode on a mobile device
- [ ] Select an aircraft from the nearby list
- [ ] Verify the direction indicator arrow points toward the aircraft (including diagonal directions)
- [ ] Pan the phone toward the aircraft and verify the aircraft icon appears when in view