### PR TITLE
Fix current flight and view on map buttons showing for stale flights

### DIFF
--- a/web/src/lib/components/AircraftTile.svelte
+++ b/web/src/lib/components/AircraftTile.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
 	import { Plane, Antenna, Check, Activity, Map, Navigation } from '@lucide/svelte';
 	import { resolve } from '$app/paths';
 	import {
@@ -15,15 +16,24 @@
 	// Consider the aircraft actively flying only if we received a fix within the last 10 minutes
 	// (matches the backend's threshold for Active vs Stale flight state)
 	const STALE_THRESHOLD_MS = 10 * 60 * 1000;
+	let now = $state(Date.now());
+	let timer: ReturnType<typeof setInterval> | null = null;
+
+	onMount(() => {
+		timer = setInterval(() => (now = Date.now()), 60_000);
+	});
+
+	onDestroy(() => {
+		if (timer) clearInterval(timer);
+	});
+
 	let isRecentlyActive = $derived(
-		aircraft.lastFixAt
-			? Date.now() - new Date(aircraft.lastFixAt).getTime() < STALE_THRESHOLD_MS
-			: false
+		aircraft.lastFixAt ? now - new Date(aircraft.lastFixAt).getTime() <= STALE_THRESHOLD_MS : false
 	);
 
 	// Build the live map URL with location parameters from latest fix
 	let mapUrl = $derived(
-		isRecentlyActive && aircraft.latitude && aircraft.longitude
+		isRecentlyActive && aircraft.latitude != null && aircraft.longitude != null
 			? `/live?lat=${aircraft.latitude}&lng=${aircraft.longitude}&zoom=13`
 			: null
 	);


### PR DESCRIPTION
## Summary
- **View on Map** and **Current Flight** buttons in `AircraftTile` were appearing even after a flight timed out or went stale, because `currentFix.flightId` and `latitude`/`longitude` persist indefinitely on the aircraft record
- Added a 10-minute recency check on `lastFixAt` before showing either button, matching the backend's Active vs Stale flight state threshold in `Flight::state()`
- Affects both `/aircraft` and `/clubs/[id]` pages which use this component

## Test plan
- [ ] Find an aircraft with a timed-out flight — verify the buttons no longer appear
- [ ] Find an aircraft currently flying — verify both buttons still appear and work correctly
- [ ] Wait for an active aircraft to go stale (10+ min without fix) — verify buttons disappear