### PR TITLE
Fix radar OTLP export and split deployments by environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -869,12 +869,12 @@ jobs:
           ls -lh target/aarch64-unknown-linux-musl/release/soar
           file target/aarch64-unknown-linux-musl/release/soar
 
-  deploy-radar:
-    name: Deploy to Radar
+  deploy-radar-staging:
+    name: Deploy Radar (Staging)
     runs-on: ubuntu-latest
     needs: [build-release-arm64]
-    # Deploy to radar on main push (like staging) and on release (like production)
-    if: github.ref == 'refs/heads/main' || (github.event_name == 'release' && github.event.action == 'published')
+    # Deploy staging binary to radar on main push (same trigger as deploy-staging)
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
     steps:
       - name: Checkout code
@@ -907,8 +907,114 @@ jobs:
           cp soar deploy-pkg/
           cp infrastructure/soar-deploy deploy-pkg/
           cp infrastructure/ingest-radar-staging.toml deploy-pkg/
-          cp infrastructure/ingest-radar-production.toml deploy-pkg/
           cp infrastructure/systemd/soar-ingest-radar-staging.service deploy-pkg/
+
+          echo "Deployment package prepared for timestamp: $TIMESTAMP"
+          ls -lh deploy-pkg/
+
+      - name: Upload deployment package
+        run: |
+          DEPLOY_DIR="/tmp/soar/deploy/${{ env.DEPLOY_TIMESTAMP }}"
+
+          echo "Creating deployment directory on radar: $DEPLOY_DIR"
+          ssh soar@radar.hut8.tools "mkdir -p $DEPLOY_DIR"
+
+          echo "Uploading deployment package..."
+          rsync -az --info=progress2 deploy-pkg/ soar@radar.hut8.tools:$DEPLOY_DIR/
+
+          echo "Deployment package uploaded successfully"
+
+      - name: Execute deployment to radar
+        run: |
+          DEPLOY_DIR="/tmp/soar/deploy/${{ env.DEPLOY_TIMESTAMP }}"
+          DEPLOY_ID="radar-staging-${{ env.DEPLOY_TIMESTAMP }}"
+          LOG_FILE="/var/lib/soar/deploy/logs/${DEPLOY_ID}.log"
+          STATUS_FILE="/var/lib/soar/deploy/status/${DEPLOY_ID}.status"
+
+          echo "Executing deployment script for radar-staging..."
+          echo "Deployment ID: $DEPLOY_ID"
+
+          ssh soar@radar.hut8.tools "nohup sudo /usr/local/bin/soar-deploy radar-staging $DEPLOY_DIR &"
+
+          sleep 3
+
+          echo "Deployment started in background, polling for completion..."
+
+          MAX_WAIT=300
+          ELAPSED=0
+          POLL_INTERVAL=5
+
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            if ssh soar@radar.hut8.tools "test -f $STATUS_FILE" 2>/dev/null; then
+              echo "Deployment completed, fetching results..."
+
+              EXIT_CODE=$(ssh soar@radar.hut8.tools "cat $STATUS_FILE")
+              echo "Deployment exit code: $EXIT_CODE"
+
+              echo ""
+              echo "=== Deployment Log ==="
+              ssh soar@radar.hut8.tools "cat $LOG_FILE" || echo "(Failed to retrieve log)"
+              echo "=== End Deployment Log ==="
+              echo ""
+
+              exit $EXIT_CODE
+            fi
+
+            if [ $((ELAPSED % 30)) -eq 0 ] && [ $ELAPSED -gt 0 ]; then
+              echo "Still waiting for deployment... (${ELAPSED}s elapsed)"
+              ssh soar@radar.hut8.tools "tail -5 $LOG_FILE 2>/dev/null" || true
+            fi
+
+            sleep $POLL_INTERVAL
+            ELAPSED=$((ELAPSED + POLL_INTERVAL))
+          done
+
+          echo "Deployment timed out after ${MAX_WAIT} seconds"
+          exit 1
+
+      - name: Cleanup SSH
+        if: always()
+        run: |
+          rm -f ~/.ssh/id_rsa
+
+  deploy-radar-production:
+    name: Deploy Radar (Production)
+    runs-on: ubuntu-latest
+    needs: [build-release-arm64]
+    # Deploy production binary to radar on release (same trigger as deploy-production)
+    if: github.event_name == 'release' && github.event.action == 'published'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Download ARM64 release binary
+        uses: actions/download-artifact@v8
+        with:
+          name: soar-linux-arm64
+          path: ./
+
+      - name: Extract binary
+        run: |
+          tar -xzf soar-linux-arm64.tar.gz
+          chmod +x soar
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.RADAR_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H radar.hut8.tools >> ~/.ssh/known_hosts
+
+      - name: Prepare deployment package
+        run: |
+          TIMESTAMP=$(date +%Y%m%d%H%M%S)
+          echo "DEPLOY_TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+
+          mkdir -p deploy-pkg
+          cp soar deploy-pkg/
+          cp infrastructure/soar-deploy deploy-pkg/
+          cp infrastructure/ingest-radar-production.toml deploy-pkg/
           cp infrastructure/systemd/soar-ingest-radar-production.service deploy-pkg/
 
           echo "Deployment package prepared for timestamp: $TIMESTAMP"
@@ -929,14 +1035,14 @@ jobs:
       - name: Execute deployment to radar
         run: |
           DEPLOY_DIR="/tmp/soar/deploy/${{ env.DEPLOY_TIMESTAMP }}"
-          DEPLOY_ID="radar-${{ env.DEPLOY_TIMESTAMP }}"
+          DEPLOY_ID="radar-production-${{ env.DEPLOY_TIMESTAMP }}"
           LOG_FILE="/var/lib/soar/deploy/logs/${DEPLOY_ID}.log"
           STATUS_FILE="/var/lib/soar/deploy/status/${DEPLOY_ID}.status"
 
-          echo "Executing deployment script for radar..."
+          echo "Executing deployment script for radar-production..."
           echo "Deployment ID: $DEPLOY_ID"
 
-          ssh soar@radar.hut8.tools "nohup sudo /usr/local/bin/soar-deploy radar $DEPLOY_DIR &"
+          ssh soar@radar.hut8.tools "nohup sudo /usr/local/bin/soar-deploy radar-production $DEPLOY_DIR &"
 
           sleep 3
 

--- a/infrastructure/OPENTELEMETRY.md
+++ b/infrastructure/OPENTELEMETRY.md
@@ -11,17 +11,23 @@ SOAR uses OpenTelemetry for distributed tracing and observability, with traces e
 ## Architecture
 
 ```
-┌─────────────┐   OTLP/HTTP        ┌─────────────┐
-│ SOAR        │────────────────────>│ Tempo       │
-│ (Rust app)  │   port 4318        │ (Traces)    │
-└─────────────┘   HTTP/protobuf    └─────────────┘
-       │                                   │
-       │                                   │
-       │         Prometheus                │
-       └────────────────────>┌─────────────▼────────┐
-              port 9090      │ Grafana              │
-                             │ (Visualization)      │
-                             └──────────────────────┘
+                            ┌─────────────┐
+                            │ Tempo       │
+                            │ (Traces)    │
+                            └──────▲──────┘
+                                   │
+┌─────────────┐   OTLP/HTTP  ┌────┴────────┐
+│ SOAR        │──────────────>│ Alloy       │───> Loki (Logs)
+│ (local)     │  localhost    │ (Pipeline)  │
+└─────────────┘   :4318      └──────▲──────┘
+                                    │
+┌─────────────┐   OTLP/HTTP        │
+│ SOAR        │─────────────────────┘
+│ (radar)     │  Tailscale IP:4318
+└─────────────┘
+
+       SOAR ──── Prometheus ──── Grafana
+              port 9090      (Visualization)
 ```
 
 ### Components
@@ -411,12 +417,39 @@ curl -G http://localhost:3200/api/search \
 curl http://localhost:3200/api/traces/<trace-id>
 ```
 
+## Remote Service OTLP Export (Radar)
+
+The radar host runs two ingest services (`soar-ingest-radar-staging` and `soar-ingest-radar-production`) that export OTLP telemetry to their respective servers over Tailscale.
+
+### How It Works
+
+The radar host has no local observability stack. Instead, each service's systemd unit sets a per-service `OTEL_EXPORTER_OTLP_ENDPOINT` that overrides the default from `/etc/soar/env`:
+
+| Service | Target Server | Endpoint |
+|---------|--------------|----------|
+| `soar-ingest-radar-staging` | supervillain | `http://supervillain:4318` |
+| `soar-ingest-radar-production` | tenerife | `http://tenerife:4318` |
+
+Each service also sets `SOAR_ENV` to ensure the correct trace sampling rate (staging=10%, production=1%).
+
+### Alloy Tailscale Receiver
+
+Alloy on supervillain and tenerife listens for OTLP on both localhost (for local services) and the Tailscale IP (for remote services like radar):
+
+- `otelcol.receiver.otlp "ingest"` - binds to `127.0.0.1:4317`/`4318` (local)
+- `otelcol.receiver.otlp "tailscale"` - binds to `<tailscale-ip>:4317`/`4318` (remote)
+
+Both receivers feed into the same batch processor pipeline. The Tailscale receiver is conditionally included by `soar-deploy` - if `tailscale ip -4` fails, the block is stripped from the config.
+
+Tailscale provides mutual authentication via WireGuard, so no additional TLS configuration is needed.
+
 ## Security Considerations
 
 ### Network Exposure
 
 - **Tempo**: Bind OTLP receivers to localhost or internal network only
 - **Loki**: Same as Tempo
+- **Alloy**: OTLP receivers bound to localhost and Tailscale IP only (not public interfaces)
 - **Grafana**: Use authentication and HTTPS for public access
 
 ### Sensitive Data in Traces

--- a/infrastructure/alloy-config.alloy.template
+++ b/infrastructure/alloy-config.alloy.template
@@ -21,6 +21,23 @@ otelcol.receiver.otlp "ingest" {
   }
 }
 
+// BEGIN:tailscale
+// Receive OTLP from remote services via Tailscale (e.g., radar ingest)
+otelcol.receiver.otlp "tailscale" {
+  grpc {
+    endpoint = "{{TAILSCALE_IP}}:4317"
+  }
+  http {
+    endpoint = "{{TAILSCALE_IP}}:4318"
+  }
+
+  output {
+    logs   = [otelcol.processor.batch.pipeline.input]
+    traces = [otelcol.processor.batch.pipeline.input]
+  }
+}
+// END:tailscale
+
 // Batch for efficiency
 otelcol.processor.batch "pipeline" {
   output {

--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -6,7 +6,7 @@
 # It must be installed at /usr/local/bin/soar-deploy with permissions 755.
 #
 # Usage:
-#   sudo /usr/local/bin/soar-deploy [production|staging|radar] /tmp/soar/deploy/YYYYMMDDHHMMSS
+#   sudo /usr/local/bin/soar-deploy [production|staging|radar-staging|radar-production] /tmp/soar/deploy/YYYYMMDDHHMMSS
 #   sudo /usr/local/bin/soar-deploy /tmp/soar/deploy/YYYYMMDDHHMMSS  (defaults to production)
 #
 # The deployment directory should contain:
@@ -58,14 +58,15 @@ elif [ $# -eq 1 ]; then
     ENVIRONMENT="production"
     DEPLOY_DIR="$1"
 else
-    log_error "Usage: $0 [production|staging] /tmp/soar/deploy/YYYYMMDDHHMMSS"
+    log_error "Usage: $0 [production|staging|radar-staging|radar-production] /tmp/soar/deploy/YYYYMMDDHHMMSS"
     log_error "   or: $0 /tmp/soar/deploy/YYYYMMDDHHMMSS  (defaults to production)"
     exit 1
 fi
 
 # Validate environment
-if [ "$ENVIRONMENT" != "production" ] && [ "$ENVIRONMENT" != "staging" ] && [ "$ENVIRONMENT" != "radar" ]; then
-    log_error "Invalid environment: $ENVIRONMENT (must be 'production', 'staging', or 'radar')"
+VALID_ENVS="production staging radar-staging radar-production"
+if ! echo "$VALID_ENVS" | grep -qw "$ENVIRONMENT"; then
+    log_error "Invalid environment: $ENVIRONMENT (must be one of: $VALID_ENVS)"
     exit 1
 fi
 
@@ -130,13 +131,21 @@ else
 fi
 
 # Set environment-specific variables
-if [ "$ENVIRONMENT" = "radar" ]; then
-    # Radar is a lightweight deployment: single ingest service, no migrations,
-    # no observability stack, no Grafana. It runs on a dedicated ADS-B receiver host.
+if [ "$ENVIRONMENT" = "radar-staging" ]; then
+    # Radar staging: lightweight deployment of the staging ingest service only.
+    # Runs on a dedicated ADS-B receiver host, sends data to supervillain.
+    SERVICE_SUFFIX=""
+    ENV_FILE="/etc/soar/env"
+    BINARY_PATH="/usr/local/bin/soar-staging"
+    BACKUP_DIR="/home/soar/backups/radar-staging"
+    TARGET_FILE=""
+elif [ "$ENVIRONMENT" = "radar-production" ]; then
+    # Radar production: lightweight deployment of the production ingest service only.
+    # Runs on a dedicated ADS-B receiver host, sends data to tenerife.
     SERVICE_SUFFIX=""
     ENV_FILE="/etc/soar/env"
     BINARY_PATH="/usr/local/bin/soar"
-    BACKUP_DIR="/home/soar/backups/radar"
+    BACKUP_DIR="/home/soar/backups/radar-production"
     TARGET_FILE=""
 elif [ "$ENVIRONMENT" = "staging" ]; then
     SERVICE_SUFFIX="-staging"
@@ -262,9 +271,20 @@ log_info "Binary installed successfully at $BINARY_PATH"
 log_info "Cleaning up temporary binary: $TEMP_BIN_PATH"
 rm -f "$TEMP_BIN_PATH"
 
-# Radar deployment: lightweight path (binary + dual ingest services)
-if [ "$ENVIRONMENT" = "radar" ]; then
-    log_info "Radar deployment: installing configs and services..."
+# Radar deployment: lightweight path (binary + single ingest service per environment)
+# radar-staging deploys the staging binary and service only
+# radar-production deploys the production binary and service only
+if [ "$ENVIRONMENT" = "radar-staging" ] || [ "$ENVIRONMENT" = "radar-production" ]; then
+    # Determine which service this deployment targets
+    if [ "$ENVIRONMENT" = "radar-staging" ]; then
+        RADAR_ENV_SUFFIX="staging"
+    else
+        RADAR_ENV_SUFFIX="production"
+    fi
+    SERVICE="soar-ingest-radar-${RADAR_ENV_SUFFIX}.service"
+    CONFIG_FILE="ingest-radar-${RADAR_ENV_SUFFIX}.toml"
+
+    log_info "Radar $RADAR_ENV_SUFFIX deployment: installing binary, config, and service..."
 
     mkdir -p /etc/soar
 
@@ -283,58 +303,47 @@ if [ "$ENVIRONMENT" = "radar" ]; then
         rm -f /etc/soar/ingest-radar.toml
     fi
 
-    # Install ingest configs (staging + production)
-    for ENV_SUFFIX in staging production; do
-        CONFIG_FILE="ingest-radar-${ENV_SUFFIX}.toml"
-        if [ -f "$DEPLOY_DIR/$CONFIG_FILE" ]; then
-            log_info "Installing $CONFIG_FILE to /etc/soar/..."
-            cp "$DEPLOY_DIR/$CONFIG_FILE" "/etc/soar/$CONFIG_FILE"
-            chmod 644 "/etc/soar/$CONFIG_FILE"
-        else
-            log_warn "$CONFIG_FILE not found in deployment directory"
-        fi
-    done
+    # Install ingest config
+    if [ -f "$DEPLOY_DIR/$CONFIG_FILE" ]; then
+        log_info "Installing $CONFIG_FILE to /etc/soar/..."
+        cp "$DEPLOY_DIR/$CONFIG_FILE" "/etc/soar/$CONFIG_FILE"
+        chmod 644 "/etc/soar/$CONFIG_FILE"
+    else
+        log_warn "$CONFIG_FILE not found in deployment directory"
+    fi
 
-    # Install systemd services (staging + production)
-    for ENV_SUFFIX in staging production; do
-        SERVICE_FILE="soar-ingest-radar-${ENV_SUFFIX}.service"
-        if [ -f "$DEPLOY_DIR/$SERVICE_FILE" ]; then
-            log_info "Installing $SERVICE_FILE..."
-            cp "$DEPLOY_DIR/$SERVICE_FILE" /etc/systemd/system/
-            chmod 644 "/etc/systemd/system/$SERVICE_FILE"
-        else
-            log_warn "$SERVICE_FILE not found in deployment directory"
-        fi
-    done
+    # Install systemd service
+    SERVICE_FILE="$SERVICE"
+    if [ -f "$DEPLOY_DIR/$SERVICE_FILE" ]; then
+        log_info "Installing $SERVICE_FILE..."
+        cp "$DEPLOY_DIR/$SERVICE_FILE" /etc/systemd/system/
+        chmod 644 "/etc/systemd/system/$SERVICE_FILE"
+    else
+        log_warn "$SERVICE_FILE not found in deployment directory"
+    fi
 
-    # Reload systemd and restart services
+    # Reload systemd and restart the service
     log_info "Reloading systemd daemon..."
     systemctl daemon-reload
 
-    for ENV_SUFFIX in staging production; do
-        SERVICE="soar-ingest-radar-${ENV_SUFFIX}.service"
-        log_info "Enabling and restarting $SERVICE..."
-        systemctl enable "$SERVICE" || log_warn "Failed to enable $SERVICE"
-        systemctl restart "$SERVICE" || log_warn "Failed to restart $SERVICE"
-    done
+    log_info "Enabling and restarting $SERVICE..."
+    systemctl enable "$SERVICE" || log_warn "Failed to enable $SERVICE"
+    systemctl restart "$SERVICE" || log_warn "Failed to restart $SERVICE"
 
-    # Wait for services to start
+    # Wait for service to start
     sleep 3
 
-    # Verify services are running
-    for ENV_SUFFIX in staging production; do
-        SERVICE="soar-ingest-radar-${ENV_SUFFIX}.service"
-        if systemctl is-active --quiet "$SERVICE"; then
-            log_info "$SERVICE: ${GREEN}ACTIVE${NC}"
-        else
-            log_error "$SERVICE: ${RED}FAILED${NC}"
-            journalctl -u "$SERVICE" --no-pager --lines=10 || true
-            ALL_HEALTHY=false
-        fi
-    done
+    # Verify service is running
+    if systemctl is-active --quiet "$SERVICE"; then
+        log_info "$SERVICE: ${GREEN}ACTIVE${NC}"
+    else
+        log_error "$SERVICE: ${RED}FAILED${NC}"
+        journalctl -u "$SERVICE" --no-pager --lines=10 || true
+        ALL_HEALTHY=false
+    fi
 
     # Show version
-    soar --version || log_warn "(version check failed)"
+    "$BINARY_PATH" --version || log_warn "(version check failed)"
 
     # Clean up old deployment directories (keep last 3)
     log_info "Cleaning up old deployment directories (keeping last 3)..."
@@ -346,11 +355,11 @@ if [ "$ENVIRONMENT" = "radar" ]; then
     ls -t "$DEPLOY_STATUS_DIR"/*.status 2>/dev/null | tail -n +11 | xargs rm -f || true
 
     if [ "${ALL_HEALTHY:-true}" != "true" ]; then
-        log_error "${RED}Radar deployment completed with errors. Service failed to start.${NC}"
+        log_error "${RED}Radar $RADAR_ENV_SUFFIX deployment completed with errors. Service failed to start.${NC}"
         exit 1
     fi
 
-    log_info "${GREEN}Radar deployment completed successfully!${NC}"
+    log_info "${GREEN}Radar $RADAR_ENV_SUFFIX deployment completed successfully!${NC}"
     exit 0
 fi
 
@@ -1228,12 +1237,34 @@ if [ -f "$DEPLOY_DIR/alloy-config.alloy.template" ]; then
         STRIP_ENV="staging"
     fi
 
+    # Resolve Tailscale IP for remote OTLP receiver
+    TAILSCALE_IP=$(tailscale ip -4 2>/dev/null || echo "")
+    if [ -n "$TAILSCALE_IP" ]; then
+        log_info "Tailscale IP detected: $TAILSCALE_IP - enabling remote OTLP receiver"
+    else
+        log_warn "Tailscale not available - OTLP receiver will only accept localhost connections"
+    fi
+
     # Process template: replace placeholders and strip blocks for the other environment.
     # Lines between "// BEGIN:<other-env>" and "// END:<other-env>" (inclusive) are removed.
-    sed -e "s|{{GIT_COMMIT}}|$GIT_COMMIT|g" \
-        -e "/^\/\/ BEGIN:${STRIP_ENV}$/,/^\/\/ END:${STRIP_ENV}$/d" \
-        -e "/^\/\/ BEGIN:${ENVIRONMENT}$/d" \
-        -e "/^\/\/ END:${ENVIRONMENT}$/d" \
+    SED_ARGS=(
+        -e "s|{{GIT_COMMIT}}|$GIT_COMMIT|g"
+        -e "/^\/\/ BEGIN:${STRIP_ENV}$/,/^\/\/ END:${STRIP_ENV}$/d"
+        -e "/^\/\/ BEGIN:${ENVIRONMENT}$/d"
+        -e "/^\/\/ END:${ENVIRONMENT}$/d"
+    )
+
+    if [ -n "$TAILSCALE_IP" ]; then
+        SED_ARGS+=(
+            -e "s|{{TAILSCALE_IP}}|$TAILSCALE_IP|g"
+            -e "/^\/\/ BEGIN:tailscale$/d"
+            -e "/^\/\/ END:tailscale$/d"
+        )
+    else
+        SED_ARGS+=(-e "/^\/\/ BEGIN:tailscale$/,/^\/\/ END:tailscale$/d")
+    fi
+
+    sed "${SED_ARGS[@]}" \
         "$DEPLOY_DIR/alloy-config.alloy.template" \
         > /etc/alloy/config.alloy
     log_info "Stripped $STRIP_ENV-only blocks, kept $ENVIRONMENT blocks"

--- a/infrastructure/systemd/soar-ingest-radar-production.service
+++ b/infrastructure/systemd/soar-ingest-radar-production.service
@@ -18,6 +18,8 @@ ExecReload=/bin/kill -s HUP $MAINPID
 # Environment variables
 EnvironmentFile=/etc/soar/env
 Environment=METRICS_PORT=9095
+Environment=OTEL_EXPORTER_OTLP_ENDPOINT=http://tenerife:4318
+Environment=SOAR_ENV=production
 
 # Security settings
 NoNewPrivileges=yes

--- a/infrastructure/systemd/soar-ingest-radar-staging.service
+++ b/infrastructure/systemd/soar-ingest-radar-staging.service
@@ -12,12 +12,14 @@ User=soar
 Group=soar
 WorkingDirectory=/var/lib/soar
 SyslogIdentifier=soar-ingest-radar-staging
-ExecStart=/usr/local/bin/soar ingest --config /etc/soar/ingest-radar-staging.toml
+ExecStart=/usr/local/bin/soar-staging ingest --config /etc/soar/ingest-radar-staging.toml
 ExecReload=/bin/kill -s HUP $MAINPID
 
 # Environment variables
 EnvironmentFile=/etc/soar/env
 Environment=METRICS_PORT=9197
+Environment=OTEL_EXPORTER_OTLP_ENDPOINT=http://supervillain:4318
+Environment=SOAR_ENV=staging
 
 # Security settings
 NoNewPrivileges=yes


### PR DESCRIPTION
## Summary

- **Split radar CI deployment** into `deploy-radar-staging` (main push) and `deploy-radar-production` (release publish) so each service gets its own binary — staging uses `/usr/local/bin/soar-staging`, production keeps `/usr/local/bin/soar`
- **Fix OTLP telemetry export** from the radar host by setting per-service `OTEL_EXPORTER_OTLP_ENDPOINT` to route to the correct server's Alloy over Tailscale
- **Add Tailscale OTLP receiver** to Alloy config so it accepts connections on the Tailscale interface (not just localhost), conditionally enabled by `soar-deploy` based on `tailscale ip -4` availability

## Problem

Both `soar-ingest-radar-staging` and `soar-ingest-radar-production` ran from the same binary at `/usr/local/bin/soar`. A single `deploy-radar` CI job deployed on both main push and release, so whichever ran last would overwrite the other. Additionally, OTLP export failed with `BatchLogProcessor.ExportError` because the radar host has no local Alloy, and the target servers' Alloy only listened on localhost.

## Test plan

- [ ] Verify CI YAML parses correctly (validated locally with Python yaml.safe_load)
- [ ] `deploy-radar-staging` triggers only on main push, deploys staging config + binary to `/usr/local/bin/soar-staging`
- [ ] `deploy-radar-production` triggers only on release, deploys production config + binary to `/usr/local/bin/soar`
- [ ] After Alloy config deploys: `ss -tlnp | grep 4318` shows two listeners (127.0.0.1 and Tailscale IP)
- [ ] After radar deploys: `journalctl -u soar-ingest-radar-staging -f` — no `BatchLogProcessor.ExportError`
- [ ] After radar deploys: `journalctl -u soar-ingest-radar-production -f` — no `BatchLogProcessor.ExportError`