### PR TITLE
Fix KML/IGC export showing wrong takeoff airport

### DIFF
--- a/src/flight_tracker/runway.rs
+++ b/src/flight_tracker/runway.rs
@@ -1,5 +1,5 @@
 use crate::aircraft::Aircraft;
-use crate::fixes_repo::FixesRepository;
+use crate::fixes_repo::{FixOrder, FixesRepository};
 use crate::magnetic::MagneticService;
 use crate::runways_repo::RunwaysRepository;
 use chrono::{DateTime, Utc};
@@ -95,7 +95,13 @@ pub(crate) async fn determine_runway_identifier(
     }
 
     let fixes = match fixes_repo
-        .get_fixes_for_aircraft_with_time_range(&device_id, start_time, end_time, None)
+        .get_fixes_for_aircraft_with_time_range(
+            &device_id,
+            start_time,
+            end_time,
+            None,
+            FixOrder::Ascending,
+        )
         .await
     {
         Ok(f) if !f.is_empty() => {

--- a/src/flights.rs
+++ b/src/flights.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 
 use crate::Fix;
 use crate::aircraft::{AddressType, Aircraft};
+use crate::fixes_repo::FixOrder;
 use crate::geometry::spline::{GeoPoint, calculate_spline_distance, generate_spline_path};
 
 /// Flight state enum representing the current status of a flight
@@ -434,6 +435,7 @@ impl Flight {
                     start_time,
                     end_time,
                     None,
+                    FixOrder::Ascending,
                 )
                 .await?
         };
@@ -544,6 +546,7 @@ impl Flight {
                     start_time,
                     end_time,
                     None,
+                    FixOrder::Ascending,
                 )
                 .await?
         };
@@ -595,6 +598,7 @@ impl Flight {
                 start_time,
                 end_time,
                 None,
+                FixOrder::Ascending,
             )
             .await?;
 
@@ -899,6 +903,7 @@ impl Flight {
                 start_time,
                 end_time,
                 None,
+                FixOrder::Ascending,
             )
             .await?;
 


### PR DESCRIPTION
## Summary

- Fixes a bug where KML exports showed takeoff from the wrong airport (e.g., CYZR instead of CYCK) because `get_fixes_for_aircraft_with_time_range` returned fixes in descending order, causing `fixes.first()` to return the landing location instead of the takeoff location
- Adds a `FixOrder` enum parameter to make sort order explicit at each call site, replacing the hardcoded `.desc()` ordering
- Removes the `fixes.reverse()` workaround in `get_flight_gaps` that was compensating for the wrong default order

## Test plan

- [ ] Verify KML export for flight `019c9b0c-62d3-76e0-9570-fa1d8ecaa671` shows takeoff from CYCK (not CYZR)
- [ ] Verify IGC export generates correct chronological fix ordering
- [ ] Verify flight path and fixes API endpoints return fixes in chronological order
- [ ] Verify flight gaps detection still works correctly without the `.reverse()` call
- [ ] Verify runway detection is unaffected (order doesn't matter for its analysis)