### PR TITLE
Fix radar deploy: install soar-deploy before running it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -934,8 +934,8 @@ jobs:
           echo "Executing deployment script for radar-staging..."
           echo "Deployment ID: $DEPLOY_ID"
 
-          # Install updated soar-deploy before running it (self-update runs after
-          # environment validation, so an old script will reject new env names)
+          # Bootstrap: install the repo's soar-deploy so /usr/local/bin/soar-deploy
+          # is current before we invoke it (older versions may reject new env names)
           ssh soar@radar.hut8.tools "sudo install -m 755 $DEPLOY_DIR/soar-deploy /usr/local/bin/soar-deploy"
 
           ssh soar@radar.hut8.tools "nohup sudo /usr/local/bin/soar-deploy radar-staging $DEPLOY_DIR &"
@@ -1046,8 +1046,8 @@ jobs:
           echo "Executing deployment script for radar-production..."
           echo "Deployment ID: $DEPLOY_ID"
 
-          # Install updated soar-deploy before running it (self-update runs after
-          # environment validation, so an old script will reject new env names)
+          # Bootstrap: install the repo's soar-deploy so /usr/local/bin/soar-deploy
+          # is current before we invoke it (older versions may reject new env names)
           ssh soar@radar.hut8.tools "sudo install -m 755 $DEPLOY_DIR/soar-deploy /usr/local/bin/soar-deploy"
 
           ssh soar@radar.hut8.tools "nohup sudo /usr/local/bin/soar-deploy radar-production $DEPLOY_DIR &"

--- a/infrastructure/soar-deploy
+++ b/infrastructure/soar-deploy
@@ -66,10 +66,19 @@ fi
 # Self-update: if the deployment directory has a newer soar-deploy, install it
 # and re-exec before doing anything else (including environment validation),
 # so that new environment names are recognised immediately.
+# Failures here write a status file so CI polling doesn't hang.
 if [ -d "$DEPLOY_DIR" ] && [ -f "$DEPLOY_DIR/soar-deploy" ]; then
     if ! diff -q "$0" "$DEPLOY_DIR/soar-deploy" >/dev/null 2>&1; then
         echo -e "${YELLOW}[WARN]${NC} Deployment script has changed - updating /usr/local/bin/soar-deploy and re-executing..."
-        install -m 755 -o root -g root "$DEPLOY_DIR/soar-deploy" /usr/local/bin/soar-deploy
+        DEPLOY_DIR_BASENAME=$(basename "$DEPLOY_DIR")
+        _EARLY_STATUS_DIR="$DEPLOY_STATUS_DIR/${ENVIRONMENT}-${DEPLOY_DIR_BASENAME}.status"
+        _EARLY_LOG_DIR="$DEPLOY_LOG_DIR/${ENVIRONMENT}-${DEPLOY_DIR_BASENAME}.log"
+        if ! install -m 755 -o root -g root "$DEPLOY_DIR/soar-deploy" /usr/local/bin/soar-deploy; then
+            mkdir -p "$DEPLOY_STATUS_DIR" "$DEPLOY_LOG_DIR"
+            echo "Self-update failed: could not install $DEPLOY_DIR/soar-deploy" > "$_EARLY_LOG_DIR"
+            echo "1" > "$_EARLY_STATUS_DIR"
+            exit 1
+        fi
         exec /usr/local/bin/soar-deploy "$@"
     fi
 fi


### PR DESCRIPTION
## Summary
- The old `soar-deploy` on the radar server didn't recognize `radar-staging` and rejected it before reaching the self-update logic
- CI now explicitly installs the updated `soar-deploy` from the deploy package before invoking it
- Moved self-update in `soar-deploy` to before environment validation so new env names are recognized immediately on re-exec

## Test plan
- [x] Updated `soar-deploy` installed on radar server manually
- [ ] Merge to main and verify "deploy radar (staging)" CI job succeeds