### PR TITLE
Fix AR reactivity: broken derived values and non-reactive map updates

### DIFF
--- a/web/src/lib/components/ar/AircraftMarker.svelte
+++ b/web/src/lib/components/ar/AircraftMarker.svelte
@@ -23,7 +23,7 @@
 	);
 
 	// Scale crosshair based on distance (closer = larger)
-	const crosshairSize = $derived(() => {
+	const crosshairSize = $derived.by(() => {
 		if (aircraft.distance < 5) return 64;
 		if (aircraft.distance < 15) return 56;
 		if (aircraft.distance < 30) return 48;
@@ -41,8 +41,8 @@
 		<!-- Crosshair reticle -->
 		<svg
 			class="crosshair"
-			width={crosshairSize()}
-			height={crosshairSize()}
+			width={crosshairSize}
+			height={crosshairSize}
 			viewBox="0 0 64 64"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"

--- a/web/src/lib/components/ar/DirectionIndicator.svelte
+++ b/web/src/lib/components/ar/DirectionIndicator.svelte
@@ -26,7 +26,7 @@
 
 	// Calculate relative bearing from device heading to aircraft
 	// Normalize to -180 to 180
-	const relativeBearing = $derived(() => {
+	const relativeBearing = $derived.by(() => {
 		let bearing = targetAircraft.bearing - deviceOrientation.heading;
 		while (bearing > 180) bearing -= 360;
 		while (bearing < -180) bearing += 360;
@@ -34,16 +34,16 @@
 	});
 
 	// Calculate adjusted elevation accounting for device pitch
-	const adjustedElevation = $derived(() => {
+	const adjustedElevation = $derived.by(() => {
 		return targetAircraft.elevation - deviceOrientation.pitch;
 	});
 
 	// Determine which direction to show based on relative bearing and elevation
 	// Use FOV settings for accurate thresholds
 	// Supports diagonal directions when both horizontal and vertical are off-screen
-	const direction = $derived((): Direction => {
-		const rb = relativeBearing();
-		const elev = adjustedElevation();
+	const direction = $derived.by((): Direction => {
+		const rb = relativeBearing;
+		const elev = adjustedElevation;
 		const hFovHalf = settings.fovHorizontal / 2;
 		const vFovHalf = settings.fovVertical / 2;
 
@@ -81,9 +81,9 @@
 
 	// Calculate the arrow rotation angle for diagonal/angled directions
 	// Returns angle in degrees (0 = up, 90 = right, etc.)
-	const arrowAngle = $derived(() => {
-		const rb = relativeBearing();
-		const elev = adjustedElevation();
+	const arrowAngle = $derived.by(() => {
+		const rb = relativeBearing;
+		const elev = adjustedElevation;
 
 		// Calculate angle from center to target position
 		// atan2 gives angle in radians, convert to degrees
@@ -94,9 +94,9 @@
 	});
 
 	// Calculate how far off-screen (for intensity of indicator)
-	const intensity = $derived(() => {
-		const rb = Math.abs(relativeBearing());
-		const elev = Math.abs(adjustedElevation());
+	const intensity = $derived.by(() => {
+		const rb = Math.abs(relativeBearing);
+		const elev = Math.abs(adjustedElevation);
 		const hFovHalf = settings.fovHorizontal / 2;
 		const vFovHalf = settings.fovVertical / 2;
 
@@ -116,9 +116,9 @@
 	}
 </script>
 
-{#if direction() !== 'in-view'}
-	<div class="direction-indicator {direction()}" class:intense={intensity() >= 2}>
-		<div class="indicator-content" style:--arrow-angle="{arrowAngle()}deg">
+{#if direction !== 'in-view'}
+	<div class="direction-indicator {direction}" class:intense={intensity >= 2}>
+		<div class="indicator-content" style:--arrow-angle="{arrowAngle}deg">
 			<!-- Use ChevronUp rotated to point in the actual direction -->
 			<ChevronUp size={40} class="arrow rotated-arrow" />
 			<ChevronUp size={40} class="arrow rotated-arrow arrow-2" />


### PR DESCRIPTION
## Summary

- **Fix `aircraftPositions` not triggering reactivity**: The `updateAircraftProjections` function was creating a new `SvelteMap` and reassigning the variable every ~100ms. In Svelte 5 runes mode, plain `let` reassignment is not reactive—only `SvelteMap`'s built-in `.set()`/`.delete()` methods trigger updates. Changed to mutate the existing map in place (set new entries, delete stale ones).
- **Fix `$derived(() => ...)` → `$derived.by(() => ...)`** across `DirectionIndicator.svelte`, `AircraftMarker.svelte`, and `+page.svelte`: Using `$derived(() => { ... })` makes the derived value equal to the arrow function itself (a stable reference that never changes), not the computed result. This broke Svelte's dependency tracking for visibility checks, direction indicators, crosshair sizing, and arrow angles.
- **Fix template function call syntax**: Removed `()` calls on derived values in templates (e.g., `crosshairSize()` → `crosshairSize`, `direction()` → `direction`) since they are now proper values, not functions.

## Test plan

- [ ] Open AR view on mobile device, verify aircraft markers appear and move as phone orientation changes
- [ ] Check debug panel: "on screen" count should change as you rotate the phone (not stay stuck at 0 or 1)
- [ ] Select a target aircraft from the list — direction indicator arrows should appear and update in real-time as you rotate
- [ ] Point phone toward the target aircraft — arrows should disappear and the marker should be visible on screen
- [ ] Verify crosshair sizes scale correctly based on aircraft distance