### PR TITLE
Bump bytes to 1.11.1 to fix RUSTSEC-2026-0007

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,9 +1155,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bcrypt = "0.18"
 bigdecimal = { version = "0.4", features = ["serde"] }
 axum = { version = "0.8.8", features = ["macros", "ws"] }
 axum-extra = { version = "0.12.5", features = ["typed-header"] }
-bytes = "1.11"
+bytes = "=1.11.1"
 http-body = "1.0"
 http-body-util = "0.1"
 pin-project = "1.0"


### PR DESCRIPTION
## Summary

- Pins `bytes` to exactly `1.11.1` to resolve RUSTSEC-2026-0007 (integer overflow in `BytesMut::reserve`)

## Test plan

- [ ] `cargo audit` passes