### PR TITLE
Fix CI: use pre-built cross binary instead of cargo install

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -81,16 +81,10 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-all-crates: true
 
-      - name: Cache cross
-        id: cache-cross
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cross
-          key: ${{ runner.os }}-cross-0.2.5
-
       - name: Install cross
-        if: steps.cache-cross.outputs.cache-hit != 'true'
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross@0.2.5
 
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/build-cross-x64.yml
+++ b/.github/workflows/build-cross-x64.yml
@@ -80,16 +80,10 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-all-crates: true
 
-      - name: Cache cross
-        id: cache-cross
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cross
-          key: ${{ runner.os }}-cross-0.2.5
-
       - name: Install cross
-        if: steps.cache-cross.outputs.cache-hit != 'true'
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross@0.2.5
 
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -831,16 +831,10 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-all-crates: true
 
-      - name: Cache cross
-        id: cache-cross
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/cross
-          key: ${{ runner.os }}-cross-0.2.5
-
       - name: Install cross
-        if: steps.cache-cross.outputs.cache-hit != 'true'
-        run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross@0.2.5
 
       - name: Install protobuf compiler
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler


### PR DESCRIPTION
## Summary
- `cross` v0.2.5 fails to compile from source on newer Rust toolchains because `static mut` references are hard errors in Rust 2024 edition
- Switch all three workflows (`ci.yml`, `build-arm64.yml`, `build-cross-x64.yml`) to install `cross` via `taiki-e/install-action@v2`, which downloads pre-built binaries with checksum verification
- Also removes the now-unnecessary `actions/cache` step for caching the compiled `cross` binary

## Test plan
- [ ] ARM64 build job in CI passes
- [ ] x64 cross build workflow still works