### PR TITLE
Fix run dashboard process status and uptime panels

### DIFF
--- a/infrastructure/dashboards/definitions/run.json
+++ b/infrastructure/dashboards/definitions/run.json
@@ -23,14 +23,13 @@
     {
       "row": "Core System & Infrastructure"
     },
-    "version",
+    [{"panel": "process-status", "w": 4}, {"panel": "version", "w": 20}],
     "build-details",
     "message-routing-rates",
     "processing-lag",
     "processing-rate-ratio",
     "processing-catchup-eta",
     "process-uptime",
-    "process-status",
     "process-memory-usage",
     "packet-queue",
     "nats-fix-publishing-rate",

--- a/infrastructure/dashboards/panels/run/process-status.json
+++ b/infrastructure/dashboards/panels/run/process-status.json
@@ -30,23 +30,21 @@
         "steps": [
           {
             "color": "red",
-            "value": 0
+            "value": null
           },
           {
             "color": "green",
             "value": 1
           }
         ]
-      },
-      "max": 1,
-      "min": 0,
-      "unit": "short"
+      }
     },
     "overrides": []
   },
   "options": {
-    "minVizHeight": 75,
-    "minVizWidth": 75,
+    "colorMode": "background",
+    "graphMode": "none",
+    "justifyMode": "center",
     "orientation": "auto",
     "reduceOptions": {
       "calcs": [
@@ -55,9 +53,7 @@
       "fields": "",
       "values": false
     },
-    "showThresholdLabels": false,
-    "showThresholdMarkers": true,
-    "sizing": "auto"
+    "textMode": "value"
   },
   "pluginVersion": "12.2.1",
   "targets": [
@@ -74,5 +70,6 @@
     }
   ],
   "title": "Process Status",
-  "type": "gauge"
+  "type": "stat",
+  "_height": 4
 }

--- a/infrastructure/dashboards/panels/run/process-uptime.json
+++ b/infrastructure/dashboards/panels/run/process-uptime.json
@@ -70,7 +70,7 @@
         "uid": "prometheus"
       },
       "editorMode": "code",
-      "expr": "max(process_uptime_seconds{component=\"run\",environment=\"$environment\"}) by (component, environment) or on() vector(0)",
+      "expr": "max(process_uptime_seconds{component=\"run\",environment=\"$environment\"}) or vector(0)",
       "legendFormat": "__auto",
       "range": true,
       "refId": "A"


### PR DESCRIPTION
## Summary
- **Process Status**: Converted from gauge to stat panel to fix the red ring that appeared even when showing "Up" (gauge arc colored by thresholds, not value mappings)
- **Process Status**: Moved to top-left of dashboard, compact (4-wide) next to version panel
- **Process Uptime**: Removed `by (component, environment)` from query so the `or vector(0)` fallback correctly deduplicates — previously it always returned two series because the label sets didn't overlap

## Test plan
- [ ] Verify process status shows green background when run is up, red when down
- [ ] Verify process uptime shows a single series, not two
- [ ] Verify layout: process status is compact at top-left, version beside it