### PR TITLE
Make AR controls panel span full screen width

### DIFF
--- a/web/src/lib/components/ar/ARControls.svelte
+++ b/web/src/lib/components/ar/ARControls.svelte
@@ -116,8 +116,10 @@
 		background: rgba(0, 0, 0, 0.85);
 		backdrop-filter: blur(12px);
 		border-radius: 1rem 1rem 0 0;
-		padding: 1rem 1.5rem;
+		padding-top: 1rem;
 		padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+		padding-left: calc(1.5rem + env(safe-area-inset-left, 0px));
+		padding-right: calc(1.5rem + env(safe-area-inset-right, 0px));
 		display: flex;
 		gap: 1rem;
 		align-items: center;


### PR DESCRIPTION
## Summary
- Removes the 500px max-width cap on the AR bottom controls panel so it spans the full width of the screen edge-to-edge
- Rounds only the top corners for a proper bottom-bar appearance
- Adds `env(safe-area-inset-bottom)` padding for notched/home-indicator devices (iPhone etc.)
- Gives the range slider and Live indicator significantly more room

## Test plan
- [ ] Open AR view on mobile — panel should span full width at the bottom
- [ ] Verify range slider has more room and tick labels are legible
- [ ] Verify Live indicator and action buttons are not crowded
- [ ] Test on an iPhone with a notch/home indicator — controls should not be obscured