### PR TITLE
Add global data freshness guard to receiver alerts, fix email formatting

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -1305,10 +1305,6 @@ The SOAR Team"#,
         .content {{ padding: 24px; }}
         .greeting {{ font-size: 16px; margin-bottom: 16px; }}
         .alert-message {{ background-color: #fff3cd; border-left: 4px solid #ffc107; padding: 16px; border-radius: 4px; margin-bottom: 24px; font-size: 16px; }}
-        .detail-row {{ display: flex; justify-content: space-between; padding: 12px 0; border-bottom: 1px solid #eee; }}
-        .detail-row:last-child {{ border-bottom: none; }}
-        .detail-label {{ color: #666; }}
-        .detail-value {{ font-weight: 500; text-align: right; }}
         .cta-button {{ display: inline-block; background: linear-gradient(135deg, #1e3a5f 0%, #2c5282 100%); color: white; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 600; margin-top: 16px; }}
         .footer {{ background-color: #f8f9fa; padding: 16px 24px; text-align: center; font-size: 12px; color: #666; }}
     </style>
@@ -1324,25 +1320,25 @@ The SOAR Team"#,
             <div class="alert-message">
                 <strong>{condition}</strong>
             </div>
-            <div class="flight-details">
-                <div class="detail-row">
-                    <span class="detail-label">Receiver</span>
-                    <span class="detail-value">{callsign}</span>
-                </div>
-                <div class="detail-row">
-                    <span class="detail-label">Alert Type</span>
-                    <span class="detail-value">{alert_type}</span>
-                </div>
-                <div class="detail-row">
-                    <span class="detail-label">Alert #</span>
-                    <span class="detail-value">{ordinal} notification</span>
-                </div>
-                <div class="detail-row">
-                    <span class="detail-label">Detected At</span>
-                    <span class="detail-value">{detected_at}</span>
-                </div>
-            </div>
-            <a href="{receiver_url}" class="cta-button">View Receiver</a>
+            <table style="width: 100%; border-collapse: collapse;" cellpadding="0" cellspacing="0">
+                <tr>
+                    <td style="color: #666; padding: 12px 0; border-bottom: 1px solid #eee;">Receiver</td>
+                    <td style="font-weight: 500; text-align: right; padding: 12px 0; border-bottom: 1px solid #eee;">{callsign}</td>
+                </tr>
+                <tr>
+                    <td style="color: #666; padding: 12px 0; border-bottom: 1px solid #eee;">Alert Type</td>
+                    <td style="font-weight: 500; text-align: right; padding: 12px 0; border-bottom: 1px solid #eee;">{alert_type}</td>
+                </tr>
+                <tr>
+                    <td style="color: #666; padding: 12px 0; border-bottom: 1px solid #eee;">Alert #</td>
+                    <td style="font-weight: 500; text-align: right; padding: 12px 0; border-bottom: 1px solid #eee;">{ordinal} notification</td>
+                </tr>
+                <tr>
+                    <td style="color: #666; padding: 12px 0;">Detected At</td>
+                    <td style="font-weight: 500; text-align: right; padding: 12px 0;">{detected_at}</td>
+                </tr>
+            </table>
+            <a href="{receiver_url}" class="cta-button" style="display: inline-block; background: linear-gradient(135deg, #1e3a5f 0%, #2c5282 100%); color: #ffffff !important; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 600; margin-top: 16px;">View Receiver</a>
         </div>
         <div class="footer">
             <p>You are receiving this email because you subscribed to alerts for this receiver on SOAR ({environment}).</p>
@@ -1476,10 +1472,6 @@ The SOAR Team"#,
         .content {{ padding: 24px; }}
         .greeting {{ font-size: 16px; margin-bottom: 16px; }}
         .recovery-message {{ background-color: #d4edda; border-left: 4px solid #28a745; padding: 16px; border-radius: 4px; margin-bottom: 24px; font-size: 16px; }}
-        .detail-row {{ display: flex; justify-content: space-between; padding: 12px 0; border-bottom: 1px solid #eee; }}
-        .detail-row:last-child {{ border-bottom: none; }}
-        .detail-label {{ color: #666; }}
-        .detail-value {{ font-weight: 500; text-align: right; }}
         .cta-button {{ display: inline-block; background: linear-gradient(135deg, #1e3a5f 0%, #2c5282 100%); color: white; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 600; margin-top: 16px; }}
         .footer {{ background-color: #f8f9fa; padding: 16px 24px; text-align: center; font-size: 12px; color: #666; }}
     </style>
@@ -1495,25 +1487,25 @@ The SOAR Team"#,
             <div class="recovery-message">
                 <strong>The "{condition_label}" condition for {callsign} has cleared.</strong>
             </div>
-            <div class="flight-details">
-                <div class="detail-row">
-                    <span class="detail-label">Receiver</span>
-                    <span class="detail-value">{callsign}</span>
-                </div>
-                <div class="detail-row">
-                    <span class="detail-label">Resolved Condition</span>
-                    <span class="detail-value">{condition_label}</span>
-                </div>
-                <div class="detail-row">
-                    <span class="detail-label">Notifications</span>
-                    <span class="detail-value">{alerts_sent}</span>
-                </div>
-                <div class="detail-row">
-                    <span class="detail-label">Resolved At</span>
-                    <span class="detail-value">{resolved_at}</span>
-                </div>{started_row}{duration_row}
-            </div>
-            <a href="{receiver_url}" class="cta-button">View Receiver</a>
+            <table style="width: 100%; border-collapse: collapse;" cellpadding="0" cellspacing="0">
+                <tr>
+                    <td style="color: #666; padding: 12px 0; border-bottom: 1px solid #eee;">Receiver</td>
+                    <td style="font-weight: 500; text-align: right; padding: 12px 0; border-bottom: 1px solid #eee;">{callsign}</td>
+                </tr>
+                <tr>
+                    <td style="color: #666; padding: 12px 0; border-bottom: 1px solid #eee;">Resolved Condition</td>
+                    <td style="font-weight: 500; text-align: right; padding: 12px 0; border-bottom: 1px solid #eee;">{condition_label}</td>
+                </tr>
+                <tr>
+                    <td style="color: #666; padding: 12px 0; border-bottom: 1px solid #eee;">Notifications</td>
+                    <td style="font-weight: 500; text-align: right; padding: 12px 0; border-bottom: 1px solid #eee;">{alerts_sent}</td>
+                </tr>
+                <tr>
+                    <td style="color: #666; padding: 12px 0; border-bottom: 1px solid #eee;">Resolved At</td>
+                    <td style="font-weight: 500; text-align: right; padding: 12px 0; border-bottom: 1px solid #eee;">{resolved_at}</td>
+                </tr>{started_row}{duration_row}
+            </table>
+            <a href="{receiver_url}" class="cta-button" style="display: inline-block; background: linear-gradient(135deg, #1e3a5f 0%, #2c5282 100%); color: #ffffff !important; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 600; margin-top: 16px;">View Receiver</a>
         </div>
         <div class="footer">
             <p>You are receiving this email because you subscribed to alerts for this receiver on SOAR ({environment}).</p>
@@ -1530,10 +1522,10 @@ The SOAR Team"#,
                 .first_alerted_at
                 .map(|t| format!(
                     r#"
-                <div class="detail-row">
-                    <span class="detail-label">Started At</span>
-                    <span class="detail-value">{}</span>
-                </div>"#,
+                <tr>
+                    <td style="color: #666; padding: 12px 0; border-bottom: 1px solid #eee;">Started At</td>
+                    <td style="font-weight: 500; text-align: right; padding: 12px 0; border-bottom: 1px solid #eee;">{}</td>
+                </tr>"#,
                     html_escape(t)
                 ))
                 .unwrap_or_default(),
@@ -1541,10 +1533,10 @@ The SOAR Team"#,
                 .duration
                 .map(|d| format!(
                     r#"
-                <div class="detail-row">
-                    <span class="detail-label">Active Duration</span>
-                    <span class="detail-value">{}</span>
-                </div>"#,
+                <tr>
+                    <td style="color: #666; padding: 12px 0;">Active Duration</td>
+                    <td style="font-weight: 500; text-align: right; padding: 12px 0;">{}</td>
+                </tr>"#,
                     html_escape(d)
                 ))
                 .unwrap_or_default(),

--- a/src/receiver_alert_checker.rs
+++ b/src/receiver_alert_checker.rs
@@ -99,6 +99,29 @@ async fn run_alert_check(pool: &PgPool) -> Result<()> {
     let status_repo = ReceiverStatusRepository::new(pool.clone());
     let users_repo = UsersRepository::new(pool.clone());
 
+    // Global data freshness check: if the most recent packet across ALL receivers
+    // is older than 5 minutes, the ingestion pipeline is likely down. Skip alerts
+    // to avoid false "Receiver Down" notifications for every subscription.
+    let max_packet_at = receiver_repo.get_max_latest_packet_at().await?;
+    let now = Utc::now();
+    match max_packet_at {
+        Some(ts) if (now - ts).num_minutes() >= 5 => {
+            warn!(
+                max_latest_packet_at = %ts,
+                minutes_stale = (now - ts).num_minutes(),
+                "Global data freshness check failed — ingestion may be down. Skipping alert cycle."
+            );
+            metrics::counter!("receiver_alerts.skipped_stale_data").increment(1);
+            return Ok(());
+        }
+        None => {
+            warn!("No receivers have any packet data. Skipping alert cycle.");
+            metrics::counter!("receiver_alerts.skipped_stale_data").increment(1);
+            return Ok(());
+        }
+        _ => {}
+    }
+
     // Get all active email alert subscriptions
     let alerts = alerts_repo.get_all_active_email_alerts().await?;
     if alerts.is_empty() {
@@ -137,7 +160,6 @@ async fn run_alert_check(pool: &PgPool) -> Result<()> {
         }
     };
 
-    let now = Utc::now();
     let mut alerts_sent = 0u64;
     let mut alerts_cleared = 0u64;
     let mut recovery_sent = 0u64;

--- a/src/receiver_repo.rs
+++ b/src/receiver_repo.rs
@@ -625,6 +625,22 @@ impl ReceiverRepository {
         .await?
     }
 
+    /// Get the most recent `latest_packet_at` across all receivers.
+    /// Used as a global data-freshness check before evaluating individual alerts.
+    pub async fn get_max_latest_packet_at(&self) -> Result<Option<DateTime<Utc>>> {
+        let pool = self.pool.clone();
+
+        tokio::task::spawn_blocking(move || -> Result<Option<DateTime<Utc>>> {
+            let mut conn = pool.get()?;
+            let max_ts: Option<DateTime<Utc>> = receivers::table
+                .select(diesel::dsl::max(receivers::latest_packet_at))
+                .first(&mut conn)?;
+
+            Ok(max_ts)
+        })
+        .await?
+    }
+
     /// Get a receiver by ID
     pub async fn get_receiver_by_id(&self, id: Uuid) -> Result<Option<ReceiverModel>> {
         let pool = self.pool.clone();


### PR DESCRIPTION
## Summary

- **Global data freshness check**: Before evaluating individual receiver staleness, query `MAX(latest_packet_at)` across all receivers. If the newest data is >5 minutes old (or no data exists), skip the alert cycle entirely — the problem is systemic (e.g., APRS connection lost, ingest service down), not per-receiver. Prevents false "Receiver Down" alerts for every subscription at once.
- **Email detail rows as HTML tables**: Replace flexbox `div.detail-row` layout with proper `<table>` elements using inline `<td>` styles in both alert and recovery emails for better email client compatibility.
- **Button contrast fix**: Add fully inline styles (including `color: #ffffff !important`) to the "View Receiver" `<a>` tag so white text renders correctly even in email clients that strip `<style>` blocks.

## Test plan

- [ ] Verify `cargo check` / `cargo clippy` pass (pre-commit hooks confirmed)
- [ ] Confirm alert checker skips cycle when ingestion is stale (check logs for `receiver_alerts.skipped_stale_data` metric)
- [ ] Send test alert and recovery emails, verify table layout renders correctly in Gmail, Outlook, and Apple Mail
- [ ] Verify "View Receiver" button text is white/readable across light and dark mode email clients