### PR TITLE
Add disable clustering toggle to /live map settings

### DIFF
--- a/web/src/lib/components/SettingsModal.svelte
+++ b/web/src/lib/components/SettingsModal.svelte
@@ -21,6 +21,7 @@
 		showReceiverMarkers?: boolean;
 		showAirspaceMarkers?: boolean;
 		showRunwayOverlays?: boolean;
+		disableClustering?: boolean;
 	}
 
 	// Settings state
@@ -29,6 +30,7 @@
 	let showReceiverMarkers = $state(true);
 	let showAirspaceMarkers = $state(true);
 	let showRunwayOverlays = $state(false);
+	let disableClustering = $state(false);
 
 	// Settings persistence functions
 	async function loadSettings() {
@@ -50,6 +52,7 @@
 					showReceiverMarkers = backendSettings.showReceiverMarkers ?? true;
 					showAirspaceMarkers = backendSettings.showAirspaceMarkers ?? true;
 					showRunwayOverlays = backendSettings.showRunwayOverlays ?? false;
+					disableClustering = backendSettings.disableClustering ?? false;
 					return;
 				}
 			} catch (e) {
@@ -69,6 +72,7 @@
 				showReceiverMarkers = settings.showReceiverMarkers ?? true;
 				showAirspaceMarkers = settings.showAirspaceMarkers ?? true;
 				showRunwayOverlays = settings.showRunwayOverlays ?? false;
+				disableClustering = settings.disableClustering ?? false;
 			} catch (e) {
 				logger.warn('Failed to load settings from localStorage: {error}', { error: e });
 			}
@@ -83,7 +87,8 @@
 			showAirportMarkers,
 			showReceiverMarkers,
 			showAirspaceMarkers,
-			showRunwayOverlays
+			showRunwayOverlays,
+			disableClustering
 		};
 
 		// Always save to localStorage for offline support
@@ -114,7 +119,8 @@
 				showAirportMarkers,
 				showReceiverMarkers,
 				showAirspaceMarkers,
-				showRunwayOverlays
+				showRunwayOverlays,
+				disableClustering
 			});
 		}
 	}
@@ -254,6 +260,20 @@
 								<Switch.Thumb />
 							</Switch.Control>
 							<Switch.HiddenInput name="runways-toggle" />
+						</Switch>
+						<Switch
+							class="flex justify-between p-2"
+							checked={disableClustering}
+							onCheckedChange={(details) => {
+								disableClustering = details.checked;
+								saveSettings();
+							}}
+						>
+							<Switch.Label class="text-sm font-medium">Disable Clustering</Switch.Label>
+							<Switch.Control>
+								<Switch.Thumb />
+							</Switch.Control>
+							<Switch.HiddenInput name="clustering-toggle" />
 						</Switch>
 					</div>
 				</section>


### PR DESCRIPTION
## Summary
- Add a `cluster` query parameter to the aircraft bounding box search endpoint, allowing clients to opt out of server-side clustering
- Add a "Disable Clustering" toggle in the /live page settings modal
- When the toggle is enabled, all individual aircraft markers are returned regardless of count (still respecting the `limit` cap)
- Restores clustering threshold to 2000 aircraft

## Test plan
- [ ] Open /live, zoom out to global view — should see cluster markers as before
- [ ] Open Settings, enable "Disable Clustering", zoom out — should see individual aircraft markers instead of clusters
- [ ] Toggle setting off — clusters should reappear on next viewport change
- [ ] Verify setting persists across page reloads (localStorage and backend for authenticated users)