### PR TITLE
Improve timestamp parse error logging

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -57,8 +57,9 @@ async fn process_aprs_message(
             Ok(timestamp) => (timestamp.with_timezone(&chrono::Utc), rest),
             Err(e) => {
                 warn!(
-                    "Failed to parse timestamp from message: {} - using current time",
-                    e
+                    timestamp = %timestamp_str,
+                    error = %e,
+                    "Failed to parse timestamp from message - using current time"
                 );
                 (chrono::Utc::now(), message)
             }

--- a/src/message_sources.rs
+++ b/src/message_sources.rs
@@ -81,8 +81,9 @@ pub async fn process_messages_from_source(
                 Ok(timestamp) => (timestamp.with_timezone(&Utc), rest),
                 Err(e) => {
                     warn!(
-                        "Failed to parse timestamp from message: {} - using current time",
-                        e
+                        timestamp = %timestamp_str,
+                        error = %e,
+                        "Failed to parse timestamp from message - using current time"
                     );
                     (Utc::now(), message.as_str())
                 }


### PR DESCRIPTION
## Summary
- Include the actual timestamp string that failed to parse in the warning message
- Makes it easier to debug issues with malformed timestamps

## Changes
- Updated logging in `src/commands/run.rs` and `src/message_sources.rs`
- Changed from: `Failed to parse timestamp from message: <error> - using current time`
- Changed to: structured logging with `timestamp=<value>` and `error=<error>`

## Test plan
- [x] `cargo check` passes
- [x] Pre-commit hooks pass