### PR TITLE
Fix flight map screen showing black canvas

### DIFF
--- a/web/src/routes/flights/[id]/map/+page.svelte
+++ b/web/src/routes/flights/[id]/map/+page.svelte
@@ -677,23 +677,18 @@
 </script>
 
 <!-- Container that fills viewport - using fixed positioning to break out of main container -->
-<div class="fixed inset-x-0 top-[42px] bottom-0 w-full overflow-hidden">
+<div class="fixed inset-x-0 top-[42px] bottom-0 flex w-full flex-col overflow-hidden">
 	<!-- Map container -->
-	<div
-		bind:this={mapContainer}
-		class="absolute top-0 right-0 left-0"
-		class:bottom-[48px]={isPanelCollapsed}
-		class:bottom-[300px]={!isPanelCollapsed}
-	></div>
+	<div bind:this={mapContainer} class="relative flex-1"></div>
 
-	<!-- Back button (top-left) -->
+	<!-- Back button (top-left, overlays map) -->
 	<button onclick={goBack} class="location-btn absolute top-4 left-4 z-[80]" title="Back to Flight">
 		<ArrowLeft size={20} />
 	</button>
 
 	<!-- Bottom panel with altitude chart -->
 	<div
-		class="bg-surface-50-900-token absolute right-0 bottom-0 left-0 z-[80] shadow-lg transition-all duration-300"
+		class="bg-surface-50-900-token z-[80] flex-shrink-0 shadow-lg transition-all duration-300"
 		style={isPanelCollapsed ? 'height: 48px;' : 'height: 300px;'}
 	>
 		<!-- Panel header -->


### PR DESCRIPTION
## Summary

- Fix the full-screen flight map page (`/flights/{id}/map`) showing a black MapLibre canvas instead of satellite tiles
- The map container was using absolute positioning with dynamic `class:bottom-[48px]`/`class:bottom-[300px]` Svelte directives to set its height, which wasn't working correctly
- Switched to the same **flexbox layout** approach used by the working live map page: `flex-col` parent with `flex-1` map container and `flex-shrink-0` bottom panel

## Test plan

- [ ] Navigate to a flight detail page and click "Full Screen" map button
- [ ] Verify the satellite map renders correctly (not black)
- [ ] Verify the flight track line and arrow markers are visible
- [ ] Toggle the bottom panel (collapse/expand) and verify the map resizes correctly
- [ ] Verify the back button and panel controls still work