### PR TITLE
Add custom cross Docker image for ARM64 musl builds

### DIFF
--- a/.github/cross-arm64-musl.Dockerfile
+++ b/.github/cross-arm64-musl.Dockerfile
@@ -3,7 +3,7 @@
 # Based on the official cross-rs image for this target.
 #
 # Build and publish via: .github/workflows/build-cross-arm64-image.yml
-# Used by Cross.toml: [target.aarch64-unknown-linux-musl] image = "ghcr.io/hut8/cross-arm64-musl:latest"
+# Referenced by Cross.toml in PR #1216: [target.aarch64-unknown-linux-musl] image = "..."
 
 FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5
 

--- a/.github/workflows/build-cross-arm64-image.yml
+++ b/.github/workflows/build-cross-arm64-image.yml
@@ -45,15 +45,17 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v7
         with:
-          context: .
+          context: .github
           file: .github/cross-arm64-musl.Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Output image digest
+      - name: Output image info
         run: |
           echo "Image pushed to: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
           echo "Tags: ${{ steps.meta.outputs.tags }}"
+          echo "Digest: ${{ steps.build.outputs.digest }}"


### PR DESCRIPTION
## Summary
- Adds `.github/cross-arm64-musl.Dockerfile` — custom cross image with build deps pre-installed
- Adds `.github/workflows/build-cross-arm64-image.yml` — build/push workflow for the image

Split out from #1216 so the `workflow_dispatch` trigger is available on `main`. Once merged, trigger the workflow manually to push the image to GHCR, then #1216 can be merged.

## Test plan
- [ ] Merge this PR
- [ ] Trigger `Build Cross ARM64 musl Image` workflow manually
- [ ] Verify image is pushed to `ghcr.io/hut8/cross-arm64-musl:latest`