### PR TITLE
Deploy prometheus defaults to enable remote-write-receiver for Tempo

### DIFF
--- a/infrastructure/prometheus-defaults
+++ b/infrastructure/prometheus-defaults
@@ -3,4 +3,4 @@
 # Install to: /etc/default/prometheus
 
 # Enable remote-write-receiver to allow Tempo to push span metrics
-ARGS="--web.enable-remote-write-receiver"
+ARGS="--config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/var/lib/prometheus/metrics2/ --web.enable-remote-write-receiver"

--- a/infrastructure/prometheus-systemd-override.conf
+++ b/infrastructure/prometheus-systemd-override.conf
@@ -1,9 +1,0 @@
-# Prometheus systemd service override
-# Install to: /etc/systemd/system/prometheus.service.d/override.conf
-
-[Service]
-ExecStart=
-ExecStart=/usr/bin/prometheus \
-  --config.file=/etc/prometheus/prometheus.yml \
-  --web.listen-address=127.0.0.1:9090 \
-  --web.enable-remote-write-receiver

--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -666,8 +666,44 @@ else
     log_warn "prometheus-jobs directory not found in deployment, skipping Prometheus configuration"
 fi
 
+# Install Prometheus defaults file (enables remote-write-receiver for Tempo)
+PROMETHEUS_DEFAULTS_CHANGED=false
+if [ -f "$DEPLOY_DIR/prometheus-defaults" ]; then
+    log_info "Installing Prometheus defaults file..."
+
+    # Check if config differs from current
+    if [ -f "/etc/default/prometheus" ]; then
+        if ! diff -q "$DEPLOY_DIR/prometheus-defaults" "/etc/default/prometheus" > /dev/null 2>&1; then
+            log_info "Prometheus defaults have changed, updating..."
+            cp "$DEPLOY_DIR/prometheus-defaults" /etc/default/prometheus
+            chmod 644 /etc/default/prometheus
+            PROMETHEUS_DEFAULTS_CHANGED=true
+            log_info "Prometheus defaults file updated"
+        else
+            log_info "Prometheus defaults unchanged, skipping"
+        fi
+    else
+        log_info "No existing Prometheus defaults, installing..."
+        cp "$DEPLOY_DIR/prometheus-defaults" /etc/default/prometheus
+        chmod 644 /etc/default/prometheus
+        PROMETHEUS_DEFAULTS_CHANGED=true
+        log_info "Prometheus defaults file installed"
+    fi
+else
+    log_warn "prometheus-defaults not found in deployment, skipping"
+fi
+
 # Reload Prometheus if job configurations were updated
-if [ "$PROMETHEUS_NEEDS_RELOAD" = true ]; then
+# Restart Prometheus if defaults changed (requires restart for command-line args)
+if [ "$PROMETHEUS_DEFAULTS_CHANGED" = true ]; then
+    if systemctl is-active --quiet prometheus; then
+        log_info "Prometheus defaults changed - restarting Prometheus to apply new arguments..."
+        systemctl restart prometheus || log_warn "Failed to restart Prometheus"
+        log_info "Prometheus restarted successfully"
+    else
+        log_warn "Prometheus is not running, skipping restart"
+    fi
+elif [ "$PROMETHEUS_NEEDS_RELOAD" = true ]; then
     if systemctl is-active --quiet prometheus; then
         log_info "Reloading Prometheus to load new scrape configurations..."
         systemctl reload prometheus || log_warn "Failed to reload Prometheus"

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -171,6 +171,12 @@ for config_file in tempo-config.yml loki-config.yml pyroscope-config.yml alloy-c
     fi
 done
 
+# Copy Prometheus defaults (for enabling remote-write-receiver)
+if [ -f "infrastructure/prometheus-defaults" ]; then
+    cp infrastructure/prometheus-defaults "$DEPLOY_PKG/"
+    log_info "Prometheus defaults included"
+fi
+
 # Copy backup scripts directory
 if [ -d "scripts/backup" ]; then
     mkdir -p "$DEPLOY_PKG/scripts"


### PR DESCRIPTION
## Summary
- Fixes Tempo's "remote write receiver needs to be enabled" errors
- Deploys prometheus-defaults to enable `--web.enable-remote-write-receiver` flag
- Removes redundant prometheus-systemd-override.conf (defaults file is the proper mechanism)

## Context
Tempo's metrics generator pushes span metrics to Prometheus via remote write at `http://127.0.0.1:9090/api/v1/write`. Prometheus requires the `--web.enable-remote-write-receiver` flag to accept these requests.

The `infrastructure/prometheus-defaults` file existed but was never deployed. This PR adds it to the deployment process.

## Changes
1. Deleted `infrastructure/prometheus-systemd-override.conf` (redundant approach)
2. Updated `infrastructure/prometheus-defaults` with complete ARGS including the flag
3. Updated `scripts/deploy` to copy prometheus-defaults to deployment package
4. Updated `infrastructure/soar-deploy` to install prometheus-defaults and restart Prometheus when changed