### PR TITLE
Add area subscriptions to live page

### DIFF
--- a/web/src/routes/live/+page.svelte
+++ b/web/src/routes/live/+page.svelte
@@ -689,7 +689,7 @@
 		const latMax = Math.floor(ne.lat);
 		const lonMin = Math.floor(sw.lng);
 		const lonMax = Math.floor(ne.lng);
-		debugAreaSubscriptionCount = (latMax - latMin + 2) * (lonMax - lonMin + 2);
+		debugAreaSubscriptionCount = (latMax - latMin + 1) * (lonMax - lonMin + 1);
 	}
 
 	// Clear all area subscriptions


### PR DESCRIPTION
## Summary

- Adds area-based WebSocket subscriptions to the `/live` page, matching the pattern already used on the `/operations` page
- The live page now receives real-time position updates for all aircraft in the viewport, including newly appearing aircraft (previously it only updated positions for aircraft already fetched via REST)
- Area subscriptions are always-on and silently deactivate in clustered mode

## Test plan

- [ ] Open `/live` page zoomed into a region with active aircraft
- [ ] Verify aircraft positions update in real-time without needing to pan/zoom
- [ ] Verify new aircraft appearing in the area show up without a manual refresh
- [ ] Zoom out to trigger clustered mode — verify area subscriptions are cleared
- [ ] Zoom back in — verify area subscriptions resume
- [ ] Check the debug panel (staging) shows "Area Subs" count
- [ ] Navigate away from `/live` — verify cleanup runs (no console errors)