### PR TITLE
Fix overlapping click on live map showing both airport and airspace modals

### DIFF
--- a/infrastructure/dashboards/definitions/run.json
+++ b/infrastructure/dashboards/definitions/run.json
@@ -76,6 +76,7 @@
     "rejected-coalesce-gap-duration",
     "flight-timeouts-by-phase",
     "flight-phase-definitions",
-    "flight-creation-5m"
+    "flight-creation-5m",
+    "spurious-flights-archived"
   ]
 }

--- a/infrastructure/dashboards/panels/run/spurious-flights-archived.json
+++ b/infrastructure/dashboards/panels/run/spurious-flights-archived.json
@@ -1,0 +1,92 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisBorderShow": false,
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "barWidthFactor": 0.6,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+          "legend": false,
+          "tooltip": false,
+          "viz": false
+        },
+        "insertNulls": false,
+        "lineInterpolation": "linear",
+        "lineWidth": 1,
+        "pointSize": 5,
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "showPoints": "never",
+        "showValues": false,
+        "spanNulls": false,
+        "stacking": {
+          "group": "A",
+          "mode": "none"
+        },
+        "thresholdsStyle": {
+          "mode": "off"
+        }
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": 0
+          }
+        ]
+      },
+      "unit": "short"
+    },
+    "overrides": []
+  },
+  "options": {
+    "legend": {
+      "calcs": [
+        "mean",
+        "lastNotNull",
+        "max"
+      ],
+      "displayMode": "table",
+      "placement": "bottom",
+      "showLegend": true
+    },
+    "tooltip": {
+      "hideZeros": false,
+      "mode": "multi",
+      "sort": "desc"
+    }
+  },
+  "pluginVersion": "12.2.1",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "editorMode": "code",
+      "expr": "sum(increase(flight_tracker_spurious_flights_archived_total{component=\"run\",environment=\"$environment\"}[5m])) or vector(0)",
+      "legendFormat": "Spurious Flights Archived",
+      "range": true,
+      "refId": "A"
+    }
+  ],
+  "title": "Spurious Flights Archived (5m)",
+  "type": "timeseries"
+}

--- a/migrations/2026-01-30-154531-0000_create_spurious_flights_table/down.sql
+++ b/migrations/2026-01-30-154531-0000_create_spurious_flights_table/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE spurious_flights;
+DROP TYPE spurious_flight_reason;

--- a/migrations/2026-01-30-154531-0000_create_spurious_flights_table/up.sql
+++ b/migrations/2026-01-30-154531-0000_create_spurious_flights_table/up.sql
@@ -1,0 +1,50 @@
+CREATE TYPE spurious_flight_reason AS ENUM (
+    'duration_too_short',
+    'altitude_range_insufficient',
+    'max_agl_too_low',
+    'excessive_altitude',
+    'excessive_speed'
+);
+
+CREATE TABLE spurious_flights (
+    -- All columns from flights table (identical schema, no foreign keys)
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    device_address VARCHAR(20) NOT NULL,
+    takeoff_time TIMESTAMPTZ,
+    landing_time TIMESTAMPTZ,
+    club_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    device_address_type address_type NOT NULL,
+    aircraft_id UUID,
+    takeoff_altitude_offset_ft INT4,
+    landing_altitude_offset_ft INT4,
+    takeoff_runway_ident TEXT,
+    landing_runway_ident TEXT,
+    total_distance_meters FLOAT8,
+    maximum_displacement_meters FLOAT8,
+    departure_airport_id INT4,
+    arrival_airport_id INT4,
+    towed_by_aircraft_id UUID,
+    towed_by_flight_id UUID,
+    tow_release_altitude_msl_ft INT4,
+    tow_release_time TIMESTAMPTZ,
+    runways_inferred BOOLEAN,
+    takeoff_location_id UUID,
+    landing_location_id UUID,
+    start_location_id UUID,
+    end_location_id UUID,
+    timed_out_at TIMESTAMPTZ,
+    timeout_phase timeout_phase,
+    last_fix_at TIMESTAMPTZ NOT NULL,
+    tow_release_height_delta_ft INT4,
+    callsign TEXT,
+    min_latitude FLOAT8,
+    max_latitude FLOAT8,
+    min_longitude FLOAT8,
+    max_longitude FLOAT8,
+    -- Spurious flight metadata
+    reasons spurious_flight_reason[] NOT NULL,
+    reason_descriptions TEXT[] NOT NULL,
+    detected_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -58,6 +58,10 @@ pub mod sql_types {
     pub struct RegistrantType;
 
     #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "spurious_flight_reason"))]
+    pub struct SpuriousFlightReason;
+
+    #[derive(diesel::query_builder::QueryId, Clone, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "timeout_phase"))]
     pub struct TimeoutPhase;
 
@@ -850,6 +854,56 @@ diesel::table! {
 diesel::table! {
     use diesel::sql_types::*;
     use postgis_diesel::sql_types::*;
+    use super::sql_types::AddressType;
+    use super::sql_types::TimeoutPhase;
+    use super::sql_types::SpuriousFlightReason;
+
+    spurious_flights (id) {
+        id -> Uuid,
+        #[max_length = 20]
+        device_address -> Varchar,
+        takeoff_time -> Nullable<Timestamptz>,
+        landing_time -> Nullable<Timestamptz>,
+        club_id -> Nullable<Uuid>,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+        device_address_type -> AddressType,
+        aircraft_id -> Nullable<Uuid>,
+        takeoff_altitude_offset_ft -> Nullable<Int4>,
+        landing_altitude_offset_ft -> Nullable<Int4>,
+        takeoff_runway_ident -> Nullable<Text>,
+        landing_runway_ident -> Nullable<Text>,
+        total_distance_meters -> Nullable<Float8>,
+        maximum_displacement_meters -> Nullable<Float8>,
+        departure_airport_id -> Nullable<Int4>,
+        arrival_airport_id -> Nullable<Int4>,
+        towed_by_aircraft_id -> Nullable<Uuid>,
+        towed_by_flight_id -> Nullable<Uuid>,
+        tow_release_altitude_msl_ft -> Nullable<Int4>,
+        tow_release_time -> Nullable<Timestamptz>,
+        runways_inferred -> Nullable<Bool>,
+        takeoff_location_id -> Nullable<Uuid>,
+        landing_location_id -> Nullable<Uuid>,
+        start_location_id -> Nullable<Uuid>,
+        end_location_id -> Nullable<Uuid>,
+        timed_out_at -> Nullable<Timestamptz>,
+        timeout_phase -> Nullable<TimeoutPhase>,
+        last_fix_at -> Timestamptz,
+        tow_release_height_delta_ft -> Nullable<Int4>,
+        callsign -> Nullable<Text>,
+        min_latitude -> Nullable<Float8>,
+        max_latitude -> Nullable<Float8>,
+        min_longitude -> Nullable<Float8>,
+        max_longitude -> Nullable<Float8>,
+        reasons -> Array<Nullable<SpuriousFlightReason>>,
+        reason_descriptions -> Array<Nullable<Text>>,
+        detected_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use postgis_diesel::sql_types::*;
 
     states (code) {
         #[max_length = 2]
@@ -1039,6 +1093,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     runways,
     server_messages,
     spatial_ref_sys,
+    spurious_flights,
     states,
     status_codes,
     type_aircraft,

--- a/web/src/lib/services/maplibre/AirspaceLayerManager.ts
+++ b/web/src/lib/services/maplibre/AirspaceLayerManager.ts
@@ -269,13 +269,25 @@ export class AirspaceLayerManager {
 		this.map.on('click', FILL_LAYER_ID, (e) => {
 			if (!e.features || e.features.length === 0) return;
 
-			// Check if an aircraft was clicked - if so, don't show airspace modal
-			// Aircraft layer has higher priority for click handling
+			// Check if an aircraft or airport was clicked - if so, don't show airspace modal
+			// Aircraft and airport layers have higher priority for click handling
 			const aircraftFeatures = this.map!.queryRenderedFeatures(e.point, {
 				layers: ['aircraft-markers']
 			});
 			if (aircraftFeatures.length > 0) {
 				return; // Aircraft clicked, let aircraft handler deal with it
+			}
+
+			const airportLayers = ['airports-symbols', 'airports-symbols-circle'].filter((id) =>
+				this.map!.getLayer(id)
+			);
+			if (airportLayers.length > 0) {
+				const airportFeatures = this.map!.queryRenderedFeatures(e.point, {
+					layers: airportLayers
+				});
+				if (airportFeatures.length > 0) {
+					return; // Airport clicked, let airport handler deal with it
+				}
 			}
 
 			const feature = e.features[0];


### PR DESCRIPTION
## Summary
- When an airport marker sits inside an airspace polygon on the `/live` map, clicking the airport triggered both the airport and airspace modals simultaneously
- Added an airport feature check in the airspace click handler (same pattern already used for aircraft markers) so it yields to the airport handler when both overlap

## Test plan
- [ ] On `/live`, enable both airports and airspaces layers
- [ ] Click an airport that's inside an airspace polygon — only the airport modal should appear
- [ ] Click an airspace area with no airport — the airspace modal should still appear
- [ ] Click an aircraft over an airspace — only the aircraft modal should appear (existing behavior, unchanged)