### PR TITLE
Fix duplicate aircraft merge failing on tow-plane FK

### DIFF
--- a/src/aircraft_repo.rs
+++ b/src/aircraft_repo.rs
@@ -875,6 +875,15 @@ impl AircraftRepository {
                         .execute(conn)
                         .context("reassigning flights")?;
 
+                        // Reassign tow-plane references from the duplicate to the target
+                        diesel::update(
+                            flights::table
+                                .filter(flights::towed_by_aircraft_id.eq(dup.id)),
+                        )
+                        .set(flights::towed_by_aircraft_id.eq(target.id))
+                        .execute(conn)
+                        .context("reassigning towed-by flights")?;
+
                         // Reassign spurious flights from the duplicate to the target
                         diesel::update(
                             spurious_flights::table
@@ -883,6 +892,15 @@ impl AircraftRepository {
                         .set(spurious_flights::aircraft_id.eq(target.id))
                         .execute(conn)
                         .context("reassigning spurious flights")?;
+
+                        // Reassign tow-plane references in spurious flights
+                        diesel::update(
+                            spurious_flights::table
+                                .filter(spurious_flights::towed_by_aircraft_id.eq(dup.id)),
+                        )
+                        .set(spurious_flights::towed_by_aircraft_id.eq(target.id))
+                        .execute(conn)
+                        .context("reassigning spurious towed-by flights")?;
 
                         // Delete the duplicate first, then copy its addresses to the target.
                         // This avoids two problems:


### PR DESCRIPTION
## Summary
- When merging duplicate aircraft, `towed_by_aircraft_id` references in `flights` and `spurious_flights` were not being reassigned to the target aircraft before deleting the duplicate
- This caused a foreign key violation (`flights_towed_by_aircraft_id_fkey`) when the duplicate had been used as a tow plane

## Test plan
- [x] `cargo check` passes
- [x] Pre-commit hooks pass (clippy, fmt, tests)
- [ ] Verify `pull-data` no longer errors on aircraft with tow-plane references (e.g. N9892P)