### PR TITLE
Fix git version showing VERGEN_IDEMPOTENT_OUTPUT in CI builds

### DIFF
--- a/.github/soar-ci.Dockerfile
+++ b/.github/soar-ci.Dockerfile
@@ -66,7 +66,10 @@ RUN cargo install diesel_cli --no-default-features --features postgres --version
     rm -rf /usr/local/cargo/registry /usr/local/cargo/git
 
 # Mark all directories as safe for git (needed for actions/checkout in containers)
-RUN git config --global --add safe.directory '*'
+# Use --system instead of --global because GitHub Actions overrides HOME=/github/home
+# at container runtime, making the global gitconfig (written to /root/.gitconfig at
+# build time) invisible. System-level config (/etc/gitconfig) persists regardless of HOME.
+RUN git config --system --add safe.directory '*'
 
 # Disable incremental compilation for CI (standard practice)
 ENV CARGO_INCREMENTAL=0


### PR DESCRIPTION
## Summary
- Use `--system` instead of `--global` for `git config safe.directory` in the CI container Dockerfile
- GitHub Actions overrides `HOME=/github/home` at container runtime, making the global gitconfig (written to `/root/.gitconfig` at Docker build time) invisible to git, libgit2 (vergen), and the SvelteKit version generator during `cargo build`
- System-level config (`/etc/gitconfig`) persists regardless of `HOME`, fixing the issue

## Root cause
PR #1093 moved CI jobs into a container (`ghcr.io/hut8/soar-ci:latest`). The Dockerfile correctly ran `git config --global --add safe.directory '*'`, but `--global` writes to `/root/.gitconfig`. At runtime, GitHub Actions sets `HOME=/github/home`, so git looks at `/github/home/.gitconfig` instead — which doesn't have the safe.directory setting. This caused vergen to fall back to `VERGEN_IDEMPOTENT_OUTPUT`.

## Test plan
- [ ] CI image rebuild triggers and completes
- [ ] Subsequent CI runs show correct `VERGEN_GIT_DESCRIBE` (no "set to default" warnings)
- [ ] `soar --version` shows proper git-derived version string