### PR TITLE
Fix club members not showing and auth refresh logout

### DIFF
--- a/src/actions/auth.rs
+++ b/src/actions/auth.rs
@@ -11,7 +11,7 @@ use crate::users_repo::UsersRepository;
 use crate::web::AppState;
 
 use super::{
-    json_error,
+    DataResponse, json_error,
     views::{
         CreateUserRequest, EmailVerificationConfirm, LoginRequest, LoginResponse,
         PasswordResetConfirm, PasswordResetRequest, UserView,
@@ -203,7 +203,9 @@ pub async fn login_user(
 }
 
 pub async fn get_current_user(auth_user: AuthUser) -> impl IntoResponse {
-    Json(UserView::from(auth_user.0))
+    Json(DataResponse {
+        data: UserView::from(auth_user.0),
+    })
 }
 
 pub async fn verify_email(

--- a/src/actions/pilots.rs
+++ b/src/actions/pilots.rs
@@ -58,9 +58,9 @@ pub async fn get_pilot_by_id(
     }
 }
 
-/// Get all pilots for a specific club
+/// Get all members for a specific club
 /// Requires authentication and user must belong to the requested club
-pub async fn get_pilots_by_club(
+pub async fn get_members_by_club(
     Path(club_id): Path<Uuid>,
     State(state): State<AppState>,
     AuthUser(user): AuthUser,
@@ -69,20 +69,20 @@ pub async fn get_pilots_by_club(
     if user.club_id != Some(club_id) && !user.is_admin {
         return json_error(
             StatusCode::FORBIDDEN,
-            "You must be a member of this club to view its pilots",
+            "You must be a member of this club to view its members",
         )
         .into_response();
     }
 
     let users_repo = UsersRepository::new(state.pool.clone());
 
-    match users_repo.get_pilots_by_club(club_id).await {
-        Ok(pilots) => Json(DataListResponse { data: pilots }).into_response(),
+    match users_repo.get_members_by_club(club_id).await {
+        Ok(members) => Json(DataListResponse { data: members }).into_response(),
         Err(e) => {
-            tracing::error!(club_id = %club_id, error = %e, "Failed to get pilots for club");
+            tracing::error!(club_id = %club_id, error = %e, "Failed to get members for club");
             json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to get pilots for club",
+                "Failed to get members for club",
             )
             .into_response()
         }

--- a/src/actions/users.rs
+++ b/src/actions/users.rs
@@ -206,8 +206,8 @@ pub async fn create_pilot(
     }
 }
 
-/// Get pilots for a specific club (convenience endpoint that filters to only pilots)
-pub async fn get_pilots_by_club(
+/// Get all members for a specific club
+pub async fn get_members_by_club(
     auth_user: AuthUser,
     State(state): State<AppState>,
     Path(club_id): Path<Uuid>,
@@ -218,21 +218,21 @@ pub async fn get_pilots_by_club(
     if !auth_user.0.is_admin && auth_user.0.club_id != Some(club_id) {
         return json_error(
             StatusCode::FORBIDDEN,
-            "You must be a member of this club to view its pilots",
+            "You must be a member of this club to view its members",
         )
         .into_response();
     }
 
-    match users_repo.get_pilots_by_club(club_id).await {
-        Ok(pilots) => {
-            let pilot_views: Vec<UserView> = pilots.into_iter().map(UserView::from).collect();
-            Json(DataListResponse { data: pilot_views }).into_response()
+    match users_repo.get_members_by_club(club_id).await {
+        Ok(members) => {
+            let member_views: Vec<UserView> = members.into_iter().map(UserView::from).collect();
+            Json(DataListResponse { data: member_views }).into_response()
         }
         Err(e) => {
-            error!(club_id = %club_id, error = %e, "Failed to get pilots for club");
+            error!(club_id = %club_id, error = %e, "Failed to get members for club");
             json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
-                "Failed to get pilots for club",
+                "Failed to get members for club",
             )
             .into_response()
         }

--- a/src/users_repo.rs
+++ b/src/users_repo.rs
@@ -560,13 +560,6 @@ impl UsersRepository {
             let pilots = users::table
                 .filter(users::club_id.eq(Some(club_id)))
                 .filter(users::deleted_at.is_null())
-                .filter(
-                    users::is_licensed
-                        .eq(true)
-                        .or(users::is_instructor.eq(true))
-                        .or(users::is_tow_pilot.eq(true))
-                        .or(users::is_examiner.eq(true)),
-                )
                 .order((users::last_name.asc(), users::first_name.asc()))
                 .load::<UserRecord>(&mut conn)?;
             Ok(pilots.into_iter().map(|r| r.into()).collect())

--- a/src/users_repo.rs
+++ b/src/users_repo.rs
@@ -550,19 +550,19 @@ impl UsersRepository {
         .await?
     }
 
-    /// Get all pilots (users with pilot qualifications) for a club
+    /// Get all members for a club
     /// Excludes soft-deleted users
-    pub async fn get_pilots_by_club(&self, club_id: Uuid) -> Result<Vec<User>> {
+    pub async fn get_members_by_club(&self, club_id: Uuid) -> Result<Vec<User>> {
         let pool = self.pool.clone();
 
         tokio::task::spawn_blocking(move || -> Result<Vec<User>> {
             let mut conn = pool.get()?;
-            let pilots = users::table
+            let members = users::table
                 .filter(users::club_id.eq(Some(club_id)))
                 .filter(users::deleted_at.is_null())
                 .order((users::last_name.asc(), users::first_name.asc()))
                 .load::<UserRecord>(&mut conn)?;
-            Ok(pilots.into_iter().map(|r| r.into()).collect())
+            Ok(members.into_iter().map(|r| r.into()).collect())
         })
         .await?
     }

--- a/src/web.rs
+++ b/src/web.rs
@@ -779,7 +779,7 @@ pub async fn start_web_server(interface: String, port: u16, pool: PgPool) -> Res
         .route("/pilots", post(actions::users::create_pilot))
         .route(
             "/clubs/{id}/pilots",
-            get(actions::users::get_pilots_by_club),
+            get(actions::users::get_members_by_club),
         )
         .route(
             "/users/{id}/invite",

--- a/tests/pilot_invitation_workflow_test.rs
+++ b/tests/pilot_invitation_workflow_test.rs
@@ -208,7 +208,7 @@ async fn test_full_pilot_invitation_workflow() {
 
 #[tokio::test]
 #[serial]
-async fn test_get_pilots_by_club() {
+async fn test_get_members_by_club() {
     let test_db = setup_test_db().await;
     let pool = test_db.pool();
     let users_repo = UsersRepository::new(pool.clone());
@@ -254,7 +254,7 @@ async fn test_get_pilots_by_club() {
     users_repo.create_pilot(pilot3.clone()).await.unwrap();
 
     // Get all pilots for the club
-    let pilots = users_repo.get_pilots_by_club(club.id).await.unwrap();
+    let pilots = users_repo.get_members_by_club(club.id).await.unwrap();
     assert_eq!(pilots.len(), 3);
 
     // Verify all returned pilots are from the correct club

--- a/web/src/lib/stores/auth.ts
+++ b/web/src/lib/stores/auth.ts
@@ -93,6 +93,9 @@ function createAuthStore() {
 			}
 		},
 		updateUser: (user: User) => {
+			if (!user || !user.id) {
+				return;
+			}
 			if (browser) {
 				localStorage.setItem('auth_user', JSON.stringify(user));
 			}

--- a/web/src/lib/stores/auth.ts
+++ b/web/src/lib/stores/auth.ts
@@ -92,7 +92,7 @@ function createAuthStore() {
 				}
 			}
 		},
-		updateUser: (user: User) => {
+		updateUser: (user: User | null | undefined) => {
 			if (!user || !user.id) {
 				return;
 			}


### PR DESCRIPTION
## Summary
- **Club members page showed "No members found"**: `get_pilots_by_club()` filtered for users with at least one qualification flag (`is_licensed`, `is_instructor`, `is_tow_pilot`, `is_examiner`). Members without any flags were excluded. Removed the filter so all club members appear.
- **Refreshing the members page logged users out**: `GET /auth/me` returned a bare `UserView` but the frontend expected `DataResponse<User>` (wrapped in `{ data: ... }`). The `undefined` `response.data` was passed to `updateUser()`, which wrote `"undefined"` to localStorage. On next load, `JSON.parse("undefined")` threw, and the catch block cleared the auth token. Fixed by wrapping the backend response in `DataResponse` and adding a guard in `updateUser()` to reject nullish input.

## Test plan
- [ ] Log in and navigate to My Club → Members — members should now appear
- [ ] Refresh the members page multiple times — should stay logged in
- [ ] Verify `/auth/me` returns `{ "data": { "id": ..., ... } }` shape