### PR TITLE
Update ogn-parser to v0.3.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4320,8 +4320,8 @@ dependencies = [
 
 [[package]]
 name = "ogn-parser"
-version = "0.3.15"
-source = "git+https://github.com/hut8/ogn-parser-rs?branch=master#332bf4d3dc41a186dd6e8c69db599881e2b3daf2"
+version = "0.3.16"
+source = "git+https://github.com/hut8/ogn-parser-rs?branch=master#991bb67c5018a912ee0895240cd55c1e38fbf58d"
 dependencies = [
  "chrono",
  "flat_projection",


### PR DESCRIPTION
## Summary

- Updates ogn-parser to v0.3.16 which eliminates all remaining unsafe string slicing across every parser source file (lonlat, timestamp, packet, position, status, position_comment, status_comment)
- Every direct `s[a..b]` index operation replaced with `str::get()` to return errors instead of panicking on non-ASCII input
- Follows up on v0.3.15 which fixed the specific `position_comment.rs` and `status_comment.rs` panics

## Test plan

- [x] ogn-parser-rs: all 115 tests pass (PR #8, merged)
- [x] `cargo check` passes
- [x] `cargo clippy` passes (via pre-commit hook)
- [ ] Deploy to staging and verify no panics