### PR TITLE
Fix ingest dashboard "Total (queued)" metric

### DIFF
--- a/infrastructure/dashboards/panels/ingest/messages-queued-per-second.json
+++ b/infrastructure/dashboards/panels/ingest/messages-queued-per-second.json
@@ -80,7 +80,7 @@
         "uid": "prometheus"
       },
       "editorMode": "code",
-      "expr": "rate(queue_ingest_messages_buffered_total{component=\"ingest\",environment=~\"$environment\"}[1m])",
+      "expr": "rate(aprs_raw_message_queued_aprs_total{component=\"ingest\",environment=~\"$environment\"}[1m]) + rate(beast_frames_published_total{component=\"ingest\",environment=~\"$environment\"}[1m])",
       "legendFormat": "Total (queued)",
       "range": true,
       "refId": "A"


### PR DESCRIPTION
## Summary

- Fix the "Total (queued)" line in the "Messages Queued per Second" panel to show actual total throughput instead of only disk-spillover events

The previous query used `queue_ingest_messages_buffered_total`, which only counts messages spilled to disk (the slow/overflow path). This is almost always zero during normal operation, spiking only during spillover episodes. Replaced with the sum of the APRS and Beast per-source rates to show actual combined throughput.

## Test plan

- [x] `python3 infrastructure/dashboards/build.py --verify` passes
- [ ] Verify in Grafana that "Total (queued)" now tracks as the sum of APRS + Beast lines