### PR TITLE
Fix coverage hexes BigInt decoding error

### DIFF
--- a/src/coverage_repo.rs
+++ b/src/coverage_repo.rs
@@ -114,7 +114,7 @@ impl CoverageRepository {
                     FROM bbox
                 )
                 SELECT rch.h3_index, rch.resolution,
-                       SUM(rch.fix_count) AS fix_count,
+                       SUM(rch.fix_count)::bigint AS fix_count,
                        MIN(rch.first_seen_at) AS first_seen_at,
                        MAX(rch.last_seen_at) AS last_seen_at,
                        MIN(rch.min_altitude_msl_feet) AS min_altitude_msl_feet,


### PR DESCRIPTION
## Summary
- Cast `SUM(rch.fix_count)` to `::bigint` in the coverage hexes query
- PostgreSQL `SUM()` on a `BIGINT` column returns `NUMERIC`, which Diesel cannot decode as `i64` (it sends more than 8 bytes on the wire)
- This caused a 500 error on `/data/coverage/hexes`: "Received more than 8 bytes while decoding an i64"

## Test plan
- [ ] Verify `/data/coverage/hexes` returns valid GeoJSON instead of the BigInt error