### PR TITLE
Add message type distribution metrics for SBS and Beast

### DIFF
--- a/infrastructure/dashboards/definitions/run.json
+++ b/infrastructure/dashboards/definitions/run.json
@@ -57,6 +57,8 @@
       "row": "Data Ingestion Pipelines"
     },
     "aprs-type-distribution-before-filtering",
+    "sbs-message-type-distribution",
+    ["beast-df-type-distribution", "beast-adsb-bds-type-distribution"],
     "receiver-cache-hit-rate",
     "receiver-cache-hitmiss",
     "beast-fixes-processed",

--- a/infrastructure/dashboards/panels/run/beast-adsb-bds-type-distribution.json
+++ b/infrastructure/dashboards/panels/run/beast-adsb-bds-type-distribution.json
@@ -1,0 +1,90 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisBorderShow": false,
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "barWidthFactor": 0.6,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+          "legend": false,
+          "tooltip": false,
+          "viz": false
+        },
+        "insertNulls": false,
+        "lineInterpolation": "linear",
+        "lineWidth": 1,
+        "pointSize": 5,
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+          "group": "A",
+          "mode": "none"
+        },
+        "thresholdsStyle": {
+          "mode": "off"
+        }
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      },
+      "unit": "ops"
+    },
+    "overrides": []
+  },
+  "options": {
+    "legend": {
+      "calcs": [
+        "mean",
+        "lastNotNull",
+        "max"
+      ],
+      "displayMode": "table",
+      "placement": "bottom",
+      "showLegend": true
+    },
+    "tooltip": {
+      "mode": "multi",
+      "sort": "desc"
+    }
+  },
+  "pluginVersion": "12.2.1",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "editorMode": "code",
+      "expr": "rate(beast_run_adsb_bds_type_total{component=\"run\",environment=\"$environment\"}[5m])",
+      "legendFormat": "{{bds}}",
+      "range": true,
+      "refId": "A"
+    }
+  ],
+  "title": "Beast ADS-B Message Subtype (BDS) Distribution",
+  "type": "timeseries"
+}

--- a/infrastructure/dashboards/panels/run/beast-df-type-distribution.json
+++ b/infrastructure/dashboards/panels/run/beast-df-type-distribution.json
@@ -1,0 +1,90 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisBorderShow": false,
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "barWidthFactor": 0.6,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+          "legend": false,
+          "tooltip": false,
+          "viz": false
+        },
+        "insertNulls": false,
+        "lineInterpolation": "linear",
+        "lineWidth": 1,
+        "pointSize": 5,
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+          "group": "A",
+          "mode": "none"
+        },
+        "thresholdsStyle": {
+          "mode": "off"
+        }
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      },
+      "unit": "ops"
+    },
+    "overrides": []
+  },
+  "options": {
+    "legend": {
+      "calcs": [
+        "mean",
+        "lastNotNull",
+        "max"
+      ],
+      "displayMode": "table",
+      "placement": "bottom",
+      "showLegend": true
+    },
+    "tooltip": {
+      "mode": "multi",
+      "sort": "desc"
+    }
+  },
+  "pluginVersion": "12.2.1",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "editorMode": "code",
+      "expr": "rate(beast_run_df_type_total{component=\"run\",environment=\"$environment\"}[5m])",
+      "legendFormat": "{{df}}",
+      "range": true,
+      "refId": "A"
+    }
+  ],
+  "title": "Beast Downlink Format (DF) Distribution",
+  "type": "timeseries"
+}

--- a/infrastructure/dashboards/panels/run/sbs-message-type-distribution.json
+++ b/infrastructure/dashboards/panels/run/sbs-message-type-distribution.json
@@ -1,0 +1,90 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisBorderShow": false,
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "barWidthFactor": 0.6,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+          "legend": false,
+          "tooltip": false,
+          "viz": false
+        },
+        "insertNulls": false,
+        "lineInterpolation": "linear",
+        "lineWidth": 1,
+        "pointSize": 5,
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+          "group": "A",
+          "mode": "none"
+        },
+        "thresholdsStyle": {
+          "mode": "off"
+        }
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      },
+      "unit": "ops"
+    },
+    "overrides": []
+  },
+  "options": {
+    "legend": {
+      "calcs": [
+        "mean",
+        "lastNotNull",
+        "max"
+      ],
+      "displayMode": "table",
+      "placement": "bottom",
+      "showLegend": true
+    },
+    "tooltip": {
+      "mode": "multi",
+      "sort": "desc"
+    }
+  },
+  "pluginVersion": "12.2.1",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "editorMode": "code",
+      "expr": "rate(sbs_run_message_type_total{component=\"run\",environment=\"$environment\"}[5m])",
+      "legendFormat": "{{type}}",
+      "range": true,
+      "refId": "A"
+    }
+  ],
+  "title": "SBS Message Type Distribution",
+  "type": "timeseries"
+}

--- a/src/commands/run/sbs.rs
+++ b/src/commands/run/sbs.rs
@@ -63,6 +63,19 @@ pub(crate) async fn process_sbs_message(
         }
     };
 
+    // Track message type distribution
+    let type_label = match sbs_msg.message_type {
+        soar::sbs::SbsMessageType::EsIdentification => "MSG,1 Identification",
+        soar::sbs::SbsMessageType::EsSurfacePosition => "MSG,2 Surface Position",
+        soar::sbs::SbsMessageType::EsAirbornePosition => "MSG,3 Airborne Position",
+        soar::sbs::SbsMessageType::EsAirborneVelocity => "MSG,4 Airborne Velocity",
+        soar::sbs::SbsMessageType::SurveillanceAlt => "MSG,5 Surveillance Alt",
+        soar::sbs::SbsMessageType::SurveillanceId => "MSG,6 Surveillance ID",
+        soar::sbs::SbsMessageType::AirToAir => "MSG,7 Air-to-Air",
+        soar::sbs::SbsMessageType::AllCallReply => "MSG,8 All Call Reply",
+    };
+    metrics::counter!("sbs.run.message_type_total", "type" => type_label).increment(1);
+
     // Extract ICAO address from the aircraft_id field (hex string)
     let icao_address = match sbs_msg.icao_address() {
         Some(icao) => icao,


### PR DESCRIPTION
## Summary

- Adds per-type message rate metrics for both SBS and Beast/Mode S protocols, giving visibility into the composition of incoming ADS-B data streams
- **SBS**: `sbs.run.message_type_total` counter labeled by MSG type (1-8: Identification, Surface Position, Airborne Position, Airborne Velocity, Surveillance Alt, Surveillance ID, Air-to-Air, All Call Reply)
- **Beast DF**: `beast.run.df_type_total` counter labeled by Mode S Downlink Format (DF0, DF4, DF5, DF11, DF16, DF17, DF18, DF19, DF20, DF21, DF24)
- **Beast ADS-B subtypes**: `beast.run.adsb_bds_type_total` counter (DF17 only) labeled by BDS subtype (BDS05 Airborne Position, BDS06 Surface Position, BDS08 Identification, BDS09 Airborne Velocity, BDS61 Aircraft Status, BDS62 Target State, BDS65 Operation Status)
- Three new Grafana panels on the Run dashboard under "Data Ingestion Pipelines"

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt` clean
- [x] Pre-commit hooks pass (clippy, tests, formatting)
- [x] `python3 infrastructure/dashboards/build.py --verify` passes
- [ ] Deploy to staging and verify metrics appear in Prometheus
- [ ] Verify Grafana panels render correctly with real data