### PR TITLE
Downgrade socket send failure from error to warn

### DIFF
--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -308,7 +308,7 @@ pub async fn handle_ingest(config: IngestConfig) -> Result<()> {
                                 }
                             }
                             Err(e) => {
-                                error!(error = %e, "Failed to send message to socket");
+                                warn!(error = %e, "Failed to send message to socket (will retry)");
                                 metrics::counter!("ingest.socket_send_error_total").increment(1);
 
                                 // DON'T commit - message will be replayed on next recv()


### PR DESCRIPTION
## Summary
- Downgrades "Failed to send message to socket" from `error!` to `warn!` in the ingest process
- This is an expected transient condition when soar-run is unavailable — the message stays in the queue and is replayed on the next `recv()`, so no data is lost
- Stops unnecessary Sentry alerts for a non-error condition

## Test plan
- [ ] Verify ingest process logs at warn level when soar-run socket is unavailable
- [ ] Confirm messages are still buffered and replayed after reconnection
- [ ] Confirm Sentry no longer receives "Failed to send message to socket" events