### PR TITLE
Optimize raw message lookups with timestamp hint for partition pruning

### DIFF
--- a/src/actions/raw_messages.rs
+++ b/src/actions/raw_messages.rs
@@ -1,25 +1,44 @@
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::{IntoResponse, Json},
 };
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::actions::{DataResponse, json_error};
 use crate::raw_messages_repo::RawMessagesRepository;
 use crate::web::AppState;
 
+/// Query parameters for raw message lookup
+#[derive(Debug, Deserialize)]
+pub struct RawMessageQuery {
+    /// Timestamp hint to optimize partition lookup (raw_messages is partitioned by received_at)
+    /// If provided, the query will filter to a narrow time range around this timestamp
+    pub timestamp: Option<DateTime<Utc>>,
+}
+
 /// Get a raw message by ID
 /// Returns the raw message with proper encoding based on source type:
 /// - APRS: UTF-8 text
 /// - ADS-B/Beast: hex-encoded binary
+///
+/// Query parameters:
+/// - timestamp: Optional timestamp hint to optimize partition lookup
 pub async fn get_raw_message(
     Path(id): Path<Uuid>,
+    Query(query): Query<RawMessageQuery>,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
     let repo = RawMessagesRepository::new(state.pool.clone());
 
-    match repo.get_message_response_by_id(id).await {
+    let result = match query.timestamp {
+        Some(ts) => repo.get_message_response_by_id_with_hint(id, ts).await,
+        None => repo.get_message_response_by_id(id).await,
+    };
+
+    match result {
         Ok(Some(message)) => Json(DataResponse { data: message }).into_response(),
         Ok(None) => json_error(StatusCode::NOT_FOUND, "Raw message not found").into_response(),
         Err(e) => {


### PR DESCRIPTION
## Summary
- Add optional `timestamp` query parameter to `GET /data/raw-messages/{id}` endpoint
- When provided, the query filters to a ±5 minute window around the hint, allowing TimescaleDB to prune partitions
- Frontend now passes `fix.receivedAt` as the timestamp hint when fetching raw messages

## Problem
The `raw_messages` table is a TimescaleDB hypertable partitioned by `received_at`. When querying by ID alone, all partitions must be scanned, causing slow lookups when clicking "Show raw" for Recent Position Fixes.

## Solution
By passing the timestamp from the associated fix as a hint, we can narrow the search to a single partition (chunk), dramatically improving query performance.

## Test plan
- [ ] Load an aircraft page with recent position fixes
- [ ] Click "Show raw" checkbox
- [ ] Verify raw messages load quickly
- [ ] Check network requests include `?timestamp=` parameter
- [ ] Verify the endpoint still works without the timestamp parameter (backward compatible)