### PR TITLE
Fix OGN ingest rate always showing 0.0/s

### DIFF
--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -634,6 +634,7 @@ pub async fn handle_ingest(config: IngestConfig) -> Result<()> {
 
         let queue_for_ogn = queue.clone();
         let aprs_health = aprs_health_shared.clone();
+        let stats_rx = stats_ogn_received.clone();
 
         tokio::spawn(async move {
             let mut client = AprsClient::new(config);
@@ -642,7 +643,11 @@ pub async fn handle_ingest(config: IngestConfig) -> Result<()> {
             // with timestamps captured at receive time
             loop {
                 match client
-                    .start_with_envelope_queue(queue_for_ogn.clone(), aprs_health.clone())
+                    .start_with_envelope_queue(
+                        queue_for_ogn.clone(),
+                        aprs_health.clone(),
+                        Some(stats_rx.clone()),
+                    )
                     .await
                 {
                     Ok(_) => {


### PR DESCRIPTION
## Summary
- The `stats_ogn_received` atomic counter was created but never passed to the APRS client, so the per-source OGN frame counter was never incremented
- The EWMA for OGN rate was always fed `0 / 30s = 0.0`, keeping the displayed rate permanently at `0.0/s` despite records increasing
- Added `stats_counter` parameter to `AprsClient::start_with_envelope_queue` (matching the existing Beast and SBS client signatures) and pass `stats_ogn_received` from the ingest command

## Test plan
- [ ] Deploy to staging and verify OGN rate in stats log shows non-zero values
- [ ] Verify Beast and SBS rates are unaffected
- [ ] Confirm `ingest.messages_per_second{source="OGN"}` Prometheus metric is populated