### PR TITLE
Fix airports page crash: BigDecimal serialized as string

### DIFF
--- a/src/actions/views/airport.rs
+++ b/src/actions/views/airport.rs
@@ -1,6 +1,7 @@
-use bigdecimal::ToPrimitive;
+use bigdecimal::{BigDecimal, ToPrimitive};
 use serde::{Deserialize, Serialize};
 use std::f64::consts::PI;
+use tracing::warn;
 use ts_rs::TS;
 
 use crate::airports::Airport;
@@ -197,15 +198,31 @@ pub struct AirportView {
     pub runways: Vec<RunwayView>,
 }
 
+fn bigdecimal_to_f64(value: &Option<BigDecimal>, field: &str, ident: &str) -> Option<f64> {
+    match value {
+        Some(d) => match d.to_f64() {
+            Some(f) => Some(f),
+            None => {
+                warn!(ident, field, value = %d, "Failed to convert BigDecimal coordinate to f64");
+                None
+            }
+        },
+        None => None,
+    }
+}
+
 impl From<Airport> for AirportView {
     fn from(airport: Airport) -> Self {
+        let latitude_deg = bigdecimal_to_f64(&airport.latitude_deg, "latitude_deg", &airport.ident);
+        let longitude_deg =
+            bigdecimal_to_f64(&airport.longitude_deg, "longitude_deg", &airport.ident);
         Self {
             id: airport.id,
             ident: airport.ident,
             airport_type: airport.airport_type,
             name: airport.name,
-            latitude_deg: airport.latitude_deg.as_ref().and_then(|d| d.to_f64()),
-            longitude_deg: airport.longitude_deg.as_ref().and_then(|d| d.to_f64()),
+            latitude_deg,
+            longitude_deg,
             elevation_ft: airport.elevation_ft,
             continent: airport.continent,
             iso_country: airport.iso_country,


### PR DESCRIPTION
## Summary
- `AirportView.latitude_deg` and `longitude_deg` were `Option<BigDecimal>`, which serde serializes as JSON strings (e.g., `"40.070985"`)
- The TypeScript type was overridden with `#[ts(type = "number | null")]`, hiding the mismatch
- The frontend `formatCoordinates` function called `.toFixed()` on these values, which fails on strings
- Changed the fields to `Option<f64>` with conversion from `BigDecimal` in the `From<Airport>` impl, so the API returns actual JSON numbers

## Test plan
- [ ] Search for an airport on the /airports page and verify results render without console errors
- [ ] Verify coordinates display correctly (e.g., `40.0710°N, 74.9337°W`)
- [ ] Verify Google Maps links work from coordinate cells