### PR TITLE
Improve aircraft detail page: club link, Plane icon, Unified DDB

### DIFF
--- a/web/src/lib/components/AircraftStatusModal.svelte
+++ b/web/src/lib/components/AircraftStatusModal.svelte
@@ -514,7 +514,7 @@
 													? 'preset-filled-success-500'
 													: 'preset-filled-secondary-500'}"
 											>
-												{selectedAircraft.fromOgnDdb ? 'In OGN DB' : 'Not in OGN DB'}
+												{selectedAircraft.fromOgnDdb ? 'In Unified DDB' : 'Not in Unified DDB'}
 											</span>
 										</dd>
 									</div>

--- a/web/src/lib/components/AircraftTile.svelte
+++ b/web/src/lib/components/AircraftTile.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Radio, Plane, Antenna, Check, Activity, Map, Navigation } from '@lucide/svelte';
+	import { Plane, Antenna, Check, Activity, Map, Navigation } from '@lucide/svelte';
 	import { resolve } from '$app/paths';
 	import {
 		getAircraftCategoryDescription,
@@ -70,7 +70,7 @@
 				{#if flagUrl()}
 					<img src={flagUrl()} alt="" class="inline-block h-5 rounded-sm" />
 				{:else}
-					<Radio class="h-5 w-5 text-primary-500" />
+					<Plane class="h-5 w-5 text-primary-500" />
 				{/if}
 				<h3 class="text-lg font-semibold">{getAircraftTitle(aircraft)}</h3>
 			</div>
@@ -112,7 +112,7 @@
 			{#if aircraft.fromOgnDdb}
 				<span class="badge preset-filled-success-500 text-xs">
 					<Check class="mr-1 h-3 w-3" />
-					OGN DB
+					Unified DDB
 				</span>
 			{/if}
 			{#if aircraft.aircraftCategory}

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
-	import { Users, Radar, Radio, Antenna, MapPin, Plane, Camera, Globe } from '@lucide/svelte';
+	import { Users, Radar, Antenna, MapPin, Plane, Camera, Globe } from '@lucide/svelte';
 	import { auth } from '$lib/stores/auth';
 
 	const clubsPath = resolve('/clubs');
@@ -128,7 +128,7 @@
 							<div
 								class="rounded-full bg-tertiary-500/20 p-4 transition-colors group-hover:bg-tertiary-500/30"
 							>
-								<Radio size={48} class="text-white drop-shadow-lg" />
+								<Plane size={48} class="text-white drop-shadow-lg" />
 							</div>
 						</div>
 						<div class="space-y-2">

--- a/web/src/routes/aircraft/+page.svelte
+++ b/web/src/routes/aircraft/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import {
 		Search,
-		Radio,
 		Plane,
 		Antenna,
 		Building2,
@@ -229,7 +228,7 @@
 	<!-- Header -->
 	<header class="space-y-2 text-center">
 		<h1 class="flex items-center justify-center gap-2 h1">
-			<Radio class="h-8 w-8" />
+			<Plane class="h-8 w-8" />
 			Aircraft
 		</h1>
 	</header>

--- a/web/src/routes/aircraft/issues/+page.svelte
+++ b/web/src/routes/aircraft/issues/+page.svelte
@@ -164,7 +164,7 @@
 								<th class="p-3 text-left font-semibold">Address Type</th>
 								<th class="p-3 text-left font-semibold">Registration</th>
 								<th class="p-3 text-left font-semibold">Aircraft Model</th>
-								<th class="p-3 text-left font-semibold">From DDB</th>
+								<th class="p-3 text-left font-semibold">In Unified DDB</th>
 								<th class="p-3 text-left font-semibold">Tracked</th>
 								<th class="p-3 text-left font-semibold">Last Fix</th>
 							</tr>


### PR DESCRIPTION
## Summary
- Add club name as a clickable link in the aircraft registration card, fetched in parallel with registration and model data
- Replace Radio icon with Plane icon on home page aircraft button, aircraft list page header, and aircraft tile flag fallback
- Rename "OGN DB" to "Unified DDB" across all aircraft views (detail page, tiles, status modal, issues page)
- Show "Not in Unified DDB" badge when aircraft is not in the database, matching the existing ADSB Exchange badge pattern

## Test plan
- [ ] Verify aircraft detail page shows club name as a link when aircraft is assigned to a club
- [ ] Verify home page shows Plane icon for the Aircraft button
- [ ] Verify aircraft list page header uses Plane icon
- [ ] Verify aircraft tiles use Plane icon as fallback when no country flag is available
- [ ] Verify "Unified DDB" badge appears on aircraft detail page for both in/not-in states
- [ ] Verify "Unified DDB" label in aircraft status modal and issues page