### PR TITLE
Fix setup-pgdog: build from source, avoid PgBouncer port conflict

### DIFF
--- a/scripts/setup-pgdog
+++ b/scripts/setup-pgdog
@@ -34,6 +34,14 @@ echo "SOAR PgDog Setup - $ENVIRONMENT"
 echo "========================================="
 echo
 
+# When run via sudo, use the calling user's Rust toolchain
+if [[ -n "${SUDO_USER:-}" ]]; then
+    SUDO_HOME=$(eval echo "~$SUDO_USER")
+    export RUSTUP_HOME="${RUSTUP_HOME:-$SUDO_HOME/.rustup}"
+    export CARGO_HOME="${CARGO_HOME:-$SUDO_HOME/.cargo}"
+    export PATH="$CARGO_HOME/bin:$PATH"
+fi
+
 # Check build dependencies
 for cmd in git cargo cmake; do
     if ! command -v "$cmd" &>/dev/null; then


### PR DESCRIPTION
## Summary
- PgDog does not publish prebuilt binaries on GitHub releases — the download URL was 404ing
- Build from source via `cargo build --release` instead
- Use ports 6434/6435 (production/staging) to avoid conflicting with PgBouncer on 6432

## Test plan
- [ ] Run `sudo ./scripts/setup-pgdog staging` on staging server