### PR TITLE
Add migration cleanup and out-of-band dedup scripts

### DIFF
--- a/infrastructure/alloy-config.alloy.template
+++ b/infrastructure/alloy-config.alloy.template
@@ -31,7 +31,7 @@ otelcol.processor.batch "pipeline" {
 
 // Filter logs based on severity:
 // - TRACE logs (severity 1-4): Always dropped - too verbose for log aggregation
-// - DEBUG logs (severity 5-8): Dropped for production, kept for staging/dev
+// - DEBUG logs (severity 5-8): Always dropped - too verbose for Loki
 // - INFO+ (severity 9+): Always kept
 // This reduces noise and storage costs while keeping useful logs
 otelcol.processor.filter "log_level" {
@@ -40,10 +40,9 @@ otelcol.processor.filter "log_level" {
   logs {
     // OTTL severity_number: TRACE=1-4, DEBUG=5-8, INFO=9-12, WARN=13-16, ERROR=17-20, FATAL=21-24
     log_record = [
-      // Always drop TRACE logs - they include tokio runtime internals and are too noisy
-      "severity_number <= 4",
-      // Drop DEBUG logs from production services (if deployment.environment is set)
-      "severity_number < 9 and resource.attributes[\"deployment.environment\"] == \"production\"",
+      // Drop TRACE and DEBUG logs - they're too verbose for log aggregation
+      // DEBUG logs are still visible in journalctl for debugging
+      "severity_number < 9",
     ]
   }
 

--- a/migrations/2026-01-28-000000-0000_drop_aircraft_merge_mapping_table/down.sql
+++ b/migrations/2026-01-28-000000-0000_drop_aircraft_merge_mapping_table/down.sql
@@ -1,0 +1,1 @@
+-- No-op: table was a temporary prep artifact, not needed for rollback

--- a/migrations/2026-01-28-000000-0000_drop_aircraft_merge_mapping_table/up.sql
+++ b/migrations/2026-01-28-000000-0000_drop_aircraft_merge_mapping_table/up.sql
@@ -1,0 +1,5 @@
+-- Clean up out-of-band migration prep table
+-- This table was created manually to run the fixes aircraft_id update out-of-band
+-- before the deduplicate_aircraft_registration migration, to avoid slow updates
+-- through compressed TimescaleDB chunks.
+DROP TABLE IF EXISTS aircraft_merge_mapping;

--- a/scripts/create-aircraft-merge-mapping.sql
+++ b/scripts/create-aircraft-merge-mapping.sql
@@ -1,0 +1,30 @@
+-- Create the aircraft merge mapping table for out-of-band fixes update
+-- This identifies FLARM+ICAO duplicate pairs that need to be merged
+--
+-- Run this BEFORE running update_fixes_decompress_first.sh or update_fixes_parallel.py
+--
+-- Usage:
+--   psql -d soar -f scripts/create-aircraft-merge-mapping.sql
+
+-- Drop if exists (in case of re-run)
+DROP TABLE IF EXISTS aircraft_merge_mapping;
+
+-- Create mapping table: FLARM records to merge into ICAO records
+CREATE TABLE aircraft_merge_mapping AS
+SELECT
+    f.id as flarm_id,
+    i.id as icao_id,
+    f.registration
+FROM aircraft f
+JOIN aircraft i ON f.registration = i.registration
+WHERE f.address_type = 'flarm'
+  AND i.address_type = 'icao'
+  AND f.registration IS NOT NULL
+  AND f.registration != ''
+  AND f.id != i.id;
+
+-- Add index for fast lookups during UPDATE
+CREATE INDEX idx_aircraft_merge_mapping_flarm_id ON aircraft_merge_mapping(flarm_id);
+
+-- Show count
+SELECT COUNT(*) as duplicate_pairs_to_merge FROM aircraft_merge_mapping;

--- a/scripts/decompress-all-fixes-chunks.sh
+++ b/scripts/decompress-all-fixes-chunks.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Decompress all compressed fixes chunks before running migrations
+#
+# This is a pre-migration step that makes subsequent UPDATE operations
+# on the fixes hypertable MUCH faster by avoiding transparent decompression.
+#
+# After the migration completes, the compression policy will automatically
+# recompress chunks older than 7 days.
+#
+# Usage:
+#   ./scripts/decompress-all-fixes-chunks.sh [database_name]
+#   ./scripts/decompress-all-fixes-chunks.sh soar
+
+set -e
+
+DB="${1:-soar}"
+
+echo "=== Decompress All Fixes Chunks ==="
+echo "Database: $DB"
+echo ""
+
+# Get list of all compressed chunks
+echo "Finding compressed chunks..."
+CHUNKS=$(psql -d "$DB" -tAc "
+    SELECT chunk_schema || '.' || chunk_name
+    FROM timescaledb_information.chunks
+    WHERE hypertable_name = 'fixes'
+      AND is_compressed = true
+    ORDER BY range_start
+")
+
+CHUNK_COUNT=$(echo "$CHUNKS" | grep -c . || echo "0")
+echo "Found $CHUNK_COUNT compressed chunks"
+
+if [ "$CHUNK_COUNT" -eq 0 ]; then
+    echo "No compressed chunks - nothing to do."
+    exit 0
+fi
+
+echo ""
+echo "Decompressing chunks..."
+
+DECOMPRESS_START=$(date +%s)
+DECOMP_NUM=0
+for CHUNK in $CHUNKS; do
+    DECOMP_NUM=$((DECOMP_NUM + 1))
+    CHUNK_SHORT=$(echo "$CHUNK" | sed 's/.*\.//')
+    echo "  [$DECOMP_NUM/$CHUNK_COUNT] $CHUNK_SHORT..."
+    psql -d "$DB" -c "SELECT decompress_chunk('$CHUNK');" >/dev/null 2>&1
+done
+DECOMPRESS_END=$(date +%s)
+DECOMPRESS_DURATION=$((DECOMPRESS_END - DECOMPRESS_START))
+
+echo ""
+echo "=== Complete ==="
+echo "Decompressed $CHUNK_COUNT chunks in ${DECOMPRESS_DURATION}s"
+echo ""
+echo "You can now run the migration. Compression policy will recompress"
+echo "chunks older than 7 days automatically."

--- a/scripts/update_fixes_decompress_first.sh
+++ b/scripts/update_fixes_decompress_first.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Fast approach: Decompress chunks first, then bulk update, then recompress
+#
+# This is MUCH faster than transparent decompression because:
+# 1. Decompression is done once per chunk (not per row)
+# 2. UPDATE on uncompressed data is fast
+# 3. Recompression is done once at the end
+#
+# Usage:
+#   ./scripts/update_fixes_decompress_first.sh [database_name]
+
+set -e
+
+DB="${1:-soar_staging}"
+
+echo "=== Fast Fixes Update (Decompress First) ==="
+echo "Database: $DB"
+echo ""
+
+# Check prerequisites
+echo "Checking prerequisites..."
+EXISTS=$(psql -d "$DB" -tAc "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = 'aircraft_merge_mapping')")
+if [ "$EXISTS" != "t" ]; then
+    echo "ERROR: aircraft_merge_mapping table not found. Run migration 1 first."
+    exit 1
+fi
+
+# Get count from mapping table (fast)
+AIRCRAFT_COUNT=$(psql -d "$DB" -tAc "SELECT COUNT(*) FROM aircraft_merge_mapping")
+echo "Aircraft to merge: $AIRCRAFT_COUNT"
+
+echo ""
+echo "Step 1: Get all compressed chunks..."
+
+# Get list of ALL compressed chunks (faster than checking which have affected rows)
+# Use fully qualified name: schema.table
+CHUNKS=$(psql -d "$DB" -tAc "
+    SELECT chunk_schema || '.' || chunk_name
+    FROM timescaledb_information.chunks
+    WHERE hypertable_name = 'fixes'
+      AND is_compressed = true
+    ORDER BY range_start
+")
+
+CHUNK_COUNT=$(echo "$CHUNKS" | grep -c . || echo "0")
+echo "Found $CHUNK_COUNT compressed chunks"
+
+if [ "$CHUNK_COUNT" -eq 0 ]; then
+    echo "No compressed chunks found - trying direct update..."
+
+    START_TIME=$(date +%s)
+    UPDATED=$(psql -d "$DB" -tAc "
+        UPDATE fixes fx
+        SET aircraft_id = m.icao_id
+        FROM aircraft_merge_mapping m
+        WHERE fx.aircraft_id = m.flarm_id
+    " | grep -oP 'UPDATE \K\d+' || echo "0")
+    END_TIME=$(date +%s)
+    DURATION=$((END_TIME - START_TIME))
+
+    echo "Updated $UPDATED fixes in ${DURATION}s"
+    exit 0
+fi
+
+echo ""
+echo "Step 2: Decompress all chunks..."
+
+DECOMPRESS_START=$(date +%s)
+DECOMP_NUM=0
+for CHUNK in $CHUNKS; do
+    DECOMP_NUM=$((DECOMP_NUM + 1))
+    echo "  Decompressing $DECOMP_NUM/$CHUNK_COUNT: $CHUNK..."
+    psql -d "$DB" -c "SELECT decompress_chunk('$CHUNK');" >/dev/null 2>&1
+done
+DECOMPRESS_END=$(date +%s)
+DECOMPRESS_DURATION=$((DECOMPRESS_END - DECOMPRESS_START))
+echo "Decompression complete in ${DECOMPRESS_DURATION}s"
+
+echo ""
+echo "Step 3: Bulk update (uncompressed data)..."
+
+UPDATE_START=$(date +%s)
+# Also disable decompression limit in case some chunks were recompressed by background job
+UPDATED=$(psql -d "$DB" -tAc "
+    SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0;
+    UPDATE fixes fx
+    SET aircraft_id = m.icao_id
+    FROM aircraft_merge_mapping m
+    WHERE fx.aircraft_id = m.flarm_id
+" | grep -oP 'UPDATE \K\d+' || echo "0")
+UPDATE_END=$(date +%s)
+UPDATE_DURATION=$((UPDATE_END - UPDATE_START))
+
+echo "Updated $UPDATED fixes in ${UPDATE_DURATION}s"
+if [ "$UPDATE_DURATION" -gt 0 ]; then
+    RATE=$((UPDATED / UPDATE_DURATION))
+    echo "Rate: ${RATE}/sec"
+fi
+
+# Skip recompression - let the compression policy handle it
+# This minimizes downtime for soar-run
+echo ""
+echo "Skipping recompression - compression policy will handle this automatically."
+
+echo ""
+echo "=== Summary ==="
+TOTAL_DURATION=$((UPDATE_END - DECOMPRESS_START))
+echo "Fixes updated: $UPDATED"
+echo "Chunks processed: $CHUNK_COUNT"
+echo "Decompress time: ${DECOMPRESS_DURATION}s"
+echo "Update time: ${UPDATE_DURATION}s"
+echo "Compress time: ${COMPRESS_DURATION}s"
+echo "Total time: ${TOTAL_DURATION}s"
+
+# Verify with quick check on mapping table
+REMAINING=$(psql -d "$DB" -tAc "
+    SELECT COUNT(*)
+    FROM aircraft_merge_mapping m
+    WHERE EXISTS (
+        SELECT 1 FROM fixes fx
+        WHERE fx.aircraft_id = m.flarm_id
+        LIMIT 1
+    )
+")
+echo ""
+echo "Aircraft IDs still needing fixes updated: $REMAINING"
+
+if [ "$REMAINING" -eq 0 ]; then
+    echo ""
+    echo "SUCCESS! All fixes updated."
+    echo "Next: Run 'diesel migration run' to complete migration 2"
+else
+    echo ""
+    echo "WARNING: Some fixes may still need updating. Check manually."
+fi

--- a/scripts/update_fixes_parallel.py
+++ b/scripts/update_fixes_parallel.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+Parallel fixes update - decompresses/updates/recompresses chunks concurrently.
+
+Usage:
+    python3 scripts/update_fixes_parallel.py [database_name] [parallelism]
+    python3 scripts/update_fixes_parallel.py soar_staging 4
+"""
+
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import time
+
+DB = sys.argv[1] if len(sys.argv) > 1 else "soar_staging"
+PARALLELISM = int(sys.argv[2]) if len(sys.argv) > 2 else 4
+
+
+def run_sql(sql: str, return_output: bool = False):
+    """Run SQL command and optionally return output."""
+    cmd = ["psql", "-d", DB, "-tAc", sql]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"SQL Error: {result.stderr}")
+        return None
+    return result.stdout.strip() if return_output else result.returncode == 0
+
+
+def get_compressed_chunks():
+    """Get list of all compressed chunks."""
+    sql = """
+        SELECT chunk_schema || '.' || chunk_name
+        FROM timescaledb_information.chunks
+        WHERE hypertable_name = 'fixes'
+          AND is_compressed = true
+        ORDER BY range_start
+    """
+    output = run_sql(sql, return_output=True)
+    return [c.strip() for c in output.split('\n') if c.strip()]
+
+
+def decompress_chunk(chunk: str) -> tuple[str, float, bool]:
+    """Decompress a single chunk. Returns (chunk, duration, success)."""
+    start = time.time()
+    try:
+        result = run_sql(f"SELECT decompress_chunk('{chunk}');")
+        duration = time.time() - start
+        return (chunk, duration, True)
+    except Exception as e:
+        duration = time.time() - start
+        print(f"  Error decompressing {chunk}: {e}")
+        return (chunk, duration, False)
+
+
+def compress_chunk(chunk: str) -> tuple[str, float, bool]:
+    """Compress a single chunk. Returns (chunk, duration, success)."""
+    start = time.time()
+    try:
+        result = run_sql(f"SELECT compress_chunk('{chunk}');")
+        duration = time.time() - start
+        return (chunk, duration, True)
+    except Exception as e:
+        duration = time.time() - start
+        print(f"  Error compressing {chunk}: {e}")
+        return (chunk, duration, False)
+
+
+def update_fixes_for_chunk(chunk: str) -> tuple[str, int, float]:
+    """Update fixes in a specific chunk. Returns (chunk, count, duration)."""
+    # Get the time range for this chunk
+    chunk_name = chunk.split('.')[-1]
+    time_range_sql = f"""
+        SELECT range_start::text, range_end::text
+        FROM timescaledb_information.chunks
+        WHERE chunk_name = '{chunk_name}'
+    """
+    output = run_sql(time_range_sql, return_output=True)
+    if not output:
+        return (chunk, 0, 0)
+
+    range_start, range_end = output.split('|') if '|' in output else (None, None)
+    if not range_start:
+        return (chunk, 0, 0)
+
+    start = time.time()
+    update_sql = f"""
+        SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0;
+        UPDATE fixes fx
+        SET aircraft_id = m.icao_id
+        FROM aircraft_merge_mapping m
+        WHERE fx.aircraft_id = m.flarm_id
+          AND fx.received_at >= '{range_start}'::timestamptz
+          AND fx.received_at < '{range_end}'::timestamptz
+    """
+    result = subprocess.run(
+        ["psql", "-d", DB, "-c", update_sql],
+        capture_output=True, text=True
+    )
+    duration = time.time() - start
+
+    # Parse UPDATE count
+    count = 0
+    if "UPDATE" in result.stdout:
+        try:
+            count = int(result.stdout.split("UPDATE")[1].strip().split()[0])
+        except:
+            pass
+
+    return (chunk, count, duration)
+
+
+def main():
+    print(f"=== Parallel Fixes Update ===")
+    print(f"Database: {DB}")
+    print(f"Parallelism: {PARALLELISM}")
+    print()
+
+    # Check prerequisites
+    exists = run_sql(
+        "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = 'aircraft_merge_mapping')",
+        return_output=True
+    )
+    if exists != 't':
+        print("ERROR: aircraft_merge_mapping table not found.")
+        sys.exit(1)
+
+    aircraft_count = run_sql("SELECT COUNT(*) FROM aircraft_merge_mapping", return_output=True)
+    print(f"Aircraft to merge: {aircraft_count}")
+    print()
+
+    # Step 1: Get all compressed chunks
+    print("Step 1: Getting compressed chunks...")
+    chunks = get_compressed_chunks()
+    print(f"Found {len(chunks)} compressed chunks")
+
+    if not chunks:
+        print("No compressed chunks - running direct update...")
+        start = time.time()
+        result = subprocess.run([
+            "psql", "-d", DB, "-c",
+            """SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0;
+               UPDATE fixes fx
+               SET aircraft_id = m.icao_id
+               FROM aircraft_merge_mapping m
+               WHERE fx.aircraft_id = m.flarm_id"""
+        ], capture_output=True, text=True)
+        print(f"Update complete in {time.time() - start:.1f}s")
+        print(result.stdout)
+        return
+
+    # Step 2: Decompress all chunks in parallel
+    print()
+    print(f"Step 2: Decompressing {len(chunks)} chunks (parallelism={PARALLELISM})...")
+    decompress_start = time.time()
+
+    with ThreadPoolExecutor(max_workers=PARALLELISM) as executor:
+        futures = {executor.submit(decompress_chunk, chunk): chunk for chunk in chunks}
+        completed = 0
+        for future in as_completed(futures):
+            completed += 1
+            chunk, duration, success = future.result()
+            status = "OK" if success else "FAILED"
+            print(f"  [{completed}/{len(chunks)}] {chunk.split('.')[-1]}: {duration:.1f}s ({status})")
+
+    decompress_duration = time.time() - decompress_start
+    print(f"Decompression complete in {decompress_duration:.1f}s")
+
+    # Step 3: Bulk update
+    print()
+    print("Step 3: Bulk update (single query with decompression limit disabled)...")
+    update_start = time.time()
+
+    result = subprocess.run([
+        "psql", "-d", DB, "-c",
+        """SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0;
+           UPDATE fixes fx
+           SET aircraft_id = m.icao_id
+           FROM aircraft_merge_mapping m
+           WHERE fx.aircraft_id = m.flarm_id"""
+    ], capture_output=True, text=True)
+
+    update_duration = time.time() - update_start
+    print(f"Update complete in {update_duration:.1f}s")
+    print(result.stdout.strip())
+
+    # Step 4: Recompress all chunks in parallel
+    print()
+    print(f"Step 4: Recompressing {len(chunks)} chunks (parallelism={PARALLELISM})...")
+    compress_start = time.time()
+
+    # Need to get the list again since chunk names are the same
+    with ThreadPoolExecutor(max_workers=PARALLELISM) as executor:
+        futures = {executor.submit(compress_chunk, chunk): chunk for chunk in chunks}
+        completed = 0
+        for future in as_completed(futures):
+            completed += 1
+            chunk, duration, success = future.result()
+            status = "OK" if success else "FAILED"
+            print(f"  [{completed}/{len(chunks)}] {chunk.split('.')[-1]}: {duration:.1f}s ({status})")
+
+    compress_duration = time.time() - compress_start
+    print(f"Compression complete in {compress_duration:.1f}s")
+
+    # Summary
+    total_duration = time.time() - decompress_start
+    print()
+    print("=== Summary ===")
+    print(f"Chunks processed: {len(chunks)}")
+    print(f"Decompress time: {decompress_duration:.1f}s")
+    print(f"Update time: {update_duration:.1f}s")
+    print(f"Compress time: {compress_duration:.1f}s")
+    print(f"Total time: {total_duration:.1f}s")
+
+    # Verify
+    remaining = run_sql("""
+        SELECT COUNT(*)
+        FROM aircraft_merge_mapping m
+        WHERE EXISTS (
+            SELECT 1 FROM fixes fx
+            WHERE fx.aircraft_id = m.flarm_id
+            LIMIT 1
+        )
+    """, return_output=True)
+    print()
+    print(f"Aircraft IDs still needing fixes updated: {remaining}")
+
+    if remaining == "0":
+        print()
+        print("SUCCESS! All fixes updated.")
+        print("Next: Run 'diesel migration run' to complete migration 2")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add migration to drop `aircraft_merge_mapping` table (cleanup from out-of-band fixes update)
- Add helper scripts for running large hypertable updates out-of-band
- Filter DEBUG logs from Loki for all environments to reduce log volume

## Scripts Added

| Script | Purpose |
|--------|---------|
| `create-aircraft-merge-mapping.sql` | Creates mapping table for FLARM→ICAO deduplication |
| `decompress-all-fixes-chunks.sh` | Decompresses all compressed TimescaleDB chunks |
| `update_fixes_decompress_first.sh` | Sequential: decompress → bulk update → skip recompress |
| `update_fixes_parallel.py` | Parallel version with configurable worker count |

These scripts enable running large hypertable updates (like the 16.5M fixes update in `deduplicate_aircraft_registration`) out-of-band to avoid slow transparent decompression during migrations.

## Alloy Config Change

Changed log filter from production-only to all environments:
```diff
- "severity_number < 9 and resource.attributes[\"deployment.environment\"] == \"production\""
+ "severity_number < 9"
```

DEBUG logs are still available in journalctl for debugging.

## Test plan

- [x] Migration tested on production (already deployed `deduplicate_aircraft_registration`)
- [ ] Verify `aircraft_merge_mapping` table is dropped on next deploy
- [ ] Verify Loki stops receiving DEBUG logs after Alloy restart