### PR TITLE
Warn on significant receiver position changes

### DIFF
--- a/infrastructure/dashboards/definitions/run.json
+++ b/infrastructure/dashboards/definitions/run.json
@@ -61,6 +61,7 @@
     ["beast-df-type-distribution", "beast-adsb-bds-type-distribution"],
     "receiver-cache-hit-rate",
     "receiver-cache-hitmiss",
+    "receiver-position-moves",
     "beast-fixes-processed",
     "beast-processing-latency-percentiles",
     {

--- a/infrastructure/dashboards/panels/run/receiver-position-moves.json
+++ b/infrastructure/dashboards/panels/run/receiver-position-moves.json
@@ -1,0 +1,103 @@
+{
+  "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "color": {
+        "mode": "palette-classic"
+      },
+      "custom": {
+        "axisBorderShow": false,
+        "axisCenteredZero": false,
+        "axisColorMode": "text",
+        "axisLabel": "",
+        "axisPlacement": "auto",
+        "barAlignment": 0,
+        "barWidthFactor": 0.6,
+        "drawStyle": "line",
+        "fillOpacity": 10,
+        "gradientMode": "none",
+        "hideFrom": {
+          "legend": false,
+          "tooltip": false,
+          "viz": false
+        },
+        "insertNulls": false,
+        "lineInterpolation": "linear",
+        "lineWidth": 1,
+        "pointSize": 5,
+        "scaleDistribution": {
+          "type": "linear"
+        },
+        "showPoints": "never",
+        "spanNulls": false,
+        "stacking": {
+          "group": "A",
+          "mode": "none"
+        },
+        "thresholdsStyle": {
+          "mode": "off"
+        }
+      },
+      "mappings": [],
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      },
+      "unit": "short"
+    },
+    "overrides": []
+  },
+  "options": {
+    "legend": {
+      "calcs": [
+        "mean",
+        "lastNotNull",
+        "max"
+      ],
+      "displayMode": "table",
+      "placement": "bottom",
+      "showLegend": true
+    },
+    "tooltip": {
+      "hideZeros": false,
+      "mode": "multi",
+      "sort": "desc"
+    }
+  },
+  "pluginVersion": "12.2.1",
+  "targets": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "editorMode": "code",
+      "expr": "sum(increase(aprs_receiver_position_moved_total{component=\"run\",environment=\"$environment\"}[5m])) or vector(0)",
+      "legendFormat": "Position Moves (>5km)",
+      "range": true,
+      "refId": "A"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "editorMode": "code",
+      "expr": "sum(increase(aprs_receiver_null_island_position_total{component=\"run\",environment=\"$environment\"}[5m])) or vector(0)",
+      "legendFormat": "Null Island Rejected",
+      "range": true,
+      "refId": "B"
+    }
+  ],
+  "title": "Receiver Position Anomalies (5m)",
+  "type": "timeseries",
+  "description": "Receivers reporting positions >5km from their last known location, and receivers rejected for reporting null island (0,0) coordinates"
+}

--- a/src/ogn/receiver_position.rs
+++ b/src/ogn/receiver_position.rs
@@ -46,6 +46,16 @@ impl ReceiverPositionProcessor {
             let new_lat: f64 = position.latitude.as_();
             let new_lon: f64 = position.longitude.as_();
 
+            // Reject null island coordinates — these are effectively missing data
+            if new_lat.abs() < 0.1 && new_lon.abs() < 0.1 {
+                trace!(
+                    "Ignoring null island position ({}, {}) for receiver {}",
+                    new_lat, new_lon, callsign
+                );
+                metrics::counter!("aprs.receiver.null_island_position_total").increment(1);
+                return;
+            }
+
             // Check if we've seen this receiver before and warn if it moved significantly
             if let Some((old_lat, old_lon)) = self.position_cache.get(&callsign) {
                 let distance_m = haversine_distance(old_lat, old_lon, new_lat, new_lon);


### PR DESCRIPTION
## Summary

- Add position change detection to `ReceiverPositionProcessor`: warn when an OGN receiver's reported position moves more than 5km from its last known position. This catches misconfigured receivers, callsign reuse, and MQTT gateways that report inconsistent positions.
- Uses an in-memory cache (moka, 100k capacity, 24h TTL) to track last-known positions — no extra DB lookups per position packet.
- Tracks occurrences via `aprs.receiver.position_moved_total` metric for Grafana monitoring.

### Context
Initial investigation into receiver coverage anomalies found fixes attributed to receivers thousands of km away (MQTT gateways like SKTmqtt, SKXFWD). A 400km distance filter was prototyped but reverted after discovering these gateways relay valid flight data from areas with sparse OGN coverage — dropping their fixes would lose real flights (e.g., FANET gliders in Brazil only tracked via SKTmqtt). Position move warnings provide visibility into these anomalies without data loss.

Also fixed 16 receivers at (0,0) "null island" by nulling out their coordinates directly in production.

## Test plan
- [ ] Pre-commit hooks pass (cargo fmt, clippy, tests)
- [ ] Deploy to staging and monitor `aprs.receiver.position_moved_total` metric
- [ ] Verify warnings appear in logs for known gateway receivers (SKTmqtt, SKXFWD, etc.)
- [ ] Confirm no impact on fix throughput or flight tracking