### PR TITLE
Fix pprof 404s and isolate profiling targets by environment

### DIFF
--- a/infrastructure/alloy-config.alloy.template
+++ b/infrastructure/alloy-config.alloy.template
@@ -107,7 +107,7 @@ otelcol.exporter.otlphttp "tempo" {
 
 // Discover SOAR processes and scrape pprof endpoints
 // The SOAR Rust application exposes pprof endpoints at:
-// - /debug/pprof/profile?seconds=5 (CPU profiling - 5 seconds)
+// - /debug/pprof/profile (CPU profiling - server caps duration at 5 seconds)
 // - /debug/pprof/heap (Heap profiling)
 //
 // Service metrics ports (from src/commands/*.rs):
@@ -115,6 +115,7 @@ otelcol.exporter.otlphttp "tempo" {
 // - ingest:      production=9095, staging=9197
 // - soar-web:    No pprof endpoints (metrics only at /data/metrics on main port)
 
+// BEGIN:production
 // Scrape production soar-run service (port 9091)
 // Note: service_name is required for Pyroscope to identify the service
 // service_repository and service_git_ref enable source code linking in Grafana Profiles
@@ -148,7 +149,9 @@ discovery.relabel "soar_ingest" {
     replacement  = "soar-ingest"
   }
 }
+// END:production
 
+// BEGIN:staging
 // Scrape staging soar-run service (port 9192)
 discovery.relabel "soar_run_staging" {
   targets = [{
@@ -180,10 +183,12 @@ discovery.relabel "soar_ingest_staging" {
     replacement  = "soar-ingest-staging"
   }
 }
+// END:staging
 
-// CPU profiling scraper - scrapes /debug/pprof/profile
+// BEGIN:production
+// CPU profiling scraper (production) - scrapes /debug/pprof/profile
 // SOAR services return pprof protobuf format with configurable duration via ?seconds=N
-// Default: 10 seconds profiling, so we need scrape timeout > 10s
+// The Rust handler caps duration at 5 seconds regardless of what Alloy passes.
 //
 // Note: SOAR is a Rust application using the `pprof` crate, which only supports
 // CPU profiling. Go-specific profile types (memory, goroutine, mutex, block)
@@ -192,23 +197,21 @@ pyroscope.scrape "soar_cpu" {
   targets = concat(
     discovery.relabel.soar_run.output,
     discovery.relabel.soar_ingest.output,
-    discovery.relabel.soar_run_staging.output,
-    discovery.relabel.soar_ingest_staging.output,
   )
 
   forward_to = [pyroscope.write.endpoint.receiver]
 
-  // Scrape every 60 seconds with a 20s timeout (profile takes 5s + serialization overhead)
+  // Scrape every 60 seconds with a 20s timeout (profile takes <=5s + serialization overhead)
   scrape_interval = "60s"
   scrape_timeout  = "20s"
 
   profiling_config {
     // CPU profiling - the only profile type supported by Rust pprof crate
-    // Explicitly set ?seconds=5 to override Alloy's default of passing scrape_timeout as the
-    // profiling duration, which left no time for report serialization and caused timeouts.
+    // Do NOT put query params in path - Alloy URL-encodes ? to %3F causing 404s.
+    // The Rust handler caps profiling duration at 5 seconds server-side.
     profile.process_cpu {
       enabled = true
-      path    = "/debug/pprof/profile?seconds=5"
+      path    = "/debug/pprof/profile"
       delta   = false
     }
 
@@ -227,6 +230,48 @@ pyroscope.scrape "soar_cpu" {
     }
   }
 }
+// END:production
+
+// BEGIN:staging
+// CPU profiling scraper (staging) - scrapes /debug/pprof/profile
+pyroscope.scrape "soar_cpu_staging" {
+  targets = concat(
+    discovery.relabel.soar_run_staging.output,
+    discovery.relabel.soar_ingest_staging.output,
+  )
+
+  forward_to = [pyroscope.write.endpoint.receiver]
+
+  // Scrape every 60 seconds with a 20s timeout (profile takes <=5s + serialization overhead)
+  scrape_interval = "60s"
+  scrape_timeout  = "20s"
+
+  profiling_config {
+    // CPU profiling - the only profile type supported by Rust pprof crate
+    // Do NOT put query params in path - Alloy URL-encodes ? to %3F causing 404s.
+    // The Rust handler caps profiling duration at 5 seconds server-side.
+    profile.process_cpu {
+      enabled = true
+      path    = "/debug/pprof/profile"
+      delta   = false
+    }
+
+    // Disable Go-specific profile types that SOAR doesn't support
+    profile.memory {
+      enabled = false
+    }
+    profile.block {
+      enabled = false
+    }
+    profile.goroutine {
+      enabled = false
+    }
+    profile.mutex {
+      enabled = false
+    }
+  }
+}
+// END:staging
 
 // Write profiles to Pyroscope
 pyroscope.write "endpoint" {

--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -1085,10 +1085,22 @@ if [ -f "$DEPLOY_DIR/alloy-config.alloy.template" ]; then
         log_warn "VERSION file not found, profiling source links will not work"
     fi
 
-    # Process template and install
+    # Determine the opposite environment to strip its blocks
+    if [ "$ENVIRONMENT" = "staging" ]; then
+        STRIP_ENV="production"
+    else
+        STRIP_ENV="staging"
+    fi
+
+    # Process template: replace placeholders and strip blocks for the other environment.
+    # Lines between "// BEGIN:<other-env>" and "// END:<other-env>" (inclusive) are removed.
     sed -e "s|{{GIT_COMMIT}}|$GIT_COMMIT|g" \
+        -e "/^\/\/ BEGIN:${STRIP_ENV}$/,/^\/\/ END:${STRIP_ENV}$/d" \
+        -e "/^\/\/ BEGIN:${ENVIRONMENT}$/d" \
+        -e "/^\/\/ END:${ENVIRONMENT}$/d" \
         "$DEPLOY_DIR/alloy-config.alloy.template" \
         > /etc/alloy/config.alloy
+    log_info "Stripped $STRIP_ENV-only blocks, kept $ENVIRONMENT blocks"
     sudo chown alloy:alloy /etc/alloy/config.alloy
     sudo chmod 644 /etc/alloy/config.alloy
     log_info "Alloy configuration installed with git commit: $GIT_COMMIT"


### PR DESCRIPTION
Alloy URL-encodes the path field, so ?seconds=5 became %3Fseconds=5 causing 404s on both soar-run-staging and soar-ingest-staging. Fix by removing query params from the scrape path and capping profile duration at 5 seconds server-side in the Rust handler.

Add environment markers (BEGIN/END:production, BEGIN/END:staging) to the Alloy config template so soar-deploy strips targets for the other environment, preventing staging from trying to scrape production ports.