### PR TITLE
Use dedicated SSH key for radar deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -890,7 +890,7 @@ jobs:
       - name: Setup SSH
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          echo "${{ secrets.RADAR_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H radar.hut8.tools >> ~/.ssh/known_hosts
 


### PR DESCRIPTION
## Summary
- Radar deploy was failing with `Permission denied (publickey)` because `SSH_PRIVATE_KEY` is only authorized on staging/production servers
- Generated a new ed25519 keypair and set `RADAR_SSH_PRIVATE_KEY` GitHub secret
- Installed the keypair on `soar@radar.hut8.tools`

## Test plan
- [ ] Merge to main triggers radar deploy job which should now succeed