### PR TITLE
Remove max retry limit — retry connections indefinitely

### DIFF
--- a/src/aprs_client.rs
+++ b/src/aprs_client.rs
@@ -29,8 +29,6 @@ pub struct AprsClientConfig {
     pub server: String,
     /// APRS server port
     pub port: u16,
-    /// Maximum number of connection retry attempts
-    pub max_retries: u32,
     /// Callsign for authentication
     pub callsign: String,
     /// Password for authentication (optional)
@@ -50,7 +48,6 @@ impl Default for AprsClientConfig {
         Self {
             server: "aprs.glidernet.org".to_string(),
             port: 14580,
-            max_retries: 5,
             callsign: "N0CALL".to_string(),
             password: None,
             filter: None,
@@ -614,11 +611,6 @@ impl AprsClientConfigBuilder {
         self
     }
 
-    pub fn max_retries(mut self, max_retries: u32) -> Self {
-        self.config.max_retries = max_retries;
-        self
-    }
-
     pub fn callsign<S: Into<String>>(mut self, callsign: S) -> Self {
         self.config.callsign = callsign.into();
         self
@@ -673,7 +665,6 @@ mod tests {
             .callsign("TEST123")
             .password(Some("12345"))
             .filter(Some("r/47.0/-122.0/100"))
-            .max_retries(3)
             .retry_delay_seconds(10)
             .build();
 
@@ -682,7 +673,6 @@ mod tests {
         assert_eq!(config.callsign, "TEST123");
         assert_eq!(config.password, Some("12345".to_string()));
         assert_eq!(config.filter, Some("r/47.0/-122.0/100".to_string()));
-        assert_eq!(config.max_retries, 3);
         assert_eq!(config.retry_delay_seconds, 10);
     }
 
@@ -727,7 +717,6 @@ mod tests {
             callsign: "TEST123".to_string(),
             password: Some("12345".to_string()),
             filter: Some("r/47.0/-122.0/100".to_string()),
-            max_retries: 3,
             retry_delay_seconds: 5,
             max_retry_delay_seconds: 60,
             archive_base_dir: None,
@@ -748,7 +737,6 @@ mod tests {
             callsign: "TEST123".to_string(),
             password: None,
             filter: None,
-            max_retries: 3,
             retry_delay_seconds: 5,
             max_retry_delay_seconds: 60,
             archive_base_dir: None,

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -54,7 +54,6 @@ pub struct IngestConfig {
     pub beast_servers: Vec<String>,
     pub sbs_servers: Vec<String>,
     // Common parameters
-    pub max_retries: u32,
     pub retry_delay: u64,
 }
 
@@ -66,7 +65,6 @@ pub async fn handle_ingest(config: IngestConfig) -> Result<()> {
         ogn_filter,
         beast_servers,
         sbs_servers,
-        max_retries,
         retry_delay,
     } = config;
     // Validate that at least one source is specified
@@ -628,7 +626,6 @@ pub async fn handle_ingest(config: IngestConfig) -> Result<()> {
             .port(ogn_port_final)
             .callsign(ogn_callsign)
             .filter(ogn_filter)
-            .max_retries(max_retries)
             .retry_delay_seconds(retry_delay)
             .build();
 
@@ -669,7 +666,6 @@ pub async fn handle_ingest(config: IngestConfig) -> Result<()> {
         let config = BeastClientConfig {
             server: server.clone(),
             port,
-            max_retries,
             retry_delay_seconds: retry_delay,
             max_retry_delay_seconds: 60,
         };
@@ -703,7 +699,6 @@ pub async fn handle_ingest(config: IngestConfig) -> Result<()> {
         let config = SbsClientConfig {
             server: server.clone(),
             port,
-            max_retries,
             retry_delay_seconds: retry_delay,
             max_retry_delay_seconds: 60,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,10 +150,6 @@ enum Commands {
         #[arg(long)]
         sbs: Vec<String>,
 
-        /// Maximum number of connection retry attempts
-        #[arg(long, default_value = "5")]
-        max_retries: u32,
-
         /// Delay between reconnection attempts in seconds
         #[arg(long, default_value = "5")]
         retry_delay: u64,
@@ -1105,7 +1101,6 @@ async fn main() -> Result<()> {
             ogn_filter,
             beast,
             sbs,
-            max_retries,
             retry_delay,
         } => {
             // Unified ingest service uses persistent queues + Unix sockets, doesn't need database
@@ -1116,7 +1111,6 @@ async fn main() -> Result<()> {
                 ogn_filter: ogn_filter.clone(),
                 beast_servers: beast.clone(),
                 sbs_servers: sbs.clone(),
-                max_retries: *max_retries,
                 retry_delay: *retry_delay,
             })
             .await;


### PR DESCRIPTION
## Summary

- Removes the `--max-retries` CLI argument and `max_retries` config field from all ingest clients (Beast, SBS, APRS/OGN)
- All ingest clients now retry connections indefinitely with exponential backoff, matching the expected behavior for a long-running service
- Previously, ingest would give up after 5 (default) failed connection attempts, causing the service to exit if a remote server was temporarily unavailable

## Test plan
- [x] `cargo check` — compiles cleanly
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- [x] `cargo test --verbose` — all tests pass
- [x] Pre-commit hooks pass (fmt, clippy, tests, audit)