### PR TITLE
Add approved operations to aircraft registration API response

### DIFF
--- a/src/actions/views/aircraft.rs
+++ b/src/actions/views/aircraft.rs
@@ -41,6 +41,8 @@ pub struct AircraftRegistrationView {
     pub model: Option<AircraftModelView>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aircraft_category: Option<AircraftCategory>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub approved_operations: Vec<String>,
 }
 
 impl From<AircraftDomain> for AircraftRegistrationView {
@@ -71,8 +73,9 @@ impl From<AircraftDomain> for AircraftRegistrationView {
             other_names: aircraft.other_names,
             light_sport_type: aircraft.light_sport_type,
             aircraft_id: aircraft.aircraft_id,
-            model: None,             // Will be set when fetching with model data
-            aircraft_category: None, // Will be set when fetching with device data
+            model: None,                     // Will be set when fetching with model data
+            aircraft_category: None,         // Will be set when fetching with device data
+            approved_operations: Vec::new(), // Loaded separately from aircraft_approved_operations table
         }
     }
 }
@@ -109,6 +112,7 @@ impl From<crate::aircraft_registrations::AircraftRegistrationModel> for Aircraft
             aircraft_id: model.aircraft_id,
             model: None,
             aircraft_category: None,
+            approved_operations: Vec::new(),
         }
     }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -713,11 +713,11 @@ pub async fn start_web_server(interface: String, port: u16, pool: PgPool) -> Res
         .route("/aircraft/{id}/club", put(actions::update_aircraft_club))
         .route(
             "/aircraft/{id}/registration",
-            get(actions::aircraft::get_device_aircraft_registration),
+            get(actions::aircraft::get_aircraft_registration),
         )
         .route(
             "/aircraft/{id}/model",
-            get(actions::aircraft::get_device_aircraft_model),
+            get(actions::aircraft::get_aircraft_model),
         )
         // Receiver routes
         .route("/receivers", get(actions::search_receivers))


### PR DESCRIPTION
## Summary
- Add `approvedOperations` field (`Vec<String>`) to `AircraftRegistrationView`, populated from the `aircraft_approved_operations` table via a new repo query method
- Rename "device" references in handler and repo method names to "aircraft" (`get_device_aircraft_registration` → `get_aircraft_registration`, etc.)

## Test plan
- [ ] Verify `/aircraft/{id}/registration` API response includes `approvedOperations` array when operations exist
- [ ] Verify `approvedOperations` is omitted from JSON when empty (via `skip_serializing_if`)
- [ ] Verify aircraft registration and model endpoints still work after handler renames