### PR TITLE
Fix ARM64 builds: switch to mimalloc, add custom cross image

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -2,6 +2,7 @@ name: Build ARM64 Release (Manual)
 
 permissions:
   contents: read
+  packages: read  # Required to pull custom cross image from GHCR
 
 on:
   workflow_dispatch:
@@ -86,8 +87,12 @@ jobs:
         with:
           tool: cross@0.2.5
 
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Log in to GHCR (for custom cross image)
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build static release binary (ARM64)
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -836,8 +836,12 @@ jobs:
         with:
           tool: cross@0.2.5
 
-      - name: Install protobuf compiler
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Log in to GHCR (for custom cross image)
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build static release binary (ARM64)
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3971,6 +3971,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4185,6 +4195,15 @@ dependencies = [
  "migrations_internals",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -6884,6 +6903,7 @@ dependencies = [
  "lru",
  "metrics",
  "metrics-exporter-prometheus",
+ "mimalloc",
  "mime_guess",
  "moka",
  "notify",
@@ -6920,7 +6940,6 @@ dependencies = [
  "shapefile",
  "sitemap-rs",
  "tempfile",
- "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "toml 1.0.6+spec-1.1.0",
@@ -7395,26 +7414,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 bundled-postgres = ["pq-sys/bundled", "dep:openssl", "openssl/vendored"]
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = "0.6"
+mimalloc = "0.1"
 
 [dependencies]
 anyhow = "1.0"

--- a/Cross.toml
+++ b/Cross.toml
@@ -35,17 +35,7 @@ pre-build = [
 [target.aarch64-unknown-linux-musl]
 # Musl build for aarch64 - fully static binary
 # We use pq-sys bundled feature to compile libpq from source, which includes all static libs
-pre-build = [
-    "dpkg --add-architecture arm64",
-    "apt-get update",
-    # Build dependencies for compiling PostgreSQL and OpenSSL from source
-    # build-essential: gcc, g++, make for compiling C code
-    # crossbuild-essential-arm64: cross-compilation toolchain
-    # pkg-config: for finding libraries
-    # perl: required for building OpenSSL from source
-    # clang: needed by some build scripts
-    # zlib1g-dev:arm64: ARM64 compression library
-    # protobuf-compiler: for compiling .proto files
-    # Use DEBIAN_FRONTEND=noninteractive to prevent tzdata prompts during install
-    "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq build-essential crossbuild-essential-arm64 pkg-config perl clang zlib1g-dev:arm64 protobuf-compiler",
-]
+# Build dependencies (crossbuild-essential-arm64, protobuf-compiler, etc.) are baked into
+# the custom image to avoid ~1-2 min of apt-get on every build.
+# See .github/cross-arm64-musl.Dockerfile for what's pre-installed.
+image = "ghcr.io/hut8/cross-arm64-musl:latest"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
-static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};


### PR DESCRIPTION
## Summary
- **Switch from jemalloc to mimalloc** — jemalloc hardcodes 4KB page size at compile time, which causes `Unsupported system page size` abort on the Raspberry Pi radar host (ARM64 kernel with 16KB pages). mimalloc detects page size at runtime and works on all configurations.
- **Use custom cross Docker image for ARM64 musl builds** — Cross.toml now references `ghcr.io/hut8/cross-arm64-musl:latest` (added in #1217) instead of running `apt-get install` pre-build commands on every CI run. Workflows updated with GHCR login to pull the private image.

## Test plan
- [ ] Verify ARM64 build succeeds in CI with the custom cross image
- [ ] Verify radar deployment no longer crashes with jemalloc page size error
- [ ] Verify x64 builds are unaffected (mimalloc is a drop-in replacement)