### PR TITLE
Use self-hosted runners for Rust CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
       volumes:
-        - /opt/ci-cache/cargo-registry:/usr/local/cargo/registry
-        - /opt/ci-cache/cargo-git:/usr/local/cargo/git
-        - /opt/ci-cache/target:/ci-target
+        - /opt/ci-cache:/ci-cache
     services:
       postgres:
         image: ghcr.io/hut8/postgis-timescaledb:latest
@@ -94,8 +92,12 @@ jobs:
         with:
           fetch-depth: 0  # Fetch all history for git tags (needed for vergen version)
 
-      - name: Set cargo target directory
-        run: echo "CARGO_TARGET_DIR=/ci-target/${RUNNER_NAME}-e2e" >> $GITHUB_ENV
+      - name: Setup persistent cargo cache
+        run: |
+          mkdir -p /ci-cache/${RUNNER_NAME}/cargo-registry /ci-cache/${RUNNER_NAME}/cargo-git
+          ln -sfn /ci-cache/${RUNNER_NAME}/cargo-registry /usr/local/cargo/registry
+          ln -sfn /ci-cache/${RUNNER_NAME}/cargo-git /usr/local/cargo/git
+          echo "CARGO_TARGET_DIR=/ci-cache/${RUNNER_NAME}/target-e2e" >> $GITHUB_ENV
 
       - name: Install unzip (required by setup-bun in container)
         run: apt-get update -qq && apt-get install -y -qq unzip
@@ -216,9 +218,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
       volumes:
-        - /opt/ci-cache/cargo-registry:/usr/local/cargo/registry
-        - /opt/ci-cache/cargo-git:/usr/local/cargo/git
-        - /opt/ci-cache/target:/ci-target
+        - /opt/ci-cache:/ci-cache
     services:
       postgres:
         image: ghcr.io/hut8/postgis-timescaledb:latest
@@ -244,8 +244,12 @@ jobs:
         with:
           fetch-depth: 0  # Fetch all history for git tags (needed for vergen version)
 
-      - name: Set cargo target directory
-        run: echo "CARGO_TARGET_DIR=/ci-target/${RUNNER_NAME}-test" >> $GITHUB_ENV
+      - name: Setup persistent cargo cache
+        run: |
+          mkdir -p /ci-cache/${RUNNER_NAME}/cargo-registry /ci-cache/${RUNNER_NAME}/cargo-git
+          ln -sfn /ci-cache/${RUNNER_NAME}/cargo-registry /usr/local/cargo/registry
+          ln -sfn /ci-cache/${RUNNER_NAME}/cargo-git /usr/local/cargo/git
+          echo "CARGO_TARGET_DIR=/ci-cache/${RUNNER_NAME}/target-test" >> $GITHUB_ENV
 
       - name: Install unzip (required by setup-bun in container)
         run: apt-get update -qq && apt-get install -y -qq unzip
@@ -308,9 +312,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
       volumes:
-        - /opt/ci-cache/cargo-registry:/usr/local/cargo/registry
-        - /opt/ci-cache/cargo-git:/usr/local/cargo/git
-        - /opt/ci-cache/target:/ci-target
+        - /opt/ci-cache:/ci-cache
     defaults:
       run:
         shell: bash
@@ -321,8 +323,12 @@ jobs:
         with:
           fetch-depth: 0  # Fetch all history for git tags (needed for vergen version)
 
-      - name: Set cargo target directory
-        run: echo "CARGO_TARGET_DIR=/ci-target/${RUNNER_NAME}-release-musl" >> $GITHUB_ENV
+      - name: Setup persistent cargo cache
+        run: |
+          mkdir -p /ci-cache/${RUNNER_NAME}/cargo-registry /ci-cache/${RUNNER_NAME}/cargo-git
+          ln -sfn /ci-cache/${RUNNER_NAME}/cargo-registry /usr/local/cargo/registry
+          ln -sfn /ci-cache/${RUNNER_NAME}/cargo-git /usr/local/cargo/git
+          echo "CARGO_TARGET_DIR=/ci-cache/${RUNNER_NAME}/target-release-musl" >> $GITHUB_ENV
 
       - name: Install unzip (required by setup-bun in container)
         run: apt-get update -qq && apt-get install -y -qq unzip
@@ -401,6 +407,8 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+      volumes:
+        - /opt/ci-cache:/ci-cache
     defaults:
       run:
         shell: bash
@@ -410,6 +418,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history for git tags (needed for vergen version)
+
+      - name: Setup persistent cargo cache
+        run: |
+          mkdir -p /ci-cache/${RUNNER_NAME}/cargo-registry /ci-cache/${RUNNER_NAME}/cargo-git
+          ln -sfn /ci-cache/${RUNNER_NAME}/cargo-registry /usr/local/cargo/registry
+          ln -sfn /ci-cache/${RUNNER_NAME}/cargo-git /usr/local/cargo/git
 
       - name: Run security audit
         run: cargo audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,6 @@ jobs:
         - /opt/ci-cache/cargo-registry:/usr/local/cargo/registry
         - /opt/ci-cache/cargo-git:/usr/local/cargo/git
         - /opt/ci-cache/target:/ci-target
-    env:
-      CARGO_TARGET_DIR: /ci-target/${{ runner.name }}-e2e
     services:
       postgres:
         image: ghcr.io/hut8/postgis-timescaledb:latest
@@ -95,6 +93,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history for git tags (needed for vergen version)
+
+      - name: Set cargo target directory
+        run: echo "CARGO_TARGET_DIR=/ci-target/${RUNNER_NAME}-e2e" >> $GITHUB_ENV
 
       - name: Install unzip (required by setup-bun in container)
         run: apt-get update -qq && apt-get install -y -qq unzip
@@ -218,8 +219,6 @@ jobs:
         - /opt/ci-cache/cargo-registry:/usr/local/cargo/registry
         - /opt/ci-cache/cargo-git:/usr/local/cargo/git
         - /opt/ci-cache/target:/ci-target
-    env:
-      CARGO_TARGET_DIR: /ci-target/${{ runner.name }}-test
     services:
       postgres:
         image: ghcr.io/hut8/postgis-timescaledb:latest
@@ -244,6 +243,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history for git tags (needed for vergen version)
+
+      - name: Set cargo target directory
+        run: echo "CARGO_TARGET_DIR=/ci-target/${RUNNER_NAME}-test" >> $GITHUB_ENV
 
       - name: Install unzip (required by setup-bun in container)
         run: apt-get update -qq && apt-get install -y -qq unzip
@@ -309,8 +311,6 @@ jobs:
         - /opt/ci-cache/cargo-registry:/usr/local/cargo/registry
         - /opt/ci-cache/cargo-git:/usr/local/cargo/git
         - /opt/ci-cache/target:/ci-target
-    env:
-      CARGO_TARGET_DIR: /ci-target/${{ runner.name }}-release-musl
     defaults:
       run:
         shell: bash
@@ -320,6 +320,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history for git tags (needed for vergen version)
+
+      - name: Set cargo target directory
+        run: echo "CARGO_TARGET_DIR=/ci-target/${RUNNER_NAME}-release-musl" >> $GITHUB_ENV
 
       - name: Install unzip (required by setup-bun in container)
         run: apt-get update -qq && apt-get install -y -qq unzip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,18 @@ jobs:
 
   test-e2e:
     name: E2E Tests (Playwright)
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     container:
       image: ghcr.io/hut8/soar-ci:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+      volumes:
+        - /opt/ci-cache/cargo-registry:/usr/local/cargo/registry
+        - /opt/ci-cache/cargo-git:/usr/local/cargo/git
+        - /opt/ci-cache/target:/ci-target
+    env:
+      CARGO_TARGET_DIR: /ci-target/${{ runner.name }}-e2e
     services:
       postgres:
         image: ghcr.io/hut8/postgis-timescaledb:latest
@@ -95,13 +101,6 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          shared-key: "e2e-debug"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install web dependencies
         run: bun install --frozen-lockfile
@@ -138,7 +137,7 @@ jobs:
           RUSTFLAGS="--cfg tokio_unstable" cargo build
 
           # Seed test data
-          ./target/debug/soar seed-test-data
+          $CARGO_TARGET_DIR/debug/soar seed-test-data
 
       - name: Start Rust backend server
         working-directory: .
@@ -156,7 +155,7 @@ jobs:
           BASE_URL: http://localhost:4173
         run: |
           # Start backend server in background
-          ./target/debug/soar web --port 61225 --interface localhost > backend.log 2>&1 &
+          $CARGO_TARGET_DIR/debug/soar web --port 61225 --interface localhost > backend.log 2>&1 &
           BACKEND_PID=$!
           echo "Backend PID: $BACKEND_PID"
           echo $BACKEND_PID > backend.pid
@@ -215,6 +214,12 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+      volumes:
+        - /opt/ci-cache/cargo-registry:/usr/local/cargo/registry
+        - /opt/ci-cache/cargo-git:/usr/local/cargo/git
+        - /opt/ci-cache/target:/ci-target
+    env:
+      CARGO_TARGET_DIR: /ci-target/${{ runner.name }}-test
     services:
       postgres:
         image: ghcr.io/hut8/postgis-timescaledb:latest
@@ -249,14 +254,6 @@ jobs:
       - name: Install web dependencies
         working-directory: ./web
         run: bun install --frozen-lockfile
-
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          shared-key: "test-build"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          cache-all-crates: true
 
       - name: Setup test database
         env:
@@ -308,6 +305,12 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+      volumes:
+        - /opt/ci-cache/cargo-registry:/usr/local/cargo/registry
+        - /opt/ci-cache/cargo-git:/usr/local/cargo/git
+        - /opt/ci-cache/target:/ci-target
+    env:
+      CARGO_TARGET_DIR: /ci-target/${{ runner.name }}-release-musl
     defaults:
       run:
         shell: bash
@@ -336,14 +339,6 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         run: bun run build
 
-      - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-          shared-key: "release-build-native-musl"
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          cache-all-crates: true
-
       - name: Build static release binary
         env:
           SKIP_WEB_BUILD: "1"  # Frontend already built via bun run build above
@@ -357,21 +352,21 @@ jobs:
       - name: Verify static linking
         run: |
           echo "Checking if binary is statically linked..."
-          file target/x86_64-unknown-linux-musl/release/soar
+          file $CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/soar
 
           # Check for dynamic dependencies (should show "statically linked")
-          if ldd target/x86_64-unknown-linux-musl/release/soar 2>&1 | grep -q "not a dynamic executable"; then
+          if ldd $CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/soar 2>&1 | grep -q "not a dynamic executable"; then
             echo "Binary is statically linked (no dynamic dependencies)"
           else
             echo "Binary has dynamic dependencies:"
-            ldd target/x86_64-unknown-linux-musl/release/soar || true
+            ldd $CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/soar || true
           fi
 
       - name: Create binary archive
         run: |
           rm -rf release
           mkdir -p release
-          cp target/x86_64-unknown-linux-musl/release/soar release/
+          cp $CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/soar release/
           cp README.md release/ || echo "No README.md found"
           tar -czf soar-linux-x64.tar.gz -C release .
 
@@ -385,19 +380,19 @@ jobs:
       - name: Show binary info
         run: |
           echo "Binary size:"
-          ls -lh target/x86_64-unknown-linux-musl/release/soar
+          ls -lh $CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/soar
           echo ""
           echo "Binary info:"
-          file target/x86_64-unknown-linux-musl/release/soar
+          file $CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/soar
           echo ""
           echo "Stripped binary size:"
-          cp target/x86_64-unknown-linux-musl/release/soar /tmp/soar-stripped
+          cp $CARGO_TARGET_DIR/x86_64-unknown-linux-musl/release/soar /tmp/soar-stripped
           strip /tmp/soar-stripped
           ls -lh /tmp/soar-stripped
 
   security-audit:
     name: Security Audit
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     container:
       image: ghcr.io/hut8/soar-ci:latest
       credentials:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
   release:
     types: [ published ]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -205,7 +209,7 @@ jobs:
 
   test-rust:
     name: Test Rust Project
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     container:
       image: ghcr.io/hut8/soar-ci:latest
       credentials:
@@ -298,7 +302,7 @@ jobs:
 
   build-release:
     name: Build Release Binary (Native Static musl)
-    runs-on: ubuntu-22.04
+    runs-on: self-hosted
     container:
       image: ghcr.io/hut8/soar-ci:latest
       credentials:

--- a/web/e2e/auth/login.test.ts
+++ b/web/e2e/auth/login.test.ts
@@ -98,7 +98,7 @@ test.describe('Login', () => {
 		await page.getByPlaceholder('Enter your password').press('Enter');
 
 		// Should be redirected to home page
-		await expect(page).toHaveURL('/');
+		await expect(page).toHaveURL('/', { timeout: 15000 });
 	});
 
 	test('should navigate to registration page from login', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Move `test-rust`, `build-release`, `test-e2e`, and `security-audit` jobs to self-hosted runners (tenerife-1 through tenerife-8) on a 32-core/125GB machine
- Replace `Swatinem/rust-cache` with persistent host-mounted cargo cache volumes (`/opt/ci-cache`)
- Namespace all caches per-runner (`/ci-cache/${RUNNER_NAME}/`) to prevent corruption from concurrent jobs
- Add concurrency group to cancel stale in-progress CI runs (except on main)

## How it works
- Each self-hosted container job mounts `/opt/ci-cache:/ci-cache`
- A setup step symlinks `/usr/local/cargo/registry` and `/usr/local/cargo/git` to per-runner subdirectories
- `CARGO_TARGET_DIR` is set to a per-runner, per-job-type path (e.g., `/ci-cache/tenerife-3/target-test`)
- 8 runner instances via systemd template (`github-actions-runner@{1..8}.service`) allow full parallelism

## What stays on GitHub-hosted
- `test-sveltekit` — fast (1.5 min), no Rust
- `build-android` — JDK/Gradle toolchain, fast (2 min)
- `build-release-arm64` — cross-compilation, needs separate setup
- All deploy jobs — lightweight SSH operations

## Test plan
- [x] 8 self-hosted runners registered and online
- [x] Runners configured as non-ephemeral (persist across jobs)
- [ ] Verify all self-hosted jobs complete successfully
- [ ] Verify warm-cache runs are faster than GitHub-hosted baseline (~13 min)
- [ ] Verify concurrent jobs don't corrupt shared state