### PR TITLE
Switch to jemalloc to fix musl allocator lock contention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6450,6 +6450,7 @@ dependencies = [
  "sha2",
  "sitemap-rs",
  "tempfile",
+ "tikv-jemallocator",
  "tokio",
  "tower",
  "tower-http",
@@ -6887,6 +6888,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ resolver = "2"
 # This includes all static libraries needed for fully static binaries
 bundled-postgres = ["pq-sys/bundled", "dep:openssl", "openssl/vendored"]
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.6"
+
 [dependencies]
 anyhow = "1.0"
 argon2 = "0.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use diesel::connection::{Instrumentation, InstrumentationEvent, set_default_instrumentation};


### PR DESCRIPTION
## Summary
- Replace musl's default allocator with jemalloc via `tikv-jemallocator`
- Wall-clock profiling of `soar-run-staging` showed ~37% of time spent contending on musl's global allocator lock (`__lock`/`__unlock` → futex syscalls)
- musl uses a single global lock for its allocator, which becomes a severe bottleneck with tokio's multi-threaded runtime
- jemalloc uses per-thread arenas, eliminating this contention

## Profiling data (30s wall-clock capture)
| Function | % wall-clock | Description |
|---|---|---|
| `native_queued_spin_lock_slowpath` | 18.1% | Kernel spinlock from futex contention |
| `syscall_return_via_sysret` | 9.8% | Returning from futex syscalls |
| `__lock` | 7.2% | musl allocator lock (userspace) |
| `__libc_malloc_impl` | 4.1% | musl malloc |
| `__unlock` | 2.3% | musl allocator unlock |
| `alloc_slot` | 2.7% | musl allocator internals |
| `__libc_free` | 2.6% | musl free |
| **Total allocator overhead** | **~37%** | |

## Test plan
- [ ] CI passes (clippy, tests, build)
- [ ] Deploy to staging and verify reduced lock contention via wall-clock profile
- [ ] Verify no regression in functionality