### PR TITLE
Fix tail number backfill skipping all US ICAO aircraft

### DIFF
--- a/src/commands/load_data/aircraft_backfill.rs
+++ b/src/commands/load_data/aircraft_backfill.rs
@@ -215,25 +215,29 @@ async fn backfill_tail_numbers(pool: &PgPool) -> Result<usize> {
             devices_to_update.len()
         );
 
+        // Load all existing registrations into memory to avoid O(N) duplicate checks
+        let existing_registrations: std::collections::HashSet<String> = aircraft
+            .filter(registration.is_not_null().and(registration.ne("")))
+            .select(registration.assume_not_null())
+            .load::<String>(&mut conn)?
+            .into_iter()
+            .collect();
+
+        info!(
+            "Loaded {} existing registrations for duplicate checking",
+            existing_registrations.len()
+        );
+
         let mut updated_count = 0;
         let mut pending_count = 0;
 
-        // Iterate over each device and extract tail number
         for device_model in devices_to_update {
             let icao_addr = device_model.icao_address.expect("filtered for is_not_null");
             if let Some(tail_number) =
                 Aircraft::extract_tail_number_from_icao(icao_addr as u32, AddressType::Icao)
             {
-                // Check if another aircraft already owns this registration
-                let duplicate_exists = diesel::dsl::select(diesel::dsl::exists(
-                    aircraft
-                        .filter(registration.eq(&tail_number))
-                        .filter(id.ne(device_model.id)),
-                ))
-                .get_result::<bool>(&mut conn)?;
-
-                if duplicate_exists {
-                    // Store as pending_registration for async merge
+                if existing_registrations.contains(&tail_number) {
+                    // Another aircraft already owns this registration
                     match diesel::update(aircraft.filter(id.eq(device_model.id)))
                         .set(pending_registration.eq(&tail_number))
                         .execute(&mut conn)
@@ -253,7 +257,9 @@ async fn backfill_tail_numbers(pool: &PgPool) -> Result<usize> {
                         }
                     }
                 } else {
-                    // No conflict, set registration directly
+                    // No conflict, set registration directly. If a concurrent process
+                    // claimed this registration between our check and this update,
+                    // fall back to pending_registration.
                     match diesel::update(aircraft.filter(id.eq(device_model.id)))
                         .set(registration.eq(&tail_number))
                         .execute(&mut conn)
@@ -263,9 +269,24 @@ async fn backfill_tail_numbers(pool: &PgPool) -> Result<usize> {
                         }
                         Err(e) => {
                             warn!(
-                                "Failed to update device {} with tail number: {}",
-                                device_model.id, e
+                                "Unique constraint conflict for device {} with tail number {}, \
+                                 falling back to pending_registration: {}",
+                                device_model.id, tail_number, e
                             );
+                            match diesel::update(aircraft.filter(id.eq(device_model.id)))
+                                .set(pending_registration.eq(&tail_number))
+                                .execute(&mut conn)
+                            {
+                                Ok(_) => {
+                                    pending_count += 1;
+                                }
+                                Err(e2) => {
+                                    warn!(
+                                        "Failed to set pending_registration for device {}: {}",
+                                        device_model.id, e2
+                                    );
+                                }
+                            }
                         }
                     }
                 }
@@ -282,7 +303,7 @@ async fn backfill_tail_numbers(pool: &PgPool) -> Result<usize> {
             updated_count, pending_count
         );
 
-        Ok(updated_count + pending_count)
+        Ok(updated_count)
     })
     .await?
 }


### PR DESCRIPTION
## Summary

- `backfill_tail_numbers` filtered on `registration = ''` but all aircraft created via batch imports (ADS-B Exchange, OGN DDB) have `NULL` registration — so the backfill was matching **zero** aircraft (12,071 US ICAO aircraft silently skipped)
- The backfill also set `registration` directly without checking for duplicates, which would violate the unique constraint when another aircraft record (e.g., a FLARM-addressed duplicate of the same physical aircraft) already owns that registration
- The reporting count function (`get_us_icao_devices_with_registration_count`) used `registration != ''` which doesn't exclude NULLs in SQL, so counts were also wrong

### Fixes

- Changed filter to `registration IS NULL OR registration = ''`
- Added duplicate check before setting registration — conflicts now set `pending_registration` instead, letting `merge_pending_registrations` handle deduplication (merging addresses, reassigning fixes/flights)
- Added `pending_registration IS NULL` filter to skip aircraft already queued for merge
- Fixed count function to use `registration IS NOT NULL AND registration != ''`

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy` passes (via pre-commit hook)
- [ ] Run `load-data` on staging and verify backfill finds ~12,000 US ICAO aircraft
- [ ] Verify aircraft like `1cba89c7-cddc-4e35-81c2-fb536194c5a7` (ICAO A7610D, Grob G 103A Twin II) gets `pending_registration = N575AS` set
- [ ] Verify `merge_pending_registrations` merges the FLARM-addressed duplicate (`5866c2ba`) with the ICAO-addressed record