### PR TITLE
Use native cargo build for x64 musl release binary

### DIFF
--- a/.github/workflows/build-cross-x64.yml
+++ b/.github/workflows/build-cross-x64.yml
@@ -1,0 +1,151 @@
+name: Build x64 Release with Cross (Manual)
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      upload_artifact:
+        description: 'Upload the x64 binary as an artifact'
+        required: false
+        default: 'true'
+        type: boolean
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  build-web:
+    name: Build SvelteKit Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./web
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # Fetch all history for git tags (needed for vergen version)
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build SvelteKit project
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: npm run build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: web-build
+          path: web/build/
+          retention-days: 1
+
+  build-release-cross-x64:
+    name: Build Release Binary (x64 Static musl via Cross)
+    runs-on: ubuntu-22.04
+    needs: build-web
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # Fetch all history for git tags (needed for vergen version)
+
+      - name: Download web build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: web-build
+          path: web/build/
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: x86_64-unknown-linux-musl
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: "release-build-cross-x64-musl"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-all-crates: true
+
+      - name: Cache cross
+        id: cache-cross
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/cross
+          key: ${{ runner.os }}-cross-0.2.5
+
+      - name: Install cross
+        if: steps.cache-cross.outputs.cache-hit != 'true'
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Install protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Build static release binary
+        env:
+          SKIP_WEB_BUILD: "1"  # Frontend already built via downloaded artifacts
+          # CRITICAL: tokio_unstable is required for tokio-console support
+          # Without this flag, --enable-tokio-console will cause exit code 101 with no output
+          # CRITICAL: force-frame-pointers=yes is required for Pyroscope profiling
+          # Without frame pointers, flame graphs show unhelpful "[unknown]" frames
+          RUSTFLAGS: "--cfg tokio_unstable -C target-feature=+crt-static -C link-arg=-static -C force-frame-pointers=yes"
+        run: cross build --release --target x86_64-unknown-linux-musl --features bundled-postgres
+
+      - name: Verify static linking
+        run: |
+          echo "Checking if binary is statically linked..."
+          file target/x86_64-unknown-linux-musl/release/soar
+
+          # Check for dynamic dependencies (should show "statically linked")
+          if ldd target/x86_64-unknown-linux-musl/release/soar 2>&1 | grep -q "not a dynamic executable"; then
+            echo "✓ Binary is statically linked (no dynamic dependencies)"
+          else
+            echo "⚠ Binary has dynamic dependencies:"
+            ldd target/x86_64-unknown-linux-musl/release/soar || true
+          fi
+
+      - name: Create binary archive
+        run: |
+          rm -rf release
+          mkdir -p release
+          cp target/x86_64-unknown-linux-musl/release/soar release/
+          cp README.md release/ || echo "No README.md found"
+          tar -czf soar-linux-x64.tar.gz -C release .
+
+      - name: Upload release binary
+        if: ${{ inputs.upload_artifact }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: soar-linux-x64
+          path: soar-linux-x64.tar.gz
+          retention-days: 30
+
+      - name: Show binary info
+        run: |
+          echo "Binary size:"
+          ls -lh target/x86_64-unknown-linux-musl/release/soar
+          echo ""
+          echo "Binary info:"
+          file target/x86_64-unknown-linux-musl/release/soar
+          echo ""
+          echo "Stripped binary size:"
+          cp target/x86_64-unknown-linux-musl/release/soar /tmp/soar-stripped
+          strip /tmp/soar-stripped
+          ls -lh /tmp/soar-stripped

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,7 +447,7 @@ jobs:
           docker rm postgres || true
 
   build-release:
-    name: Build Release Binary (Static musl)
+    name: Build Release Binary (Native Static musl)
     runs-on: ubuntu-22.04
     needs: test-sveltekit
 
@@ -472,23 +472,12 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
-          shared-key: "release-build-musl"
+          shared-key: "release-build-native-musl"
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-all-crates: true
 
-      - name: Cache cross
-        id: cache-cross
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cross
-          key: ${{ runner.os }}-cross-0.2.5
-
-      - name: Install cross
-        if: steps.cache-cross.outputs.cache-hit != 'true'
-        run: cargo install cross --git https://github.com/cross-rs/cross
-
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Install musl tools and protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y musl-tools protobuf-compiler
 
       - name: Build static release binary
         env:
@@ -498,7 +487,7 @@ jobs:
           # CRITICAL: force-frame-pointers=yes is required for Pyroscope profiling
           # Without frame pointers, flame graphs show unhelpful "[unknown]" frames
           RUSTFLAGS: "--cfg tokio_unstable -C target-feature=+crt-static -C link-arg=-static -C force-frame-pointers=yes"
-        run: cross build --release --target x86_64-unknown-linux-musl --features bundled-postgres
+        run: cargo build --release --target x86_64-unknown-linux-musl --features bundled-postgres
 
       - name: Verify static linking
         run: |


### PR DESCRIPTION
## Summary
- Replace `cross build` with native `cargo build` for the x64 musl release binary in CI, since the runners are already x86_64 Linux and cross-compilation is unnecessary
- Move the cross-based x64 build to a new manual-only workflow (`build-cross-x64.yml`) for cases where it's still needed
- Install `musl-tools` package instead of the `cross` tool in the main pipeline

## Test plan
- [ ] Verify CI `build-release` job succeeds with native `cargo build --target x86_64-unknown-linux-musl`
- [ ] Verify the produced binary is statically linked
- [ ] Verify `build-cross-x64.yml` can be triggered manually from the Actions tab