### PR TITLE
Android: add AR view with camera overlay

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -81,4 +81,10 @@ dependencies {
 
     // Security
     implementation(libs.androidx.security.crypto)
+
+    // CameraX
+    implementation(libs.androidx.camera.core)
+    implementation(libs.androidx.camera.camera2)
+    implementation(libs.androidx.camera.lifecycle)
+    implementation(libs.androidx.camera.view)
 }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -82,9 +82,12 @@ dependencies {
     // Security
     implementation(libs.androidx.security.crypto)
 
-    // CameraX
+    // CameraX (fallback when ARCore unavailable)
     implementation(libs.androidx.camera.core)
     implementation(libs.androidx.camera.camera2)
     implementation(libs.androidx.camera.lifecycle)
     implementation(libs.androidx.camera.view)
+
+    // ARCore
+    implementation(libs.arcore)
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -9,3 +9,6 @@
 -keepclasseswithmembers class * {
     @retrofit2.http.* <methods>;
 }
+
+# ARCore
+-keep class com.google.ar.core.** { *; }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.CAMERA" />
 
     <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.ar" android:required="false" />
 
     <application
         android:name=".SoarTrackerApp"
@@ -24,6 +25,9 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.SOARTracker">
+
+        <!-- ARCore optional: app works without it, falls back to sensor-based AR -->
+        <meta-data android:name="com.google.ar.core" android:value="optional" />
 
         <activity
             android:name=".MainActivity"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,9 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
 
     <application
         android:name=".SoarTrackerApp"

--- a/android/app/src/main/java/com/soar/tracker/ar/ARCoreSessionManager.kt
+++ b/android/app/src/main/java/com/soar/tracker/ar/ARCoreSessionManager.kt
@@ -31,8 +31,10 @@ class ARCoreSessionManager(private val activity: Activity) : GLSurfaceView.Rende
     private val backgroundRenderer = BackgroundRenderer()
 
     // North calibration: offset = magneticNorth - arcoreYaw (averaged over N samples)
+    // Accessed from both main thread (calibrateNorth) and GL thread (onDrawFrame)
+    private val calibrationLock = Any()
     private var northOffsetDegrees: Float? = null
-    private val calibrationSamples = mutableListOf<Float>() // (magneticHeading - arcoreYaw)
+    private val calibrationSamples = mutableListOf<Float>()
     @Volatile
     private var pendingMagneticHeading: Float? = null
 
@@ -57,7 +59,9 @@ class ARCoreSessionManager(private val activity: Activity) : GLSurfaceView.Rende
      * Only the first [CALIBRATION_SAMPLE_COUNT] samples are used.
      */
     fun calibrateNorth(magneticHeadingDegrees: Float) {
-        if (northOffsetDegrees != null) return // Already calibrated
+        synchronized(calibrationLock) {
+            if (northOffsetDegrees != null) return // Already calibrated
+        }
         pendingMagneticHeading = magneticHeadingDegrees
     }
 
@@ -145,23 +149,24 @@ class ARCoreSessionManager(private val activity: Activity) : GLSurfaceView.Rende
         val pose = camera.displayOrientedPose
         val (arcoreYawDeg, pitchDeg) = extractYawPitch(pose)
 
-        // Collect north calibration samples
-        if (northOffsetDegrees == null) {
-            val magHeading = pendingMagneticHeading
-            if (magHeading != null) {
-                var diff = magHeading - arcoreYawDeg
-                // Normalize to -180..180 for averaging
-                if (diff > 180f) diff -= 360f
-                if (diff < -180f) diff += 360f
-                calibrationSamples.add(diff)
+        // Collect north calibration samples (synchronized — written here on GL thread,
+        // northOffsetDegrees read on main thread via calibrateNorth's early-return check)
+        val offset = synchronized(calibrationLock) {
+            if (northOffsetDegrees == null) {
+                val magHeading = pendingMagneticHeading
+                if (magHeading != null) {
+                    var diff = magHeading - arcoreYawDeg
+                    if (diff > 180f) diff -= 360f
+                    if (diff < -180f) diff += 360f
+                    calibrationSamples.add(diff)
 
-                if (calibrationSamples.size >= CALIBRATION_SAMPLE_COUNT) {
-                    northOffsetDegrees = calibrationSamples.average().toFloat()
+                    if (calibrationSamples.size >= CALIBRATION_SAMPLE_COUNT) {
+                        northOffsetDegrees = calibrationSamples.average().toFloat()
+                    }
                 }
             }
+            northOffsetDegrees
         }
-
-        val offset = northOffsetDegrees
         if (offset != null) {
             var heading = (arcoreYawDeg + offset) % 360f
             if (heading < 0) heading += 360f

--- a/android/app/src/main/java/com/soar/tracker/ar/ARCoreSessionManager.kt
+++ b/android/app/src/main/java/com/soar/tracker/ar/ARCoreSessionManager.kt
@@ -1,0 +1,215 @@
+package com.soar.tracker.ar
+
+import android.app.Activity
+import android.opengl.GLES20
+import android.opengl.GLSurfaceView
+import com.google.ar.core.ArCoreApk
+import com.google.ar.core.Config
+import com.google.ar.core.Pose
+import com.google.ar.core.Session
+import com.google.ar.core.TrackingState
+import com.google.ar.core.exceptions.CameraNotAvailableException
+import com.google.ar.core.exceptions.UnavailableException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import javax.microedition.khronos.egl.EGLConfig
+import javax.microedition.khronos.opengles.GL10
+import kotlin.math.asin
+import kotlin.math.atan
+import kotlin.math.atan2
+
+/**
+ * Manages an ARCore [Session] and extracts heading/pitch from the camera pose each frame.
+ *
+ * ARCore's visual-inertial odometry gives frame-accurate pose tracking, so the
+ * overlay markers stay perfectly synchronized with the camera image. The heading is
+ * calibrated to magnetic north using a one-time offset from the sensor-based compass.
+ */
+class ARCoreSessionManager(private val activity: Activity) : GLSurfaceView.Renderer {
+
+    private var session: Session? = null
+    private val backgroundRenderer = BackgroundRenderer()
+
+    // North calibration: offset = magneticNorth - arcoreYaw (averaged over N samples)
+    private var northOffsetDegrees: Float? = null
+    private val calibrationSamples = mutableListOf<Float>() // (magneticHeading - arcoreYaw)
+    @Volatile
+    private var pendingMagneticHeading: Float? = null
+
+    private val _headingDegrees = MutableStateFlow<Float?>(null)
+    val headingDegrees: StateFlow<Float?> = _headingDegrees
+
+    private val _pitchDegrees = MutableStateFlow<Float?>(null)
+    val pitchDegrees: StateFlow<Float?> = _pitchDegrees
+
+    private val _fovHDegrees = MutableStateFlow<Float?>(null)
+    val fovHDegrees: StateFlow<Float?> = _fovHDegrees
+
+    private val _fovVDegrees = MutableStateFlow<Float?>(null)
+    val fovVDegrees: StateFlow<Float?> = _fovVDegrees
+
+    private val _isAvailable = MutableStateFlow(false)
+    val isAvailable: StateFlow<Boolean> = _isAvailable
+
+    /**
+     * Provide a magnetic heading sample for north calibration.
+     * Should be called whenever the sensor collector has a new heading value.
+     * Only the first [CALIBRATION_SAMPLE_COUNT] samples are used.
+     */
+    fun calibrateNorth(magneticHeadingDegrees: Float) {
+        if (northOffsetDegrees != null) return // Already calibrated
+        pendingMagneticHeading = magneticHeadingDegrees
+    }
+
+    fun createSession(): Boolean {
+        return try {
+            val availability = ArCoreApk.getInstance().checkAvailability(activity)
+            if (!availability.isSupported) {
+                _isAvailable.value = false
+                return false
+            }
+
+            val session = Session(activity)
+            val config = Config(session).apply {
+                updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
+                planeFindingMode = Config.PlaneFindingMode.DISABLED
+                lightEstimationMode = Config.LightEstimationMode.DISABLED
+                depthMode = Config.DepthMode.DISABLED
+                focusMode = Config.FocusMode.AUTO
+            }
+            session.configure(config)
+            this.session = session
+            _isAvailable.value = true
+            true
+        } catch (_: UnavailableException) {
+            _isAvailable.value = false
+            false
+        }
+    }
+
+    fun resume() {
+        try {
+            session?.resume()
+        } catch (_: CameraNotAvailableException) {
+            // Camera unavailable — will retry on next resume
+        }
+    }
+
+    fun pause() {
+        session?.pause()
+    }
+
+    fun destroy() {
+        session?.close()
+        session = null
+        _isAvailable.value = false
+        _headingDegrees.value = null
+        _pitchDegrees.value = null
+        _fovHDegrees.value = null
+        _fovVDegrees.value = null
+        northOffsetDegrees = null
+        calibrationSamples.clear()
+    }
+
+    // --- GLSurfaceView.Renderer ---
+
+    override fun onSurfaceCreated(gl: GL10?, config: EGLConfig?) {
+        GLES20.glClearColor(0f, 0f, 0f, 1f)
+        backgroundRenderer.createOnGlThread()
+        session?.setCameraTextureName(backgroundRenderer.textureId)
+    }
+
+    @Suppress("DEPRECATION") // defaultDisplay is fine for our use
+    override fun onSurfaceChanged(gl: GL10?, width: Int, height: Int) {
+        GLES20.glViewport(0, 0, width, height)
+        session?.setDisplayGeometry(activity.windowManager.defaultDisplay.rotation, width, height)
+    }
+
+    override fun onDrawFrame(gl: GL10?) {
+        GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT or GLES20.GL_DEPTH_BUFFER_BIT)
+
+        val session = this.session ?: return
+        val frame = try {
+            session.update()
+        } catch (_: CameraNotAvailableException) {
+            return
+        }
+
+        // Draw camera background
+        backgroundRenderer.draw(frame)
+
+        val camera = frame.camera
+        if (camera.trackingState != TrackingState.TRACKING) return
+
+        // Extract heading and pitch from the display-oriented pose
+        val pose = camera.displayOrientedPose
+        val (arcoreYawDeg, pitchDeg) = extractYawPitch(pose)
+
+        // Collect north calibration samples
+        if (northOffsetDegrees == null) {
+            val magHeading = pendingMagneticHeading
+            if (magHeading != null) {
+                var diff = magHeading - arcoreYawDeg
+                // Normalize to -180..180 for averaging
+                if (diff > 180f) diff -= 360f
+                if (diff < -180f) diff += 360f
+                calibrationSamples.add(diff)
+
+                if (calibrationSamples.size >= CALIBRATION_SAMPLE_COUNT) {
+                    northOffsetDegrees = calibrationSamples.average().toFloat()
+                }
+            }
+        }
+
+        val offset = northOffsetDegrees
+        if (offset != null) {
+            var heading = (arcoreYawDeg + offset) % 360f
+            if (heading < 0) heading += 360f
+            _headingDegrees.value = heading
+        }
+
+        _pitchDegrees.value = pitchDeg
+
+        // Extract actual camera FOV from projection matrix
+        val projMatrix = FloatArray(16)
+        camera.getProjectionMatrix(projMatrix, 0, 0.1f, 100f)
+        // projMatrix[0] = 1/tan(fovX/2), projMatrix[5] = 1/tan(fovY/2)
+        if (projMatrix[0] != 0f) {
+            _fovHDegrees.value = Math.toDegrees(2.0 * atan(1.0 / projMatrix[0])).toFloat()
+        }
+        if (projMatrix[5] != 0f) {
+            _fovVDegrees.value = Math.toDegrees(2.0 * atan(1.0 / projMatrix[5])).toFloat()
+        }
+    }
+
+    /**
+     * Extract yaw and pitch from an ARCore [Pose] quaternion.
+     *
+     * ARCore coordinate system: Y up, -Z is the camera forward direction.
+     * The displayOrientedPose accounts for screen rotation.
+     */
+    private fun extractYawPitch(pose: Pose): Pair<Float, Float> {
+        val qx = pose.qx()
+        val qy = pose.qy()
+        val qz = pose.qz()
+        val qw = pose.qw()
+
+        // Yaw: rotation around Y axis (gravity direction)
+        val sinYaw = 2f * (qw * qy + qx * qz)
+        val cosYaw = 1f - 2f * (qy * qy + qx * qx)
+        val yawRad = atan2(sinYaw, cosYaw)
+        // Negate because ARCore yaw increases counter-clockwise
+        var yawDeg = -Math.toDegrees(yawRad.toDouble()).toFloat()
+        if (yawDeg < 0) yawDeg += 360f
+
+        // Pitch: rotation around X axis
+        val sinPitch = 2f * (qw * qx - qy * qz)
+        val pitchDeg = Math.toDegrees(asin(sinPitch.coerceIn(-1f, 1f)).toDouble()).toFloat()
+
+        return Pair(yawDeg, pitchDeg)
+    }
+
+    companion object {
+        private const val CALIBRATION_SAMPLE_COUNT = 5
+    }
+}

--- a/android/app/src/main/java/com/soar/tracker/ar/BackgroundRenderer.kt
+++ b/android/app/src/main/java/com/soar/tracker/ar/BackgroundRenderer.kt
@@ -28,11 +28,12 @@ class BackgroundRenderer {
             position(0)
         }
 
-    // Tex coords — default values, updated per-frame by ARCore
+    // Source tex coords for ARCore's transformDisplayUvCoords.
+    // Vertices are bottom-left origin (OpenGL), so UV Y is flipped: 1=bottom, 0=top.
     private val quadTexCoordsSrc: FloatBuffer = ByteBuffer
         .allocateDirect(8 * 4).order(ByteOrder.nativeOrder()).asFloatBuffer()
         .apply {
-            put(floatArrayOf(0f, 0f, 0f, 1f, 1f, 0f, 1f, 1f))
+            put(floatArrayOf(0f, 1f, 0f, 0f, 1f, 1f, 1f, 0f))
             position(0)
         }
 

--- a/android/app/src/main/java/com/soar/tracker/ar/BackgroundRenderer.kt
+++ b/android/app/src/main/java/com/soar/tracker/ar/BackgroundRenderer.kt
@@ -1,0 +1,121 @@
+package com.soar.tracker.ar
+
+import android.opengl.GLES11Ext
+import android.opengl.GLES20
+import com.google.ar.core.Frame
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.FloatBuffer
+
+/**
+ * Minimal OpenGL renderer that draws ARCore's camera background image.
+ * Renders a fullscreen textured quad using the external OES texture
+ * that ARCore writes camera frames to.
+ */
+class BackgroundRenderer {
+    var textureId: Int = -1
+        private set
+
+    private var program = 0
+    private var positionAttrib = 0
+    private var texCoordAttrib = 0
+
+    // Fullscreen quad vertices (clip space)
+    private val quadVertices: FloatBuffer = ByteBuffer
+        .allocateDirect(8 * 4).order(ByteOrder.nativeOrder()).asFloatBuffer()
+        .apply {
+            put(floatArrayOf(-1f, -1f, -1f, +1f, +1f, -1f, +1f, +1f))
+            position(0)
+        }
+
+    // Tex coords — default values, updated per-frame by ARCore
+    private val quadTexCoordsSrc: FloatBuffer = ByteBuffer
+        .allocateDirect(8 * 4).order(ByteOrder.nativeOrder()).asFloatBuffer()
+        .apply {
+            put(floatArrayOf(0f, 0f, 0f, 1f, 1f, 0f, 1f, 1f))
+            position(0)
+        }
+
+    private val quadTexCoords: FloatBuffer = ByteBuffer
+        .allocateDirect(8 * 4).order(ByteOrder.nativeOrder()).asFloatBuffer()
+
+    fun createOnGlThread() {
+        val textures = IntArray(1)
+        GLES20.glGenTextures(1, textures, 0)
+        textureId = textures[0]
+
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, textureId)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR)
+        GLES20.glTexParameteri(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR)
+
+        val vertShader = """
+            attribute vec4 a_Position;
+            attribute vec2 a_TexCoord;
+            varying vec2 v_TexCoord;
+            void main() {
+                gl_Position = a_Position;
+                v_TexCoord = a_TexCoord;
+            }
+        """.trimIndent()
+
+        val fragShader = """
+            #extension GL_OES_EGL_image_external : require
+            precision mediump float;
+            varying vec2 v_TexCoord;
+            uniform samplerExternalOES u_Texture;
+            void main() {
+                gl_FragColor = texture2D(u_Texture, v_TexCoord);
+            }
+        """.trimIndent()
+
+        program = createProgram(vertShader, fragShader)
+        positionAttrib = GLES20.glGetAttribLocation(program, "a_Position")
+        texCoordAttrib = GLES20.glGetAttribLocation(program, "a_TexCoord")
+    }
+
+    fun draw(frame: Frame) {
+        // Transform default UVs to account for display rotation
+        quadTexCoordsSrc.position(0)
+        frame.transformDisplayUvCoords(quadTexCoordsSrc, quadTexCoords)
+        quadTexCoords.position(0)
+
+        GLES20.glDisable(GLES20.GL_DEPTH_TEST)
+        GLES20.glDepthMask(false)
+
+        GLES20.glUseProgram(program)
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, textureId)
+
+        GLES20.glEnableVertexAttribArray(positionAttrib)
+        GLES20.glVertexAttribPointer(positionAttrib, 2, GLES20.GL_FLOAT, false, 0, quadVertices)
+
+        GLES20.glEnableVertexAttribArray(texCoordAttrib)
+        GLES20.glVertexAttribPointer(texCoordAttrib, 2, GLES20.GL_FLOAT, false, 0, quadTexCoords)
+
+        GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4)
+
+        GLES20.glDisableVertexAttribArray(positionAttrib)
+        GLES20.glDisableVertexAttribArray(texCoordAttrib)
+
+        GLES20.glDepthMask(true)
+        GLES20.glEnable(GLES20.GL_DEPTH_TEST)
+    }
+
+    private fun createProgram(vertSrc: String, fragSrc: String): Int {
+        val vert = loadShader(GLES20.GL_VERTEX_SHADER, vertSrc)
+        val frag = loadShader(GLES20.GL_FRAGMENT_SHADER, fragSrc)
+        val prog = GLES20.glCreateProgram()
+        GLES20.glAttachShader(prog, vert)
+        GLES20.glAttachShader(prog, frag)
+        GLES20.glLinkProgram(prog)
+        return prog
+    }
+
+    private fun loadShader(type: Int, source: String): Int {
+        val shader = GLES20.glCreateShader(type)
+        GLES20.glShaderSource(shader, source)
+        GLES20.glCompileShader(shader)
+        return shader
+    }
+}

--- a/android/app/src/main/java/com/soar/tracker/service/SensorCollector.kt
+++ b/android/app/src/main/java/com/soar/tracker/service/SensorCollector.kt
@@ -43,6 +43,18 @@ class SensorCollector(context: Context) : SensorEventListener {
     private val _liveHeadingDegrees = MutableStateFlow<Float?>(null)
     val liveHeadingDegrees: StateFlow<Float?> = _liveHeadingDegrees
 
+    /**
+     * Live pitch in degrees for AR view.
+     * 0° = phone held vertically (screen facing user), positive = tilting up toward sky.
+     * Derived from orientation[1] which is -90° when vertical, so we add 90.
+     */
+    private val _livePitchDegrees = MutableStateFlow<Float?>(null)
+    val livePitchDegrees: StateFlow<Float?> = _livePitchDegrees
+
+    /** Live roll in degrees. 0° = upright, positive = tilted clockwise. */
+    private val _liveRollDegrees = MutableStateFlow<Float?>(null)
+    val liveRollDegrees: StateFlow<Float?> = _liveRollDegrees
+
     private val rotationMatrix = FloatArray(9)
     private val orientation = FloatArray(3)
 
@@ -61,6 +73,8 @@ class SensorCollector(context: Context) : SensorEventListener {
     fun stop() {
         sensorManager.unregisterListener(this)
         _liveHeadingDegrees.value = null
+        _livePitchDegrees.value = null
+        _liveRollDegrees.value = null
     }
 
     override fun onSensorChanged(event: SensorEvent) {
@@ -81,6 +95,12 @@ class SensorCollector(context: Context) : SensorEventListener {
                 if (azimuth < 0) azimuth += 360f
                 magneticHeadingDegrees = azimuth
                 _liveHeadingDegrees.value = azimuth
+                // orientation[1] is pitch in radians: 0 = flat, -π/2 = vertical (screen facing user)
+                // Add 90° so 0° = vertical phone, positive = tilting up toward sky
+                val pitch = Math.toDegrees(orientation[1].toDouble()).toFloat() + 90f
+                _livePitchDegrees.value = pitch
+                // orientation[2] is roll in radians: 0 = upright, positive = clockwise tilt
+                _liveRollDegrees.value = Math.toDegrees(orientation[2].toDouble()).toFloat()
             }
         }
     }

--- a/android/app/src/main/java/com/soar/tracker/service/SensorCollector.kt
+++ b/android/app/src/main/java/com/soar/tracker/service/SensorCollector.kt
@@ -51,10 +51,6 @@ class SensorCollector(context: Context) : SensorEventListener {
     private val _livePitchDegrees = MutableStateFlow<Float?>(null)
     val livePitchDegrees: StateFlow<Float?> = _livePitchDegrees
 
-    /** Live roll in degrees. 0° = upright, positive = tilted clockwise. */
-    private val _liveRollDegrees = MutableStateFlow<Float?>(null)
-    val liveRollDegrees: StateFlow<Float?> = _liveRollDegrees
-
     private val rotationMatrix = FloatArray(9)
     private val orientation = FloatArray(3)
 
@@ -74,7 +70,6 @@ class SensorCollector(context: Context) : SensorEventListener {
         sensorManager.unregisterListener(this)
         _liveHeadingDegrees.value = null
         _livePitchDegrees.value = null
-        _liveRollDegrees.value = null
     }
 
     override fun onSensorChanged(event: SensorEvent) {
@@ -99,8 +94,6 @@ class SensorCollector(context: Context) : SensorEventListener {
                 // Add 90° so 0° = vertical phone, positive = tilting up toward sky
                 val pitch = Math.toDegrees(orientation[1].toDouble()).toFloat() + 90f
                 _livePitchDegrees.value = pitch
-                // orientation[2] is roll in radians: 0 = upright, positive = clockwise tilt
-                _liveRollDegrees.value = Math.toDegrees(orientation[2].toDouble()).toFloat()
             }
         }
     }

--- a/android/app/src/main/java/com/soar/tracker/service/TrackingService.kt
+++ b/android/app/src/main/java/com/soar/tracker/service/TrackingService.kt
@@ -58,6 +58,8 @@ class TrackingService : LifecycleService() {
     private var locationCallback: LocationCallback? = null
     private var pendingSubmit: kotlinx.coroutines.Job? = null
     private var headingForwardJob: kotlinx.coroutines.Job? = null
+    private var pitchForwardJob: kotlinx.coroutines.Job? = null
+    private var rollForwardJob: kotlinx.coroutines.Job? = null
     private var wakeLock: PowerManager.WakeLock? = null
 
     // Vertical speed calculation state
@@ -101,6 +103,12 @@ class TrackingService : LifecycleService() {
          */
         private val _liveHeadingDegrees = MutableStateFlow<Float?>(null)
         val liveHeadingDegrees: StateFlow<Float?> = _liveHeadingDegrees
+
+        private val _livePitchDegrees = MutableStateFlow<Float?>(null)
+        val livePitchDegrees: StateFlow<Float?> = _livePitchDegrees
+
+        private val _liveRollDegrees = MutableStateFlow<Float?>(null)
+        val liveRollDegrees: StateFlow<Float?> = _liveRollDegrees
 
         fun start(context: Context) {
             val intent = Intent(context, TrackingService::class.java)
@@ -165,6 +173,16 @@ class TrackingService : LifecycleService() {
         headingForwardJob = lifecycleScope.launch {
             sensorCollector.liveHeadingDegrees.collect { heading ->
                 _liveHeadingDegrees.value = heading
+            }
+        }
+        pitchForwardJob = lifecycleScope.launch {
+            sensorCollector.livePitchDegrees.collect { pitch ->
+                _livePitchDegrees.value = pitch
+            }
+        }
+        rollForwardJob = lifecycleScope.launch {
+            sensorCollector.liveRollDegrees.collect { roll ->
+                _liveRollDegrees.value = roll
             }
         }
 
@@ -234,10 +252,16 @@ class TrackingService : LifecycleService() {
         locationCallback = null
         headingForwardJob?.cancel()
         headingForwardJob = null
+        pitchForwardJob?.cancel()
+        pitchForwardJob = null
+        rollForwardJob?.cancel()
+        rollForwardJob = null
         sensorCollector.stop()
         _isTracking.value = false
         _groundPressureHpa.value = null
         _liveHeadingDegrees.value = null
+        _livePitchDegrees.value = null
+        _liveRollDegrees.value = null
         cachedGeoidOffsetMeters = null
         altitudeHistory.clear()
         wakeLock?.let {

--- a/android/app/src/main/java/com/soar/tracker/service/TrackingService.kt
+++ b/android/app/src/main/java/com/soar/tracker/service/TrackingService.kt
@@ -59,7 +59,6 @@ class TrackingService : LifecycleService() {
     private var pendingSubmit: kotlinx.coroutines.Job? = null
     private var headingForwardJob: kotlinx.coroutines.Job? = null
     private var pitchForwardJob: kotlinx.coroutines.Job? = null
-    private var rollForwardJob: kotlinx.coroutines.Job? = null
     private var wakeLock: PowerManager.WakeLock? = null
 
     // Vertical speed calculation state
@@ -106,9 +105,6 @@ class TrackingService : LifecycleService() {
 
         private val _livePitchDegrees = MutableStateFlow<Float?>(null)
         val livePitchDegrees: StateFlow<Float?> = _livePitchDegrees
-
-        private val _liveRollDegrees = MutableStateFlow<Float?>(null)
-        val liveRollDegrees: StateFlow<Float?> = _liveRollDegrees
 
         fun start(context: Context) {
             val intent = Intent(context, TrackingService::class.java)
@@ -180,12 +176,6 @@ class TrackingService : LifecycleService() {
                 _livePitchDegrees.value = pitch
             }
         }
-        rollForwardJob = lifecycleScope.launch {
-            sensorCollector.liveRollDegrees.collect { roll ->
-                _liveRollDegrees.value = roll
-            }
-        }
-
         val locationRequest = LocationRequest.Builder(
             Priority.PRIORITY_HIGH_ACCURACY,
             3_000L, // 3 seconds
@@ -254,14 +244,11 @@ class TrackingService : LifecycleService() {
         headingForwardJob = null
         pitchForwardJob?.cancel()
         pitchForwardJob = null
-        rollForwardJob?.cancel()
-        rollForwardJob = null
         sensorCollector.stop()
         _isTracking.value = false
         _groundPressureHpa.value = null
         _liveHeadingDegrees.value = null
         _livePitchDegrees.value = null
-        _liveRollDegrees.value = null
         cachedGeoidOffsetMeters = null
         altitudeHistory.clear()
         wakeLock?.let {

--- a/android/app/src/main/java/com/soar/tracker/ui/components/AircraftDetailPopup.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/components/AircraftDetailPopup.kt
@@ -1,0 +1,47 @@
+package com.soar.tracker.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+/**
+ * A shared detail row for aircraft popup dialogs.
+ * Used by both ARScreen and LiveViewScreen popups.
+ *
+ * @param label The label text (left side)
+ * @param value The value text (right side)
+ * @param labelColor Color for the label text
+ * @param valueColor Color for the value text
+ */
+@Composable
+fun AircraftDetailRow(
+    label: String,
+    value: String,
+    labelColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+    valueColor: Color = Color.Unspecified,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 3.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            color = labelColor,
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Text(
+            text = value,
+            color = valueColor,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}

--- a/android/app/src/main/java/com/soar/tracker/ui/navigation/NavGraph.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/navigation/NavGraph.kt
@@ -2,6 +2,7 @@ package com.soar.tracker.ui.navigation
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Icon
@@ -21,6 +22,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.soar.tracker.SoarTrackerApp
+import com.soar.tracker.ui.screens.ARScreen
 import com.soar.tracker.ui.screens.LiveViewScreen
 import com.soar.tracker.ui.screens.LoginScreen
 import com.soar.tracker.ui.screens.TrackerScreen
@@ -74,6 +76,12 @@ private fun MainScreen(onLogout: () -> Unit) {
                     icon = { Icon(Icons.Default.LocationOn, contentDescription = null) },
                     label = { Text("Live View") },
                 )
+                NavigationBarItem(
+                    selected = selectedTab == 2,
+                    onClick = { selectedTab = 2 },
+                    icon = { Icon(Icons.Default.CameraAlt, contentDescription = null) },
+                    label = { Text("AR") },
+                )
             }
         },
     ) { padding ->
@@ -83,6 +91,9 @@ private fun MainScreen(onLogout: () -> Unit) {
                 modifier = Modifier.padding(bottom = padding.calculateBottomPadding()),
             )
             1 -> LiveViewScreen(
+                modifier = Modifier.padding(bottom = padding.calculateBottomPadding()),
+            )
+            2 -> ARScreen(
                 modifier = Modifier.padding(bottom = padding.calculateBottomPadding()),
             )
         }

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
@@ -64,6 +64,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.soar.tracker.ar.ARCoreSessionManager
 import com.soar.tracker.data.api.NearbyAircraftInfo
+import com.soar.tracker.ui.components.AircraftDetailRow
 import com.soar.tracker.service.TrackingService
 import com.soar.tracker.ui.theme.Green
 import com.soar.tracker.ui.theme.Red
@@ -73,11 +74,13 @@ import com.soar.tracker.ui.util.getAltitudeColor
 import com.soar.tracker.ui.util.normalizeBearing
 import com.soar.tracker.ui.util.projectToScreen
 import com.soar.tracker.ui.util.toARAircraftPosition
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import com.soar.tracker.ui.util.NM_TO_METERS
+import com.soar.tracker.ui.util.calculateBearing
 import java.util.Locale
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
-
-private const val NM_TO_METERS = 1852.0
 private const val TAP_RADIUS_PX = 60f // Hit-test radius for tapping aircraft markers
 
 @Composable
@@ -99,13 +102,19 @@ fun ARScreen(modifier: Modifier = Modifier) {
     val userAltM = sensorData?.altitudeMslMeters ?: sensorData?.altitudeMeters ?: 0.0
 
     // Camera permission
-    var cameraPermissionGranted by remember { mutableStateOf(false) }
+    var cameraPermissionGranted by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED,
+        )
+    }
     val cameraPermissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
     ) { granted -> cameraPermissionGranted = granted }
 
     LaunchedEffect(Unit) {
-        cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+        if (!cameraPermissionGranted) {
+            cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+        }
     }
 
     // Range slider (5–150 NM)
@@ -290,7 +299,8 @@ fun ARScreen(modifier: Modifier = Modifier) {
                             // Find the closest rendered aircraft to the tap point
                             var closest: NearbyAircraftInfo? = null
                             var closestDist = TAP_RADIUS_PX
-                            for ((ac, pos) in renderedPositions) {
+                            val positions = renderedPositions.toList()
+                            for ((ac, pos) in positions) {
                                 val dx = tapOffset.x - pos.x
                                 val dy = tapOffset.y - pos.y
                                 val dist = sqrt(dx * dx + dy * dy)
@@ -337,7 +347,7 @@ fun ARScreen(modifier: Modifier = Modifier) {
                     val distLabel = String.format(
                         Locale.US, "%.1fnm", ac.distanceMeters / NM_TO_METERS,
                     )
-                    val infoText = "$label  $altLabel  $distLabel"
+                    val infoText = listOfNotNull(label, altLabel.ifEmpty { null }, distLabel).joinToString("  ")
 
                     val textWidth = labelPaint.measureText(infoText)
                     val pillPadH = 6f
@@ -506,7 +516,7 @@ private fun AircraftDetailPopup(
 ) {
     val distNm = aircraft.distanceMeters / NM_TO_METERS
     val bearing = if (userLat != null && userLon != null) {
-        com.soar.tracker.ui.util.calculateBearing(
+        calculateBearing(
             userLat, userLon, aircraft.latitude, aircraft.longitude,
         )
     } else {
@@ -577,15 +587,16 @@ private fun AircraftDetailPopup(
             Spacer(modifier = Modifier.height(12.dp))
 
             // Position section
-            DetailRow("Altitude", aircraft.altitudeFeet?.let {
+            val arLabelColor = Color.White.copy(alpha = 0.5f)
+            AircraftDetailRow("Altitude", aircraft.altitudeFeet?.let {
                 String.format(Locale.US, "%.0f ft", it)
-            } ?: "Unknown")
-            DetailRow("Ground Speed", aircraft.groundSpeedKnots?.let {
+            } ?: "Unknown", labelColor = arLabelColor, valueColor = Color.White)
+            AircraftDetailRow("Ground Speed", aircraft.groundSpeedKnots?.let {
                 String.format(Locale.US, "%.0f kt", it)
-            } ?: "Unknown")
-            DetailRow("Track", aircraft.trackDegrees?.let {
+            } ?: "Unknown", labelColor = arLabelColor, valueColor = Color.White)
+            AircraftDetailRow("Track", aircraft.trackDegrees?.let {
                 String.format(Locale.US, "%03.0f\u00B0", it)
-            } ?: "Unknown")
+            } ?: "Unknown", labelColor = arLabelColor, valueColor = Color.White)
             aircraft.climbFpm?.let { climb ->
                 val sign = if (climb >= 0) "+" else ""
                 val climbColor = when {
@@ -593,23 +604,24 @@ private fun AircraftDetailPopup(
                     climb < -50 -> Red
                     else -> Color.White
                 }
-                DetailRow(
+                AircraftDetailRow(
                     "Climb Rate",
                     String.format(Locale.US, "%s%.0f fpm", sign, climb),
+                    labelColor = arLabelColor,
                     valueColor = climbColor,
                 )
             }
-            DetailRow("Distance", String.format(Locale.US, "%.1f nm", distNm))
+            AircraftDetailRow("Distance", String.format(Locale.US, "%.1f nm", distNm), labelColor = arLabelColor, valueColor = Color.White)
             bearing?.let {
-                DetailRow("Bearing", String.format(Locale.US, "%03.0f\u00B0", it))
+                AircraftDetailRow("Bearing", String.format(Locale.US, "%03.0f\u00B0", it), labelColor = arLabelColor, valueColor = Color.White)
             }
-            DetailRow("Position", String.format(
+            AircraftDetailRow("Position", String.format(
                 Locale.US, "%.4f, %.4f", aircraft.latitude, aircraft.longitude,
-            ))
+            ), labelColor = arLabelColor, valueColor = Color.White)
             aircraft.lastFixAt?.let {
                 // Show just the time portion if ISO format
                 val timeStr = if (it.contains("T")) it.substringAfter("T").take(8) else it
-                DetailRow("Last Seen", timeStr)
+                AircraftDetailRow("Last Seen", timeStr, labelColor = arLabelColor, valueColor = Color.White)
             }
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -630,31 +642,6 @@ private fun AircraftDetailPopup(
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun DetailRow(
-    label: String,
-    value: String,
-    valueColor: Color = Color.White,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 3.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Text(
-            text = label,
-            color = Color.White.copy(alpha = 0.5f),
-            style = MaterialTheme.typography.bodySmall,
-        )
-        Text(
-            text = value,
-            color = valueColor,
-            style = MaterialTheme.typography.bodySmall,
-        )
     }
 }
 
@@ -717,7 +704,7 @@ private fun AircraftListModal(
                 ) {
                     items(sorted, key = { it.id }) { ac ->
                         val distNm = ac.distanceMeters / NM_TO_METERS
-                        val bearing = com.soar.tracker.ui.util.calculateBearing(
+                        val bearing = calculateBearing(
                             userLat, userLon, ac.latitude, ac.longitude,
                         )
                         // Arrow rotation: bearing relative to device heading

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
@@ -11,12 +11,15 @@ import androidx.camera.view.PreviewView
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -26,6 +29,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.List
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -50,6 +54,7 @@ import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -59,14 +64,17 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.soar.tracker.data.api.NearbyAircraftInfo
 import com.soar.tracker.service.TrackingService
 import com.soar.tracker.ui.theme.Green
+import com.soar.tracker.ui.theme.Red
 import com.soar.tracker.ui.util.ARAircraftPosition
 import com.soar.tracker.ui.util.normalizeBearing
 import com.soar.tracker.ui.util.projectToScreen
 import com.soar.tracker.ui.util.toARAircraftPosition
 import java.util.Locale
 import kotlin.math.roundToInt
+import kotlin.math.sqrt
 
 private const val NM_TO_METERS = 1852.0
+private const val TAP_RADIUS_PX = 60f // Hit-test radius for tapping aircraft markers
 
 @Composable
 fun ARScreen(modifier: Modifier = Modifier) {
@@ -104,6 +112,13 @@ fun ARScreen(modifier: Modifier = Modifier) {
 
     // Target aircraft for direction indicator
     var targetAircraftId by remember { mutableStateOf<String?>(null) }
+
+    // Selected aircraft for detail popup (tapped on marker)
+    var selectedAircraft by remember { mutableStateOf<NearbyAircraftInfo?>(null) }
+
+    // Rendered aircraft positions for hit-testing taps
+    // Updated each frame by the Canvas draw pass
+    val renderedPositions = remember { mutableListOf<Pair<NearbyAircraftInfo, Offset>>() }
 
     // FOV based on orientation
     val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
@@ -207,14 +222,39 @@ fun ARScreen(modifier: Modifier = Modifier) {
             }
         }
 
-        // Aircraft overlay
+        // Aircraft overlay with tap detection
         if (userLat != null && userLon != null && hasSensors) {
             val heading = currentHeading!!
             val pitch = currentPitch!!
 
-            Canvas(modifier = Modifier.fillMaxSize()) {
+            Canvas(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .pointerInput(Unit) {
+                        detectTapGestures { tapOffset ->
+                            // Find the closest rendered aircraft to the tap point
+                            var closest: NearbyAircraftInfo? = null
+                            var closestDist = TAP_RADIUS_PX
+                            for ((ac, pos) in renderedPositions) {
+                                val dx = tapOffset.x - pos.x
+                                val dy = tapOffset.y - pos.y
+                                val dist = sqrt(dx * dx + dy * dy)
+                                if (dist < closestDist) {
+                                    closestDist = dist
+                                    closest = ac
+                                }
+                            }
+                            if (closest != null) {
+                                selectedAircraft = closest
+                            }
+                        }
+                    },
+            ) {
                 val w = size.width
                 val h = size.height
+
+                // Clear and rebuild rendered positions for hit-testing
+                renderedPositions.clear()
 
                 for (ac in aircraft) {
                     if (ac.distanceMeters / NM_TO_METERS > rangeNm) continue
@@ -226,6 +266,7 @@ fun ARScreen(modifier: Modifier = Modifier) {
                     if (!screenPos.visible) continue
 
                     val center = Offset(screenPos.x, screenPos.y)
+                    renderedPositions.add(ac to center)
 
                     // Aircraft triangle icon
                     val triSize = 12f
@@ -280,7 +321,6 @@ fun ARScreen(modifier: Modifier = Modifier) {
                 val arPos = toARAircraftPosition(targetAc, userLat, userLon, userAltM)
                 val screenPos = projectToScreen(
                     arPos, heading, pitch, fovH, fovV,
-                    // Use approximate screen size — exact size not critical for visibility check
                     with(density) { configuration.screenWidthDp.dp.toPx() },
                     with(density) { configuration.screenHeightDp.dp.toPx() },
                 )
@@ -375,6 +415,21 @@ fun ARScreen(modifier: Modifier = Modifier) {
             }
         }
 
+        // Aircraft detail popup (shown when tapping a marker)
+        selectedAircraft?.let { ac ->
+            AircraftDetailPopup(
+                aircraft = ac,
+                userLat = userLat,
+                userLon = userLon,
+                heading = currentHeading,
+                onDismiss = { selectedAircraft = null },
+                onTrack = {
+                    targetAircraftId = ac.id
+                    selectedAircraft = null
+                },
+            )
+        }
+
         // Aircraft list modal
         if (showAircraftList && userLat != null && userLon != null) {
             AircraftListModal(
@@ -390,6 +445,170 @@ fun ARScreen(modifier: Modifier = Modifier) {
                 onDismiss = { showAircraftList = false },
             )
         }
+    }
+}
+
+/** Aircraft detail popup shown when tapping a marker on the AR view. */
+@Composable
+private fun AircraftDetailPopup(
+    aircraft: NearbyAircraftInfo,
+    userLat: Double?,
+    userLon: Double?,
+    heading: Float?,
+    onDismiss: () -> Unit,
+    onTrack: () -> Unit,
+) {
+    val distNm = aircraft.distanceMeters / NM_TO_METERS
+    val bearing = if (userLat != null && userLon != null) {
+        com.soar.tracker.ui.util.calculateBearing(
+            userLat, userLon, aircraft.latitude, aircraft.longitude,
+        )
+    } else {
+        null
+    }
+    val arrowRotation = if (bearing != null && heading != null) {
+        (bearing - heading).toFloat()
+    } else {
+        null
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.5f))
+            .clickable(onClick = onDismiss),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(32.dp)
+                .background(Color(0xFF1A1A2E), RoundedCornerShape(16.dp))
+                .clickable {} // Consume clicks on the popup itself
+                .padding(20.dp),
+        ) {
+            // Header with direction arrow and name
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier.weight(1f),
+                ) {
+                    if (arrowRotation != null) {
+                        Text(
+                            text = "\u2191",
+                            color = Green,
+                            style = MaterialTheme.typography.headlineMedium,
+                            modifier = Modifier.rotate(arrowRotation),
+                        )
+                    }
+                    Column {
+                        Text(
+                            text = aircraft.registration ?: aircraft.aircraftModel,
+                            color = Color.White,
+                            style = MaterialTheme.typography.titleLarge,
+                        )
+                        if (aircraft.registration != null) {
+                            Text(
+                                text = aircraft.aircraftModel,
+                                color = Color.White.copy(alpha = 0.6f),
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        }
+                    }
+                }
+                IconButton(onClick = onDismiss) {
+                    Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.White)
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+            HorizontalDivider(color = Color.White.copy(alpha = 0.15f))
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Position section
+            DetailRow("Altitude", aircraft.altitudeFeet?.let {
+                String.format(Locale.US, "%.0f ft", it)
+            } ?: "Unknown")
+            DetailRow("Ground Speed", aircraft.groundSpeedKnots?.let {
+                String.format(Locale.US, "%.0f kt", it)
+            } ?: "Unknown")
+            DetailRow("Track", aircraft.trackDegrees?.let {
+                String.format(Locale.US, "%03.0f\u00B0", it)
+            } ?: "Unknown")
+            aircraft.climbFpm?.let { climb ->
+                val sign = if (climb >= 0) "+" else ""
+                val climbColor = when {
+                    climb > 50 -> Green
+                    climb < -50 -> Red
+                    else -> Color.White
+                }
+                DetailRow(
+                    "Climb Rate",
+                    String.format(Locale.US, "%s%.0f fpm", sign, climb),
+                    valueColor = climbColor,
+                )
+            }
+            DetailRow("Distance", String.format(Locale.US, "%.1f nm", distNm))
+            bearing?.let {
+                DetailRow("Bearing", String.format(Locale.US, "%03.0f\u00B0", it))
+            }
+            DetailRow("Position", String.format(
+                Locale.US, "%.4f, %.4f", aircraft.latitude, aircraft.longitude,
+            ))
+            aircraft.lastFixAt?.let {
+                // Show just the time portion if ISO format
+                val timeStr = if (it.contains("T")) it.substringAfter("T").take(8) else it
+                DetailRow("Last Seen", timeStr)
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Track button
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Green.copy(alpha = 0.2f), RoundedCornerShape(8.dp))
+                    .clickable(onClick = onTrack)
+                    .padding(12.dp),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = "Track this aircraft",
+                    color = Green,
+                    style = MaterialTheme.typography.labelLarge,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailRow(
+    label: String,
+    value: String,
+    valueColor: Color = Color.White,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 3.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            color = Color.White.copy(alpha = 0.5f),
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Text(
+            text = value,
+            color = valueColor,
+            style = MaterialTheme.typography.bodySmall,
+        )
     }
 }
 
@@ -476,7 +695,7 @@ private fun AircraftListModal(
                         ) {
                             // Direction arrow
                             Text(
-                                text = "\u2191", // ↑
+                                text = "\u2191", // up arrow
                                 color = Green,
                                 style = MaterialTheme.typography.titleLarge,
                                 modifier = Modifier.rotate(arrowRotation),
@@ -491,7 +710,7 @@ private fun AircraftListModal(
                                 )
                                 val altText = ac.altitudeFeet?.let {
                                     String.format(Locale.US, "%.0f ft", it)
-                                } ?: "—"
+                                } ?: "\u2014"
                                 Text(
                                     text = "$altText  \u00B7  ${String.format(Locale.US, "%.1f nm", distNm)}  \u00B7  ${String.format(Locale.US, "%03.0f\u00B0", bearing)}",
                                     color = Color.White.copy(alpha = 0.7f),
@@ -560,7 +779,7 @@ private fun DirectionIndicator(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
-                text = "\u2191", // ↑
+                text = "\u2191", // up arrow
                 color = Green,
                 style = MaterialTheme.typography.headlineMedium,
                 modifier = Modifier.rotate(arrowAngle),

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
@@ -93,7 +93,6 @@ fun ARScreen(modifier: Modifier = Modifier) {
     val configuration = LocalConfiguration.current
 
     // Tracking state
-    val isTracking by TrackingService.isTracking.collectAsState()
     val latestResponse by TrackingService.latestResponse.collectAsState()
     val sensorData by TrackingService.lastSensorData.collectAsState()
     val liveHeading by TrackingService.liveHeadingDegrees.collectAsState()
@@ -165,21 +164,6 @@ fun ARScreen(modifier: Modifier = Modifier) {
     LaunchedEffect(liveHeading, arCoreManager) {
         val heading = liveHeading ?: return@LaunchedEffect
         arCoreManager?.calibrateNorth(heading)
-    }
-
-    // Not tracking state
-    if (!isTracking) {
-        Box(
-            modifier = modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = "Start tracking to use AR view",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
-        return
     }
 
     // Camera permission denied

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
@@ -10,15 +10,27 @@ import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.List
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -26,37 +38,35 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.graphics.nativeCanvas
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.soar.tracker.data.api.NearbyAircraftInfo
 import com.soar.tracker.service.TrackingService
 import com.soar.tracker.ui.theme.Green
-import com.soar.tracker.ui.util.ARScreenPosition
+import com.soar.tracker.ui.util.ARAircraftPosition
+import com.soar.tracker.ui.util.normalizeBearing
 import com.soar.tracker.ui.util.projectToScreen
-import com.soar.tracker.ui.util.smoothAngle
-import com.soar.tracker.ui.util.smoothLinear
 import com.soar.tracker.ui.util.toARAircraftPosition
 import java.util.Locale
+import kotlin.math.roundToInt
 
-private val RANGE_PRESETS = listOf(10, 25, 50, 100)
-private const val SMOOTHING_ALPHA = 0.3f
+private const val NM_TO_METERS = 1852.0
 
 @Composable
 fun ARScreen(modifier: Modifier = Modifier) {
@@ -86,32 +96,24 @@ fun ARScreen(modifier: Modifier = Modifier) {
         cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
     }
 
-    // Range selector
-    var rangeNm by remember { mutableIntStateOf(50) }
+    // Range slider (5–150 NM)
+    var rangeNm by remember { mutableFloatStateOf(50f) }
+
+    // Aircraft list modal
+    var showAircraftList by remember { mutableStateOf(false) }
+
+    // Target aircraft for direction indicator
+    var targetAircraftId by remember { mutableStateOf<String?>(null) }
 
     // FOV based on orientation
     val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
     val fovH = if (isPortrait) 45f else 60f
     val fovV = if (isPortrait) 60f else 45f
 
-    // Smoothed heading and pitch
-    var smoothedHeading by remember { mutableFloatStateOf(0f) }
-    var smoothedPitch by remember { mutableFloatStateOf(0f) }
-    var hasInitialized by remember { mutableStateOf(false) }
-
-    // Update smoothed values when sensors change
-    val rawHeading = liveHeading
-    val rawPitch = livePitch
-    if (rawHeading != null && rawPitch != null) {
-        if (!hasInitialized) {
-            smoothedHeading = rawHeading
-            smoothedPitch = rawPitch
-            hasInitialized = true
-        } else {
-            smoothedHeading = smoothAngle(smoothedHeading, rawHeading, SMOOTHING_ALPHA)
-            smoothedPitch = smoothLinear(smoothedPitch, rawPitch, SMOOTHING_ALPHA)
-        }
-    }
+    // Use raw sensor values directly — smoothing adds visible lag vs camera
+    val currentHeading = liveHeading
+    val currentPitch = livePitch
+    val hasSensors = currentHeading != null && currentPitch != null
 
     // Not tracking state
     if (!isTracking) {
@@ -162,15 +164,6 @@ fun ARScreen(modifier: Modifier = Modifier) {
             isAntiAlias = true
         }
     }
-    val compassPaint = remember(labelTextSize) {
-        android.graphics.Paint().apply {
-            color = android.graphics.Color.WHITE
-            textSize = labelTextSize * 1.3f
-            textAlign = android.graphics.Paint.Align.CENTER
-            isAntiAlias = true
-            isFakeBoldText = true
-        }
-    }
 
     Box(modifier = modifier.fillMaxSize()) {
         // Camera preview
@@ -215,17 +208,20 @@ fun ARScreen(modifier: Modifier = Modifier) {
         }
 
         // Aircraft overlay
-        if (userLat != null && userLon != null && hasInitialized) {
+        if (userLat != null && userLon != null && hasSensors) {
+            val heading = currentHeading!!
+            val pitch = currentPitch!!
+
             Canvas(modifier = Modifier.fillMaxSize()) {
                 val w = size.width
                 val h = size.height
 
                 for (ac in aircraft) {
-                    if (ac.distanceMeters / 1852.0 > rangeNm) continue
+                    if (ac.distanceMeters / NM_TO_METERS > rangeNm) continue
 
                     val arPos = toARAircraftPosition(ac, userLat, userLon, userAltM)
                     val screenPos = projectToScreen(
-                        arPos, smoothedHeading, smoothedPitch, fovH, fovV, w, h,
+                        arPos, heading, pitch, fovH, fovV, w, h,
                     )
                     if (!screenPos.visible) continue
 
@@ -252,7 +248,7 @@ fun ARScreen(modifier: Modifier = Modifier) {
                         String.format(Locale.US, "%.0fft", it)
                     } ?: ""
                     val distLabel = String.format(
-                        Locale.US, "%.1fnm", ac.distanceMeters / 1852.0,
+                        Locale.US, "%.1fnm", ac.distanceMeters / NM_TO_METERS,
                     )
                     val infoText = "$label  $altLabel  $distLabel"
 
@@ -277,10 +273,33 @@ fun ARScreen(modifier: Modifier = Modifier) {
                     )
                 }
             }
+
+            // Direction indicator for targeted aircraft
+            val targetAc = aircraft.find { it.id == targetAircraftId }
+            if (targetAc != null) {
+                val arPos = toARAircraftPosition(targetAc, userLat, userLon, userAltM)
+                val screenPos = projectToScreen(
+                    arPos, heading, pitch, fovH, fovV,
+                    // Use approximate screen size — exact size not critical for visibility check
+                    with(density) { configuration.screenWidthDp.dp.toPx() },
+                    with(density) { configuration.screenHeightDp.dp.toPx() },
+                )
+                if (!screenPos.visible) {
+                    DirectionIndicator(
+                        arPos = arPos,
+                        heading = heading,
+                        pitch = pitch,
+                        fovH = fovH,
+                        fovV = fovV,
+                        onDismiss = { targetAircraftId = null },
+                    )
+                }
+            }
         }
 
         // Compass overlay (top-center)
-        if (hasInitialized) {
+        if (hasSensors) {
+            val heading = currentHeading!!
             Box(
                 modifier = Modifier
                     .align(Alignment.TopCenter)
@@ -292,16 +311,16 @@ fun ARScreen(modifier: Modifier = Modifier) {
                     .padding(horizontal = 16.dp, vertical = 8.dp),
             ) {
                 val headingText = String.format(
-                    Locale.US, "%03.0f\u00B0", smoothedHeading.toDouble(),
+                    Locale.US, "%03.0f\u00B0", heading.toDouble(),
                 )
                 val cardinal = when {
-                    smoothedHeading < 22.5f || smoothedHeading >= 337.5f -> "N"
-                    smoothedHeading < 67.5f -> "NE"
-                    smoothedHeading < 112.5f -> "E"
-                    smoothedHeading < 157.5f -> "SE"
-                    smoothedHeading < 202.5f -> "S"
-                    smoothedHeading < 247.5f -> "SW"
-                    smoothedHeading < 292.5f -> "W"
+                    heading < 22.5f || heading >= 337.5f -> "N"
+                    heading < 67.5f -> "NE"
+                    heading < 112.5f -> "E"
+                    heading < 157.5f -> "SE"
+                    heading < 202.5f -> "S"
+                    heading < 247.5f -> "SW"
+                    heading < 292.5f -> "W"
                     else -> "NW"
                 }
                 Text(
@@ -312,28 +331,250 @@ fun ARScreen(modifier: Modifier = Modifier) {
             }
         }
 
-        // Range selector (bottom row)
+        // Bottom controls: range slider + aircraft list button
         Row(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
-                .padding(bottom = 16.dp, start = 16.dp, end = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+                .background(Color.Black.copy(alpha = 0.5f))
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            for (preset in RANGE_PRESETS) {
-                FilledTonalButton(
-                    onClick = { rangeNm = preset },
-                ) {
-                    Text(
-                        text = "${preset} NM",
-                        color = if (rangeNm == preset) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        },
-                    )
+            // Range slider
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = "${rangeNm.roundToInt()} NM",
+                    color = Color.White,
+                    style = MaterialTheme.typography.labelSmall,
+                )
+                Slider(
+                    value = rangeNm,
+                    onValueChange = { rangeNm = it },
+                    valueRange = 5f..150f,
+                    colors = SliderDefaults.colors(
+                        thumbColor = Color.White,
+                        activeTrackColor = Green,
+                        inactiveTrackColor = Color.White.copy(alpha = 0.3f),
+                    ),
+                )
+            }
+
+            // Aircraft list button
+            IconButton(
+                onClick = { showAircraftList = true },
+                modifier = Modifier
+                    .background(Color.White.copy(alpha = 0.2f), CircleShape)
+                    .size(48.dp),
+            ) {
+                Icon(
+                    Icons.Default.List,
+                    contentDescription = "Nearby aircraft",
+                    tint = Color.White,
+                )
+            }
+        }
+
+        // Aircraft list modal
+        if (showAircraftList && userLat != null && userLon != null) {
+            AircraftListModal(
+                aircraft = aircraft.filter { it.distanceMeters / NM_TO_METERS <= rangeNm },
+                userLat = userLat,
+                userLon = userLon,
+                userAltM = userAltM,
+                heading = currentHeading,
+                onSelect = { ac ->
+                    targetAircraftId = ac.id
+                    showAircraftList = false
+                },
+                onDismiss = { showAircraftList = false },
+            )
+        }
+    }
+}
+
+/** Full-screen modal listing nearby aircraft sorted by distance. */
+@Composable
+private fun AircraftListModal(
+    aircraft: List<NearbyAircraftInfo>,
+    userLat: Double,
+    userLon: Double,
+    userAltM: Double,
+    heading: Float?,
+    onSelect: (NearbyAircraftInfo) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sorted = remember(aircraft) {
+        aircraft.sortedBy { it.distanceMeters }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.85f))
+            .clickable(onClick = onDismiss),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+        ) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Nearby Aircraft (${sorted.size})",
+                    color = Color.White,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                IconButton(onClick = onDismiss) {
+                    Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.White)
                 }
             }
+
+            if (sorted.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "No aircraft in range",
+                        color = Color.White.copy(alpha = 0.6f),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                }
+            } else {
+                LazyColumn(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    items(sorted, key = { it.id }) { ac ->
+                        val distNm = ac.distanceMeters / NM_TO_METERS
+                        val bearing = com.soar.tracker.ui.util.calculateBearing(
+                            userLat, userLon, ac.latitude, ac.longitude,
+                        )
+                        // Arrow rotation: bearing relative to device heading
+                        val arrowRotation = if (heading != null) {
+                            (bearing - heading).toFloat()
+                        } else {
+                            bearing.toFloat()
+                        }
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(
+                                    Color.White.copy(alpha = 0.1f),
+                                    RoundedCornerShape(8.dp),
+                                )
+                                .clickable { onSelect(ac) }
+                                .padding(12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            // Direction arrow
+                            Text(
+                                text = "\u2191", // ↑
+                                color = Green,
+                                style = MaterialTheme.typography.titleLarge,
+                                modifier = Modifier.rotate(arrowRotation),
+                            )
+
+                            // Info
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = ac.registration ?: ac.aircraftModel,
+                                    color = Color.White,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                                val altText = ac.altitudeFeet?.let {
+                                    String.format(Locale.US, "%.0f ft", it)
+                                } ?: "—"
+                                Text(
+                                    text = "$altText  \u00B7  ${String.format(Locale.US, "%.1f nm", distNm)}  \u00B7  ${String.format(Locale.US, "%03.0f\u00B0", bearing)}",
+                                    color = Color.White.copy(alpha = 0.7f),
+                                    style = MaterialTheme.typography.bodySmall,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Edge-of-screen indicator pointing toward an off-screen target aircraft.
+ * Shows an arrow at the screen edge and the aircraft registration + distance.
+ */
+@Composable
+private fun DirectionIndicator(
+    arPos: ARAircraftPosition,
+    heading: Float,
+    pitch: Float,
+    fovH: Float,
+    fovV: Float,
+    onDismiss: () -> Unit,
+) {
+    val relativeBearing = normalizeBearing(arPos.bearing - heading).toFloat()
+    val adjustedElevation = (arPos.elevation - pitch).toFloat()
+
+    // Determine direction
+    val isLeft = relativeBearing < -fovH / 4
+    val isRight = relativeBearing > fovH / 4
+    val isUp = adjustedElevation > fovV / 4
+    val isDown = adjustedElevation < -fovV / 4
+
+    // Arrow rotation in degrees (0 = up)
+    val arrowAngle = Math.toDegrees(
+        kotlin.math.atan2(relativeBearing.toDouble(), -adjustedElevation.toDouble()),
+    ).toFloat()
+
+    // Position at screen edge
+    val alignment = when {
+        isUp && isLeft -> Alignment.TopStart
+        isUp && isRight -> Alignment.TopEnd
+        isDown && isLeft -> Alignment.BottomStart
+        isDown && isRight -> Alignment.BottomEnd
+        isUp -> Alignment.TopCenter
+        isDown -> Alignment.BottomCenter
+        isLeft -> Alignment.CenterStart
+        isRight -> Alignment.CenterEnd
+        else -> Alignment.Center
+    }
+
+    val label = arPos.aircraft.registration ?: arPos.aircraft.aircraftModel
+    val distText = String.format(Locale.US, "%.1f nm", arPos.distanceNm)
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .align(alignment)
+                .padding(24.dp)
+                .background(Color.Black.copy(alpha = 0.7f), RoundedCornerShape(8.dp))
+                .clickable(onClick = onDismiss)
+                .padding(12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "\u2191", // ↑
+                color = Green,
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier.rotate(arrowAngle),
+            )
+            Text(
+                text = label,
+                color = Color.White,
+                style = MaterialTheme.typography.labelMedium,
+            )
+            Text(
+                text = distText,
+                color = Color.White.copy(alpha = 0.7f),
+                style = MaterialTheme.typography.labelSmall,
+            )
         }
     }
 }

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
@@ -1,0 +1,339 @@
+package com.soar.tracker.ui.screens
+
+import android.Manifest
+import android.content.res.Configuration
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.soar.tracker.service.TrackingService
+import com.soar.tracker.ui.theme.Green
+import com.soar.tracker.ui.util.ARScreenPosition
+import com.soar.tracker.ui.util.projectToScreen
+import com.soar.tracker.ui.util.smoothAngle
+import com.soar.tracker.ui.util.smoothLinear
+import com.soar.tracker.ui.util.toARAircraftPosition
+import java.util.Locale
+
+private val RANGE_PRESETS = listOf(10, 25, 50, 100)
+private const val SMOOTHING_ALPHA = 0.3f
+
+@Composable
+fun ARScreen(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val configuration = LocalConfiguration.current
+
+    // Tracking state
+    val isTracking by TrackingService.isTracking.collectAsState()
+    val latestResponse by TrackingService.latestResponse.collectAsState()
+    val sensorData by TrackingService.lastSensorData.collectAsState()
+    val liveHeading by TrackingService.liveHeadingDegrees.collectAsState()
+    val livePitch by TrackingService.livePitchDegrees.collectAsState()
+
+    val aircraft = latestResponse?.nearbyAircraft ?: emptyList()
+    val userLat = sensorData?.latitude
+    val userLon = sensorData?.longitude
+    val userAltM = sensorData?.altitudeMslMeters ?: sensorData?.altitudeMeters ?: 0.0
+
+    // Camera permission
+    var cameraPermissionGranted by remember { mutableStateOf(false) }
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted -> cameraPermissionGranted = granted }
+
+    LaunchedEffect(Unit) {
+        cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+    }
+
+    // Range selector
+    var rangeNm by remember { mutableIntStateOf(50) }
+
+    // FOV based on orientation
+    val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
+    val fovH = if (isPortrait) 45f else 60f
+    val fovV = if (isPortrait) 60f else 45f
+
+    // Smoothed heading and pitch
+    var smoothedHeading by remember { mutableFloatStateOf(0f) }
+    var smoothedPitch by remember { mutableFloatStateOf(0f) }
+    var hasInitialized by remember { mutableStateOf(false) }
+
+    // Update smoothed values when sensors change
+    val rawHeading = liveHeading
+    val rawPitch = livePitch
+    if (rawHeading != null && rawPitch != null) {
+        if (!hasInitialized) {
+            smoothedHeading = rawHeading
+            smoothedPitch = rawPitch
+            hasInitialized = true
+        } else {
+            smoothedHeading = smoothAngle(smoothedHeading, rawHeading, SMOOTHING_ALPHA)
+            smoothedPitch = smoothLinear(smoothedPitch, rawPitch, SMOOTHING_ALPHA)
+        }
+    }
+
+    // Not tracking state
+    if (!isTracking) {
+        Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "Start tracking to use AR view",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        return
+    }
+
+    // Camera permission denied
+    if (!cameraPermissionGranted) {
+        Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = "Camera permission is required for AR view",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        return
+    }
+
+    val density = LocalDensity.current
+    val labelTextSize = with(density) { 11.dp.toPx() }
+
+    // Pre-create Paint for aircraft labels
+    val labelPaint = remember(labelTextSize) {
+        android.graphics.Paint().apply {
+            color = android.graphics.Color.WHITE
+            textSize = labelTextSize
+            textAlign = android.graphics.Paint.Align.CENTER
+            isAntiAlias = true
+            isFakeBoldText = true
+        }
+    }
+    val pillPaint = remember {
+        android.graphics.Paint().apply {
+            color = android.graphics.Color.argb(200, 0, 0, 0)
+            isAntiAlias = true
+        }
+    }
+    val compassPaint = remember(labelTextSize) {
+        android.graphics.Paint().apply {
+            color = android.graphics.Color.WHITE
+            textSize = labelTextSize * 1.3f
+            textAlign = android.graphics.Paint.Align.CENTER
+            isAntiAlias = true
+            isFakeBoldText = true
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        // Camera preview
+        AndroidView(
+            factory = { ctx ->
+                val previewView = PreviewView(ctx).apply {
+                    scaleType = PreviewView.ScaleType.FILL_CENTER
+                    implementationMode = PreviewView.ImplementationMode.COMPATIBLE
+                }
+                val cameraProviderFuture = ProcessCameraProvider.getInstance(ctx)
+                cameraProviderFuture.addListener({
+                    val cameraProvider = cameraProviderFuture.get()
+                    val preview = Preview.Builder().build().also {
+                        it.surfaceProvider = previewView.surfaceProvider
+                    }
+                    try {
+                        cameraProvider.unbindAll()
+                        cameraProvider.bindToLifecycle(
+                            lifecycleOwner,
+                            CameraSelector.DEFAULT_BACK_CAMERA,
+                            preview,
+                        )
+                    } catch (_: Exception) {
+                        // Camera binding failed — preview will be blank
+                    }
+                }, ctx.mainExecutor)
+                previewView
+            },
+            modifier = Modifier.fillMaxSize(),
+        )
+
+        // Unbind camera when leaving the screen
+        DisposableEffect(lifecycleOwner) {
+            onDispose {
+                try {
+                    val cameraProvider = ProcessCameraProvider.getInstance(context).get()
+                    cameraProvider.unbindAll()
+                } catch (_: Exception) {
+                    // Ignore
+                }
+            }
+        }
+
+        // Aircraft overlay
+        if (userLat != null && userLon != null && hasInitialized) {
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                val w = size.width
+                val h = size.height
+
+                for (ac in aircraft) {
+                    if (ac.distanceMeters / 1852.0 > rangeNm) continue
+
+                    val arPos = toARAircraftPosition(ac, userLat, userLon, userAltM)
+                    val screenPos = projectToScreen(
+                        arPos, smoothedHeading, smoothedPitch, fovH, fovV, w, h,
+                    )
+                    if (!screenPos.visible) continue
+
+                    val center = Offset(screenPos.x, screenPos.y)
+
+                    // Aircraft triangle icon
+                    val triSize = 12f
+                    val trackDeg = ac.trackDegrees?.toFloat() ?: 0f
+                    rotate(trackDeg, pivot = center) {
+                        val triPath = Path().apply {
+                            moveTo(center.x, center.y - triSize)
+                            lineTo(center.x + triSize * 0.6f, center.y + triSize * 0.6f)
+                            lineTo(center.x, center.y + triSize * 0.2f)
+                            lineTo(center.x - triSize * 0.6f, center.y + triSize * 0.6f)
+                            close()
+                        }
+                        drawPath(triPath, Color.White)
+                        drawPath(triPath, Green, style = Stroke(width = 1.5f))
+                    }
+
+                    // Info label below marker
+                    val label = ac.registration ?: ac.aircraftModel
+                    val altLabel = ac.altitudeFeet?.let {
+                        String.format(Locale.US, "%.0fft", it)
+                    } ?: ""
+                    val distLabel = String.format(
+                        Locale.US, "%.1fnm", ac.distanceMeters / 1852.0,
+                    )
+                    val infoText = "$label  $altLabel  $distLabel"
+
+                    val textWidth = labelPaint.measureText(infoText)
+                    val pillPadH = 6f
+                    val pillPadV = 3f
+                    val pillTop = center.y + triSize + 4f
+                    val pillRect = android.graphics.RectF(
+                        center.x - textWidth / 2 - pillPadH,
+                        pillTop,
+                        center.x + textWidth / 2 + pillPadH,
+                        pillTop + labelTextSize + pillPadV * 2,
+                    )
+                    drawContext.canvas.nativeCanvas.drawRoundRect(
+                        pillRect, 8f, 8f, pillPaint,
+                    )
+                    drawContext.canvas.nativeCanvas.drawText(
+                        infoText,
+                        center.x,
+                        pillTop + pillPadV + labelTextSize * 0.85f,
+                        labelPaint,
+                    )
+                }
+            }
+        }
+
+        // Compass overlay (top-center)
+        if (hasInitialized) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = 16.dp)
+                    .background(
+                        Color.Black.copy(alpha = 0.6f),
+                        RoundedCornerShape(8.dp),
+                    )
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+            ) {
+                val headingText = String.format(
+                    Locale.US, "%03.0f\u00B0", smoothedHeading.toDouble(),
+                )
+                val cardinal = when {
+                    smoothedHeading < 22.5f || smoothedHeading >= 337.5f -> "N"
+                    smoothedHeading < 67.5f -> "NE"
+                    smoothedHeading < 112.5f -> "E"
+                    smoothedHeading < 157.5f -> "SE"
+                    smoothedHeading < 202.5f -> "S"
+                    smoothedHeading < 247.5f -> "SW"
+                    smoothedHeading < 292.5f -> "W"
+                    else -> "NW"
+                }
+                Text(
+                    text = "$cardinal  $headingText",
+                    color = Color.White,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+        }
+
+        // Range selector (bottom row)
+        Row(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .padding(bottom = 16.dp, start = 16.dp, end = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+        ) {
+            for (preset in RANGE_PRESETS) {
+                FilledTonalButton(
+                    onClick = { rangeNm = preset },
+                ) {
+                    Text(
+                        text = "${preset} NM",
+                        color = if (rangeNm == preset) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
@@ -50,9 +50,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalConfiguration
@@ -66,6 +63,8 @@ import com.soar.tracker.service.TrackingService
 import com.soar.tracker.ui.theme.Green
 import com.soar.tracker.ui.theme.Red
 import com.soar.tracker.ui.util.ARAircraftPosition
+import com.soar.tracker.ui.util.drawAircraftIcon
+import com.soar.tracker.ui.util.getAltitudeColor
 import com.soar.tracker.ui.util.normalizeBearing
 import com.soar.tracker.ui.util.projectToScreen
 import com.soar.tracker.ui.util.toARAircraftPosition
@@ -268,20 +267,11 @@ fun ARScreen(modifier: Modifier = Modifier) {
                     val center = Offset(screenPos.x, screenPos.y)
                     renderedPositions.add(ac to center)
 
-                    // Aircraft triangle icon
-                    val triSize = 12f
+                    // Aircraft icon with altitude-based coloring
+                    val iconSize = 24f
                     val trackDeg = ac.trackDegrees?.toFloat() ?: 0f
-                    rotate(trackDeg, pivot = center) {
-                        val triPath = Path().apply {
-                            moveTo(center.x, center.y - triSize)
-                            lineTo(center.x + triSize * 0.6f, center.y + triSize * 0.6f)
-                            lineTo(center.x, center.y + triSize * 0.2f)
-                            lineTo(center.x - triSize * 0.6f, center.y + triSize * 0.6f)
-                            close()
-                        }
-                        drawPath(triPath, Color.White)
-                        drawPath(triPath, Green, style = Stroke(width = 1.5f))
-                    }
+                    val altColor = getAltitudeColor(ac.altitudeFeet)
+                    drawAircraftIcon(center, trackDeg, iconSize, altColor)
 
                     // Info label below marker
                     val label = ac.registration ?: ac.aircraftModel
@@ -296,7 +286,7 @@ fun ARScreen(modifier: Modifier = Modifier) {
                     val textWidth = labelPaint.measureText(infoText)
                     val pillPadH = 6f
                     val pillPadV = 3f
-                    val pillTop = center.y + triSize + 4f
+                    val pillTop = center.y + iconSize / 2f + 4f
                     val pillRect = android.graphics.RectF(
                         center.x - textWidth / 2 - pillPadH,
                         pillTop,

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
@@ -93,6 +93,7 @@ fun ARScreen(modifier: Modifier = Modifier) {
     val configuration = LocalConfiguration.current
 
     // Tracking state
+    val isTracking by TrackingService.isTracking.collectAsState()
     val latestResponse by TrackingService.latestResponse.collectAsState()
     val sensorData by TrackingService.lastSensorData.collectAsState()
     val liveHeading by TrackingService.liveHeadingDegrees.collectAsState()
@@ -102,6 +103,16 @@ fun ARScreen(modifier: Modifier = Modifier) {
     val userLat = sensorData?.latitude
     val userLon = sensorData?.longitude
     val userAltM = sensorData?.altitudeMslMeters ?: sensorData?.altitudeMeters ?: 0.0
+
+    // Auto-start tracking if location permission is already granted
+    LaunchedEffect(Unit) {
+        if (!isTracking &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+            == PackageManager.PERMISSION_GRANTED
+        ) {
+            TrackingService.start(context)
+        }
+    }
 
     // Camera permission
     var cameraPermissionGranted by remember {

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
@@ -256,7 +256,7 @@ fun ARScreen(modifier: Modifier = Modifier) {
                         } catch (_: Exception) {
                             // Camera binding failed — preview will be blank
                         }
-                    }, ctx.mainExecutor)
+                    }, androidx.core.content.ContextCompat.getMainExecutor(ctx))
                     previewView
                 }
             },

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
@@ -2,6 +2,8 @@ package com.soar.tracker.ui.screens
 
 import android.Manifest
 import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import android.content.res.Configuration
 import android.opengl.GLSurfaceView
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -81,6 +83,7 @@ import com.soar.tracker.ui.util.calculateBearing
 import java.util.Locale
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
+
 private const val TAP_RADIUS_PX = 60f // Hit-test radius for tapping aircraft markers
 
 @Composable
@@ -218,10 +221,10 @@ fun ARScreen(modifier: Modifier = Modifier) {
         // Camera preview: ARCore GLSurfaceView or CameraX fallback
         AndroidView(
             factory = { ctx ->
-                val activity = ctx as Activity
-                val manager = ARCoreSessionManager(activity)
+                val activity = ctx.findActivity()
+                val manager = activity?.let { ARCoreSessionManager(it) }
 
-                if (manager.createSession()) {
+                if (manager != null && manager.createSession()) {
                     // ARCore available — use GLSurfaceView with ARCore rendering
                     liveHeading?.let { manager.calibrateNorth(it) }
                     val glView = GLSurfaceView(ctx).apply {
@@ -334,25 +337,26 @@ fun ARScreen(modifier: Modifier = Modifier) {
                     renderedPositions.add(ac to center)
 
                     // Aircraft icon with altitude-based coloring
-                    val iconSize = 24f
+                    val iconSize = 28f
                     val trackDeg = ac.trackDegrees?.toFloat() ?: 0f
                     val altColor = getAltitudeColor(ac.altitudeFeet)
                     drawAircraftIcon(center, trackDeg, iconSize, altColor)
 
                     // Info label below marker
-                    val label = ac.registration ?: ac.aircraftModel
+                    val name = ac.registration ?: ac.aircraftModel
+                    val model = if (ac.registration != null) ac.aircraftModel else null
                     val altLabel = ac.altitudeFeet?.let {
                         String.format(Locale.US, "%.0fft", it)
                     } ?: ""
                     val distLabel = String.format(
                         Locale.US, "%.1fnm", ac.distanceMeters / NM_TO_METERS,
                     )
-                    val infoText = listOfNotNull(label, altLabel.ifEmpty { null }, distLabel).joinToString("  ")
+                    val infoText = listOfNotNull(name, model, altLabel.ifEmpty { null }, distLabel).joinToString(" \u00B7 ")
 
                     val textWidth = labelPaint.measureText(infoText)
                     val pillPadH = 6f
                     val pillPadV = 3f
-                    val pillTop = center.y + iconSize / 2f + 4f
+                    val pillTop = center.y + iconSize / 2f + 2f
                     val pillRect = android.graphics.RectF(
                         center.x - textWidth / 2 - pillPadH,
                         pillTop,
@@ -829,4 +833,14 @@ private fun DirectionIndicator(
             )
         }
     }
+}
+
+/** Walk the context chain to find the hosting Activity. */
+private fun Context.findActivity(): Activity? {
+    var ctx = this
+    while (ctx is ContextWrapper) {
+        if (ctx is Activity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
 }

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/ARScreen.kt
@@ -1,7 +1,9 @@
 package com.soar.tracker.ui.screens
 
 import android.Manifest
+import android.app.Activity
 import android.content.res.Configuration
+import android.opengl.GLSurfaceView
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.camera.core.CameraSelector
@@ -57,7 +59,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.soar.tracker.ar.ARCoreSessionManager
 import com.soar.tracker.data.api.NearbyAircraftInfo
 import com.soar.tracker.service.TrackingService
 import com.soar.tracker.ui.theme.Green
@@ -119,15 +124,36 @@ fun ARScreen(modifier: Modifier = Modifier) {
     // Updated each frame by the Canvas draw pass
     val renderedPositions = remember { mutableListOf<Pair<NearbyAircraftInfo, Offset>>() }
 
-    // FOV based on orientation
-    val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
-    val fovH = if (isPortrait) 45f else 60f
-    val fovV = if (isPortrait) 60f else 45f
+    // ARCore session manager (null until camera permission granted and ARCore attempted)
+    var arCoreManager by remember { mutableStateOf<ARCoreSessionManager?>(null) }
 
-    // Use raw sensor values directly — smoothing adds visible lag vs camera
-    val currentHeading = liveHeading
-    val currentPitch = livePitch
+    // Collect ARCore values (heading, pitch, FOV) — null when unavailable
+    val arHeading by arCoreManager?.headingDegrees?.collectAsState()
+        ?: remember { mutableStateOf(null) }
+    val arPitch by arCoreManager?.pitchDegrees?.collectAsState()
+        ?: remember { mutableStateOf(null) }
+    val arFovH by arCoreManager?.fovHDegrees?.collectAsState()
+        ?: remember { mutableStateOf(null) }
+    val arFovV by arCoreManager?.fovVDegrees?.collectAsState()
+        ?: remember { mutableStateOf(null) }
+    val arAvailable by arCoreManager?.isAvailable?.collectAsState()
+        ?: remember { mutableStateOf(false) }
+
+    // Use ARCore heading/pitch when available, fall back to sensor
+    val currentHeading = if (arAvailable) arHeading ?: liveHeading else liveHeading
+    val currentPitch = if (arAvailable) arPitch ?: livePitch else livePitch
     val hasSensors = currentHeading != null && currentPitch != null
+
+    // FOV: prefer ARCore's actual camera FOV, fall back to hardcoded estimates
+    val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
+    val fovH = arFovH ?: if (isPortrait) 45f else 60f
+    val fovV = arFovV ?: if (isPortrait) 60f else 45f
+
+    // Feed sensor heading to ARCore for north calibration
+    LaunchedEffect(liveHeading, arCoreManager) {
+        val heading = liveHeading ?: return@LaunchedEffect
+        arCoreManager?.calibrateNorth(heading)
+    }
 
     // Not tracking state
     if (!isTracking) {
@@ -180,38 +206,68 @@ fun ARScreen(modifier: Modifier = Modifier) {
     }
 
     Box(modifier = modifier.fillMaxSize()) {
-        // Camera preview
+        // Camera preview: ARCore GLSurfaceView or CameraX fallback
         AndroidView(
             factory = { ctx ->
-                val previewView = PreviewView(ctx).apply {
-                    scaleType = PreviewView.ScaleType.FILL_CENTER
-                    implementationMode = PreviewView.ImplementationMode.COMPATIBLE
+                val activity = ctx as Activity
+                val manager = ARCoreSessionManager(activity)
+
+                if (manager.createSession()) {
+                    // ARCore available — use GLSurfaceView with ARCore rendering
+                    liveHeading?.let { manager.calibrateNorth(it) }
+                    val glView = GLSurfaceView(ctx).apply {
+                        preserveEGLContextOnPause = true
+                        setEGLContextClientVersion(2)
+                        setEGLConfigChooser(8, 8, 8, 8, 16, 0)
+                        setRenderer(manager)
+                        renderMode = GLSurfaceView.RENDERMODE_CONTINUOUSLY
+                    }
+                    manager.resume()
+                    arCoreManager = manager
+                    glView
+                } else {
+                    // ARCore unavailable — fall back to CameraX
+                    val previewView = PreviewView(ctx).apply {
+                        scaleType = PreviewView.ScaleType.FILL_CENTER
+                        implementationMode = PreviewView.ImplementationMode.COMPATIBLE
+                    }
+                    val cameraProviderFuture = ProcessCameraProvider.getInstance(ctx)
+                    cameraProviderFuture.addListener({
+                        val cameraProvider = cameraProviderFuture.get()
+                        val preview = Preview.Builder().build().also {
+                            it.surfaceProvider = previewView.surfaceProvider
+                        }
+                        try {
+                            cameraProvider.unbindAll()
+                            cameraProvider.bindToLifecycle(
+                                lifecycleOwner,
+                                CameraSelector.DEFAULT_BACK_CAMERA,
+                                preview,
+                            )
+                        } catch (_: Exception) {
+                            // Camera binding failed — preview will be blank
+                        }
+                    }, ctx.mainExecutor)
+                    previewView
                 }
-                val cameraProviderFuture = ProcessCameraProvider.getInstance(ctx)
-                cameraProviderFuture.addListener({
-                    val cameraProvider = cameraProviderFuture.get()
-                    val preview = Preview.Builder().build().also {
-                        it.surfaceProvider = previewView.surfaceProvider
-                    }
-                    try {
-                        cameraProvider.unbindAll()
-                        cameraProvider.bindToLifecycle(
-                            lifecycleOwner,
-                            CameraSelector.DEFAULT_BACK_CAMERA,
-                            preview,
-                        )
-                    } catch (_: Exception) {
-                        // Camera binding failed — preview will be blank
-                    }
-                }, ctx.mainExecutor)
-                previewView
             },
             modifier = Modifier.fillMaxSize(),
         )
 
-        // Unbind camera when leaving the screen
+        // Lifecycle management: pause/resume ARCore, cleanup on dispose
         DisposableEffect(lifecycleOwner) {
+            val observer = LifecycleEventObserver { _, event ->
+                when (event) {
+                    Lifecycle.Event.ON_RESUME -> arCoreManager?.resume()
+                    Lifecycle.Event.ON_PAUSE -> arCoreManager?.pause()
+                    else -> {}
+                }
+            }
+            lifecycleOwner.lifecycle.addObserver(observer)
             onDispose {
+                lifecycleOwner.lifecycle.removeObserver(observer)
+                arCoreManager?.destroy()
+                arCoreManager = null
                 try {
                     val cameraProvider = ProcessCameraProvider.getInstance(context).get()
                     cameraProvider.unbindAll()

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/LiveViewScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/LiveViewScreen.kt
@@ -51,17 +51,17 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.soar.tracker.data.api.NearbyAircraftInfo
 import com.soar.tracker.service.TrackingService
+import com.soar.tracker.ui.components.AircraftDetailRow
 import com.soar.tracker.ui.theme.Green
 import com.soar.tracker.ui.theme.Red
 import com.soar.tracker.ui.util.calculateBearing
 import com.soar.tracker.ui.util.drawAircraftIcon
 import com.soar.tracker.ui.util.getAltitudeColor
+import com.soar.tracker.ui.util.NM_TO_METERS
 import kotlin.math.cos
 import kotlin.math.min
 import kotlin.math.sin
 import kotlin.math.sqrt
-
-private const val NM_TO_METERS = 1852.0
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -253,7 +253,8 @@ fun LiveViewScreen(modifier: Modifier = Modifier) {
                             detectTapGestures { tapOffset ->
                                 var closest: NearbyAircraftInfo? = null
                                 var closestDist = 60f
-                                for ((ac, pos) in renderedPositions) {
+                                val positions = renderedPositions.toList()
+                                for ((ac, pos) in positions) {
                                     val dx = tapOffset.x - pos.x
                                     val dy = tapOffset.y - pos.y
                                     val dist = sqrt(dx * dx + dy * dy)
@@ -675,13 +676,13 @@ private fun LiveViewAircraftPopup(
             HorizontalDivider()
             Spacer(modifier = Modifier.height(12.dp))
 
-            LiveViewDetailRow("Altitude", aircraft.altitudeFeet?.let {
+            AircraftDetailRow("Altitude", aircraft.altitudeFeet?.let {
                 String.format(Locale.US, "%.0f ft", it)
             } ?: "Unknown")
-            LiveViewDetailRow("Ground Speed", aircraft.groundSpeedKnots?.let {
+            AircraftDetailRow("Ground Speed", aircraft.groundSpeedKnots?.let {
                 String.format(Locale.US, "%.0f kt", it)
             } ?: "Unknown")
-            LiveViewDetailRow("Track", aircraft.trackDegrees?.let {
+            AircraftDetailRow("Track", aircraft.trackDegrees?.let {
                 String.format(Locale.US, "%03.0f\u00B0", it)
             } ?: "Unknown")
             aircraft.climbFpm?.let { climb ->
@@ -691,46 +692,21 @@ private fun LiveViewAircraftPopup(
                     climb < -50 -> Red
                     else -> Color.Unspecified
                 }
-                LiveViewDetailRow(
+                AircraftDetailRow(
                     "Climb Rate",
                     String.format(Locale.US, "%s%.0f fpm", sign, climb),
                     valueColor = climbColor,
                 )
             }
-            LiveViewDetailRow("Distance", String.format(Locale.US, "%.1f nm", distNm))
-            LiveViewDetailRow("Bearing", String.format(Locale.US, "%03.0f\u00B0", bearing))
-            LiveViewDetailRow("Position", String.format(
+            AircraftDetailRow("Distance", String.format(Locale.US, "%.1f nm", distNm))
+            AircraftDetailRow("Bearing", String.format(Locale.US, "%03.0f\u00B0", bearing))
+            AircraftDetailRow("Position", String.format(
                 Locale.US, "%.4f, %.4f", aircraft.latitude, aircraft.longitude,
             ))
             aircraft.lastFixAt?.let {
                 val timeStr = if (it.contains("T")) it.substringAfter("T").take(8) else it
-                LiveViewDetailRow("Last Seen", timeStr)
+                AircraftDetailRow("Last Seen", timeStr)
             }
         }
-    }
-}
-
-@Composable
-private fun LiveViewDetailRow(
-    label: String,
-    value: String,
-    valueColor: Color = Color.Unspecified,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 3.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Text(
-            text = label,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            style = MaterialTheme.typography.bodySmall,
-        )
-        Text(
-            text = value,
-            color = valueColor,
-            style = MaterialTheme.typography.bodySmall,
-        )
     }
 }

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/LiveViewScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/LiveViewScreen.kt
@@ -190,7 +190,7 @@ fun LiveViewScreen(modifier: Modifier = Modifier) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(padding),
+                    .padding(top = padding.calculateTopPadding()),
             ) {
                 // Pre-create Paint objects outside Canvas to avoid allocation every frame
                 val northPaint = remember(textColor, labelTextSize) {

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/LiveViewScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/LiveViewScreen.kt
@@ -354,7 +354,7 @@ fun LiveViewScreen(modifier: Modifier = Modifier) {
                         val trackDeg = ac.trackDegrees?.toFloat() ?: 0f
                         val rotation = trackDeg + mapRotation
                         val altColor = getAltitudeColor(ac.altitudeFeet)
-                        drawAircraftIcon(pos, rotation, 20f, altColor)
+                        drawAircraftIcon(pos, rotation, 22f, altColor)
 
                         // Label
                         val label = ac.registration ?: ac.aircraftModel

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/LiveViewScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/LiveViewScreen.kt
@@ -3,17 +3,27 @@ package com.soar.tracker.ui.screens
 import java.util.Locale
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -26,6 +36,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
@@ -34,18 +45,21 @@ import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.soar.tracker.data.api.NearbyAircraftInfo
 import com.soar.tracker.service.TrackingService
 import com.soar.tracker.ui.theme.Green
 import com.soar.tracker.ui.theme.Red
 import com.soar.tracker.ui.util.calculateBearing
+import com.soar.tracker.ui.util.drawAircraftIcon
+import com.soar.tracker.ui.util.getAltitudeColor
 import kotlin.math.cos
 import kotlin.math.min
 import kotlin.math.sin
+import kotlin.math.sqrt
 
 private const val NM_TO_METERS = 1852.0
 
@@ -66,6 +80,12 @@ fun LiveViewScreen(modifier: Modifier = Modifier) {
     val userHeading: Float? = liveHeading ?: sensorData?.magneticHeadingDegrees?.toFloat()
 
     var northUp by remember { mutableStateOf(true) }
+
+    // Selected aircraft for detail popup
+    var selectedAircraft by remember { mutableStateOf<NearbyAircraftInfo?>(null) }
+
+    // Rendered aircraft positions for hit-testing taps
+    val renderedPositions = remember { mutableListOf<Pair<NearbyAircraftInfo, Offset>>() }
 
     // Dynamic range controlled by pinch zoom (NM)
     var radarRangeNm by remember { mutableStateOf(50.0f) }
@@ -230,9 +250,25 @@ fun LiveViewScreen(modifier: Modifier = Modifier) {
                         .fillMaxSize()
                         .background(MaterialTheme.colorScheme.surface)
                         .pointerInput(Unit) {
+                            detectTapGestures { tapOffset ->
+                                var closest: NearbyAircraftInfo? = null
+                                var closestDist = 60f
+                                for ((ac, pos) in renderedPositions) {
+                                    val dx = tapOffset.x - pos.x
+                                    val dy = tapOffset.y - pos.y
+                                    val dist = sqrt(dx * dx + dy * dy)
+                                    if (dist < closestDist) {
+                                        closestDist = dist
+                                        closest = ac
+                                    }
+                                }
+                                if (closest != null) {
+                                    selectedAircraft = closest
+                                }
+                            }
+                        }
+                        .pointerInput(Unit) {
                             detectTransformGestures { _, _, zoom, _ ->
-                                // Pinch out = zoom > 1 = smaller range (zoom in)
-                                // Pinch in  = zoom < 1 = larger range (zoom out)
                                 radarRangeNm = (radarRangeNm / zoom).coerceIn(minRangeNm, maxRangeNm)
                             }
                         },
@@ -303,6 +339,7 @@ fun LiveViewScreen(modifier: Modifier = Modifier) {
                     }
 
                     // Draw aircraft
+                    renderedPositions.clear()
                     for (ac in aircraft) {
                         val pos = latLonToScreen(
                             userLat, userLon,
@@ -310,28 +347,20 @@ fun LiveViewScreen(modifier: Modifier = Modifier) {
                             cx, cy, metersPerPixel, mapRotation,
                         )
 
-                        // Aircraft triangle, rotated by track
+                        renderedPositions.add(ac to pos)
+
+                        // Aircraft icon with altitude-based coloring
                         val trackDeg = ac.trackDegrees?.toFloat() ?: 0f
                         val rotation = trackDeg + mapRotation
-                        val triSize = 8f
-
-                        rotate(rotation, pivot = pos) {
-                            val triPath = Path().apply {
-                                moveTo(pos.x, pos.y - triSize)
-                                lineTo(pos.x + triSize * 0.6f, pos.y + triSize * 0.6f)
-                                lineTo(pos.x, pos.y + triSize * 0.2f)
-                                lineTo(pos.x - triSize * 0.6f, pos.y + triSize * 0.6f)
-                                close()
-                            }
-                            drawPath(triPath, aircraftColor)
-                        }
+                        val altColor = getAltitudeColor(ac.altitudeFeet)
+                        drawAircraftIcon(pos, rotation, 20f, altColor)
 
                         // Label
                         val label = ac.registration ?: ac.aircraftModel
                         drawContext.canvas.nativeCanvas.drawText(
                             label,
                             pos.x,
-                            pos.y - triSize - 3f,
+                            pos.y - 13f,
                             aircraftLabelPaint,
                         )
                     }
@@ -397,6 +426,17 @@ fun LiveViewScreen(modifier: Modifier = Modifier) {
                     distToDepartureNm = distToDepartureNm,
                     bearingToDepartureDeg = bearingToDeparture,
                     departureIdent = departureIdent,
+                )
+            }
+
+            // Aircraft detail popup
+            selectedAircraft?.let { ac ->
+                LiveViewAircraftPopup(
+                    aircraft = ac,
+                    userLat = userLat,
+                    userLon = userLon,
+                    heading = userHeading,
+                    onDismiss = { selectedAircraft = null },
                 )
             }
         }
@@ -560,4 +600,137 @@ private fun latLonToScreen(
     val screenY = cy + rotY
 
     return Offset(screenX, screenY)
+}
+
+/** Aircraft detail popup for live view — tap an aircraft on the radar to see details. */
+@Composable
+private fun LiveViewAircraftPopup(
+    aircraft: NearbyAircraftInfo,
+    userLat: Double,
+    userLon: Double,
+    heading: Float?,
+    onDismiss: () -> Unit,
+) {
+    val distNm = aircraft.distanceMeters / NM_TO_METERS
+    val bearing = calculateBearing(userLat, userLon, aircraft.latitude, aircraft.longitude)
+    val arrowRotation = if (heading != null) (bearing - heading).toFloat() else null
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.5f))
+            .clickable(onClick = onDismiss),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(32.dp)
+                .background(
+                    MaterialTheme.colorScheme.surface,
+                    RoundedCornerShape(16.dp),
+                )
+                .clickable {} // Consume clicks on the popup
+                .padding(20.dp),
+        ) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier.weight(1f),
+                ) {
+                    if (arrowRotation != null) {
+                        Text(
+                            text = "\u2191",
+                            color = Green,
+                            style = MaterialTheme.typography.headlineMedium,
+                            modifier = Modifier.rotate(arrowRotation),
+                        )
+                    }
+                    Column {
+                        Text(
+                            text = aircraft.registration ?: aircraft.aircraftModel,
+                            style = MaterialTheme.typography.titleLarge,
+                        )
+                        if (aircraft.registration != null) {
+                            Text(
+                                text = aircraft.aircraftModel,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        }
+                    }
+                }
+                IconButton(onClick = onDismiss) {
+                    Icon(Icons.Default.Close, contentDescription = "Close")
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(12.dp))
+
+            LiveViewDetailRow("Altitude", aircraft.altitudeFeet?.let {
+                String.format(Locale.US, "%.0f ft", it)
+            } ?: "Unknown")
+            LiveViewDetailRow("Ground Speed", aircraft.groundSpeedKnots?.let {
+                String.format(Locale.US, "%.0f kt", it)
+            } ?: "Unknown")
+            LiveViewDetailRow("Track", aircraft.trackDegrees?.let {
+                String.format(Locale.US, "%03.0f\u00B0", it)
+            } ?: "Unknown")
+            aircraft.climbFpm?.let { climb ->
+                val sign = if (climb >= 0) "+" else ""
+                val climbColor = when {
+                    climb > 50 -> Green
+                    climb < -50 -> Red
+                    else -> Color.Unspecified
+                }
+                LiveViewDetailRow(
+                    "Climb Rate",
+                    String.format(Locale.US, "%s%.0f fpm", sign, climb),
+                    valueColor = climbColor,
+                )
+            }
+            LiveViewDetailRow("Distance", String.format(Locale.US, "%.1f nm", distNm))
+            LiveViewDetailRow("Bearing", String.format(Locale.US, "%03.0f\u00B0", bearing))
+            LiveViewDetailRow("Position", String.format(
+                Locale.US, "%.4f, %.4f", aircraft.latitude, aircraft.longitude,
+            ))
+            aircraft.lastFixAt?.let {
+                val timeStr = if (it.contains("T")) it.substringAfter("T").take(8) else it
+                LiveViewDetailRow("Last Seen", timeStr)
+            }
+        }
+    }
+}
+
+@Composable
+private fun LiveViewDetailRow(
+    label: String,
+    value: String,
+    valueColor: Color = Color.Unspecified,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 3.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            style = MaterialTheme.typography.bodySmall,
+        )
+        Text(
+            text = value,
+            color = valueColor,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
 }

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/LiveViewScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/LiveViewScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
-import com.google.android.gms.location.LocationServices
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
@@ -77,31 +76,22 @@ fun LiveViewScreen(modifier: Modifier = Modifier) {
     val sensorData by TrackingService.lastSensorData.collectAsState()
     val liveHeading by TrackingService.liveHeadingDegrees.collectAsState()
 
+    val isTracking by TrackingService.isTracking.collectAsState()
+
     val aircraft = latestResponse?.nearbyAircraft ?: emptyList()
     val airports = latestResponse?.nearbyAirports ?: emptyList()
+    val userLat = sensorData?.latitude
+    val userLon = sensorData?.longitude
 
-    // Last-known position fallback when tracking hasn't started yet
-    var fallbackLat by remember { mutableStateOf<Double?>(null) }
-    var fallbackLon by remember { mutableStateOf<Double?>(null) }
-
-    @Suppress("MissingPermission")
+    // Auto-start tracking if location permission is already granted
     LaunchedEffect(Unit) {
-        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+        if (!isTracking &&
+            ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
             == PackageManager.PERMISSION_GRANTED
         ) {
-            val fusedClient = LocationServices.getFusedLocationProviderClient(context)
-            fusedClient.lastLocation.addOnSuccessListener { location ->
-                if (location != null) {
-                    fallbackLat = location.latitude
-                    fallbackLon = location.longitude
-                }
-            }
+            TrackingService.start(context)
         }
     }
-
-    // Prefer tracking position, fall back to last-known GPS
-    val userLat = sensorData?.latitude ?: fallbackLat
-    val userLon = sensorData?.longitude ?: fallbackLon
     // Prefer live heading (updates at ~50 Hz) over the GPS-paced snapshot (~3 s)
     // Nullable: null means heading is unknown, 0f means north
     val userHeading: Float? = liveHeading ?: sensorData?.magneticHeadingDegrees?.toFloat()

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/LiveViewScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/LiveViewScreen.kt
@@ -67,7 +67,6 @@ import kotlin.math.sqrt
 @Composable
 fun LiveViewScreen(modifier: Modifier = Modifier) {
     val latestResponse by TrackingService.latestResponse.collectAsState()
-    val isTracking by TrackingService.isTracking.collectAsState()
     val sensorData by TrackingService.lastSensorData.collectAsState()
     val liveHeading by TrackingService.liveHeadingDegrees.collectAsState()
 
@@ -143,7 +142,7 @@ fun LiveViewScreen(modifier: Modifier = Modifier) {
             )
         },
     ) { padding ->
-        if (!isTracking || userLat == null || userLon == null) {
+        if (userLat == null || userLon == null) {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -151,7 +150,7 @@ fun LiveViewScreen(modifier: Modifier = Modifier) {
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
-                    text = "Start tracking to see the radar view",
+                    text = "Waiting for GPS position\u2026",
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/android/app/src/main/java/com/soar/tracker/ui/screens/LiveViewScreen.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/screens/LiveViewScreen.kt
@@ -1,5 +1,7 @@
 package com.soar.tracker.ui.screens
 
+import android.Manifest
+import android.content.pm.PackageManager
 import java.util.Locale
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
@@ -29,11 +31,15 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import com.google.android.gms.location.LocationServices
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
@@ -66,14 +72,36 @@ import kotlin.math.sqrt
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LiveViewScreen(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
     val latestResponse by TrackingService.latestResponse.collectAsState()
     val sensorData by TrackingService.lastSensorData.collectAsState()
     val liveHeading by TrackingService.liveHeadingDegrees.collectAsState()
 
     val aircraft = latestResponse?.nearbyAircraft ?: emptyList()
     val airports = latestResponse?.nearbyAirports ?: emptyList()
-    val userLat = sensorData?.latitude
-    val userLon = sensorData?.longitude
+
+    // Last-known position fallback when tracking hasn't started yet
+    var fallbackLat by remember { mutableStateOf<Double?>(null) }
+    var fallbackLon by remember { mutableStateOf<Double?>(null) }
+
+    @Suppress("MissingPermission")
+    LaunchedEffect(Unit) {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+            == PackageManager.PERMISSION_GRANTED
+        ) {
+            val fusedClient = LocationServices.getFusedLocationProviderClient(context)
+            fusedClient.lastLocation.addOnSuccessListener { location ->
+                if (location != null) {
+                    fallbackLat = location.latitude
+                    fallbackLon = location.longitude
+                }
+            }
+        }
+    }
+
+    // Prefer tracking position, fall back to last-known GPS
+    val userLat = sensorData?.latitude ?: fallbackLat
+    val userLon = sensorData?.longitude ?: fallbackLon
     // Prefer live heading (updates at ~50 Hz) over the GPS-paced snapshot (~3 s)
     // Nullable: null means heading is unknown, 0f means north
     val userHeading: Float? = liveHeading ?: sensorData?.magneticHeadingDegrees?.toFloat()

--- a/android/app/src/main/java/com/soar/tracker/ui/util/ARProjection.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/util/ARProjection.kt
@@ -1,0 +1,126 @@
+package com.soar.tracker.ui.util
+
+import com.soar.tracker.data.api.NearbyAircraftInfo
+import kotlin.math.atan2
+
+private const val METERS_TO_FEET = 3.28084
+private const val NM_TO_FEET = 6076.12
+private const val NM_TO_METERS = 1852.0
+
+/**
+ * Aircraft position with pre-computed bearing and elevation angle for AR projection.
+ */
+data class ARAircraftPosition(
+    val aircraft: NearbyAircraftInfo,
+    /** Bearing from user to aircraft in degrees (0-360). */
+    val bearing: Double,
+    /** Elevation angle from user to aircraft in degrees (positive = above horizon). */
+    val elevation: Double,
+    /** Distance from user in nautical miles. */
+    val distanceNm: Double,
+)
+
+/**
+ * Screen-space position of an aircraft marker.
+ */
+data class ARScreenPosition(
+    val x: Float,
+    val y: Float,
+    val visible: Boolean,
+)
+
+/** Normalize bearing to -180..180 range for relative bearing calculations. */
+fun normalizeBearing(bearing: Double): Double {
+    var n = bearing
+    while (n > 180) n -= 360
+    while (n < -180) n += 360
+    return n
+}
+
+/**
+ * Calculate elevation angle from user to aircraft.
+ * @param userAltitudeM User altitude in meters
+ * @param aircraftAltitudeFt Aircraft altitude in feet
+ * @param groundDistanceNm Horizontal distance in nautical miles
+ * @return Angle in degrees above the horizon
+ */
+fun calculateElevationAngle(
+    userAltitudeM: Double,
+    aircraftAltitudeFt: Double,
+    groundDistanceNm: Double,
+): Double {
+    val userAltitudeFt = userAltitudeM * METERS_TO_FEET
+    val altDiffFt = aircraftAltitudeFt - userAltitudeFt
+    val groundDistFt = groundDistanceNm * NM_TO_FEET
+    if (groundDistFt == 0.0) return 0.0
+    return Math.toDegrees(atan2(altDiffFt, groundDistFt))
+}
+
+/**
+ * Wrap a [NearbyAircraftInfo] with bearing and elevation relative to the user.
+ */
+fun toARAircraftPosition(
+    ac: NearbyAircraftInfo,
+    userLat: Double,
+    userLon: Double,
+    userAltM: Double,
+): ARAircraftPosition {
+    val bearing = calculateBearing(userLat, userLon, ac.latitude, ac.longitude)
+    val distNm = ac.distanceMeters / NM_TO_METERS
+    val altFt = ac.altitudeFeet ?: 0.0
+    val elevation = calculateElevationAngle(userAltM, altFt, distNm)
+    return ARAircraftPosition(ac, bearing, elevation, distNm)
+}
+
+/**
+ * Project an [ARAircraftPosition] to screen coordinates.
+ *
+ * Uses the same linear FOV projection as the web AR view:
+ * relative bearing maps to X, adjusted elevation maps to Y.
+ */
+fun projectToScreen(
+    arPos: ARAircraftPosition,
+    headingDeg: Float,
+    pitchDeg: Float,
+    fovH: Float,
+    fovV: Float,
+    screenW: Float,
+    screenH: Float,
+): ARScreenPosition {
+    val relativeBearing = normalizeBearing(arPos.bearing - headingDeg)
+    val adjustedElevation = arPos.elevation - pitchDeg
+
+    val withinH = Math.abs(relativeBearing) <= fovH / 2.0
+    val withinV = Math.abs(adjustedElevation) <= fovV / 2.0
+    if (!withinH || !withinV) {
+        return ARScreenPosition(-1000f, -1000f, false)
+    }
+
+    val normalizedX = relativeBearing / (fovH / 2.0)
+    val x = (screenW / 2.0 + normalizedX * screenW / 2.0).toFloat()
+
+    val normalizedY = -adjustedElevation / (fovV / 2.0)
+    val y = (screenH / 2.0 + normalizedY * screenH / 2.0).toFloat()
+
+    return ARScreenPosition(x, y, true)
+}
+
+/**
+ * Exponential moving average that handles the 0/360 wrap-around for angles.
+ * Returns angle in 0..360 range.
+ */
+fun smoothAngle(current: Float, target: Float, alpha: Float): Float {
+    var diff = target - current
+    // Shortest path across 0/360 boundary
+    if (diff > 180f) diff -= 360f
+    if (diff < -180f) diff += 360f
+    var result = current + alpha * diff
+    if (result < 0f) result += 360f
+    if (result >= 360f) result -= 360f
+    return result
+}
+
+/** Simple EMA for pitch (no wrap-around needed). */
+fun smoothLinear(current: Float, target: Float, alpha: Float): Float {
+    return current + alpha * (target - current)
+}

--- a/android/app/src/main/java/com/soar/tracker/ui/util/ARProjection.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/util/ARProjection.kt
@@ -1,11 +1,11 @@
 package com.soar.tracker.ui.util
 
 import com.soar.tracker.data.api.NearbyAircraftInfo
+import kotlin.math.abs
 import kotlin.math.atan2
 
 private const val METERS_TO_FEET = 3.28084
 private const val NM_TO_FEET = 6076.12
-private const val NM_TO_METERS = 1852.0
 
 /**
  * Aircraft position with pre-computed bearing and elevation angle for AR projection.
@@ -90,8 +90,8 @@ fun projectToScreen(
     val relativeBearing = normalizeBearing(arPos.bearing - headingDeg)
     val adjustedElevation = arPos.elevation - pitchDeg
 
-    val withinH = Math.abs(relativeBearing) <= fovH / 2.0
-    val withinV = Math.abs(adjustedElevation) <= fovV / 2.0
+    val withinH = abs(relativeBearing) <= fovH / 2.0
+    val withinV = abs(adjustedElevation) <= fovV / 2.0
     if (!withinH || !withinV) {
         return ARScreenPosition(-1000f, -1000f, false)
     }

--- a/android/app/src/main/java/com/soar/tracker/ui/util/ARProjection.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/util/ARProjection.kt
@@ -104,23 +104,3 @@ fun projectToScreen(
 
     return ARScreenPosition(x, y, true)
 }
-
-/**
- * Exponential moving average that handles the 0/360 wrap-around for angles.
- * Returns angle in 0..360 range.
- */
-fun smoothAngle(current: Float, target: Float, alpha: Float): Float {
-    var diff = target - current
-    // Shortest path across 0/360 boundary
-    if (diff > 180f) diff -= 360f
-    if (diff < -180f) diff += 360f
-    var result = current + alpha * diff
-    if (result < 0f) result += 360f
-    if (result >= 360f) result -= 360f
-    return result
-}
-
-/** Simple EMA for pitch (no wrap-around needed). */
-fun smoothLinear(current: Float, target: Float, alpha: Float): Float {
-    return current + alpha * (target - current)
-}

--- a/android/app/src/main/java/com/soar/tracker/ui/util/AircraftIcons.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/util/AircraftIcons.kt
@@ -1,0 +1,166 @@
+package com.soar.tracker.ui.util
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.withTransform
+import androidx.compose.ui.geometry.Offset
+
+/**
+ * Aircraft icon paths and altitude-based coloring, ported from the web's aircraftIcons.ts.
+ *
+ * SVG paths from tar1090 project (https://github.com/wiedehopf/tar1090).
+ */
+
+/**
+ * Draw an aircraft icon centered at [center], rotated by [trackDegrees].
+ * Uses the "unknown" aircraft silhouette from tar1090 — a generic airplane shape
+ * that works well at small sizes on mobile.
+ *
+ * @param center Screen position to draw at
+ * @param trackDegrees Aircraft track heading for rotation
+ * @param size Icon size in pixels (height)
+ * @param fillColor Fill color (typically altitude-based)
+ * @param strokeColor Outline color
+ */
+fun DrawScope.drawAircraftIcon(
+    center: Offset,
+    trackDegrees: Float,
+    size: Float,
+    fillColor: Color,
+    strokeColor: Color = Color.White,
+) {
+    withTransform({
+        translate(center.x, center.y)
+        rotate(trackDegrees)
+    }) {
+        // "unknown" icon from tar1090: viewBox "-2.5 -2.5 22 22" → 22x22 units, centered at ~8.5,8
+        // Scale from 22-unit viewBox to desired pixel size
+        val scale = size / 22f
+        val cx = 8.5f // Approximate center X of the path
+        val cy = 8.5f // Approximate center Y of the path
+
+        val path = Path().apply {
+            // Simplified "unknown" airplane silhouette
+            // Body
+            moveTo((4.256f - cx) * scale, (15.496f - cy) * scale)
+            // Left wing sweep
+            cubicTo(
+                (3.979f - cx) * scale, (14.340f - cy) * scale,
+                (7.280f - cx) * scale, (13.606f - cy) * scale,
+                (7.280f - cx) * scale, (13.606f - cy) * scale,
+            )
+            lineTo((7.280f - cx) * scale, (8.650f - cy) * scale)
+            lineTo((1.280f - cx) * scale, (10.650f - cy) * scale)
+            cubicTo(
+                (0.600f - cx) * scale, (10.650f - cy) * scale,
+                (0.280f - cx) * scale, (10.300f - cy) * scale,
+                (0.280f - cx) * scale, (9.990f - cy) * scale,
+            )
+            cubicTo(
+                (0.242f - cx) * scale, (9.595f - cy) * scale,
+                (0.496f - cx) * scale, (9.231f - cy) * scale,
+                (0.880f - cx) * scale, (9.130f - cy) * scale,
+            )
+            cubicTo(
+                (1.140f - cx) * scale, (9.0f - cy) * scale,
+                (4.800f - cx) * scale, (7.0f - cy) * scale,
+                (7.280f - cx) * scale, (5.630f - cy) * scale,
+            )
+            lineTo((7.280f - cx) * scale, (3.0f - cy) * scale)
+            cubicTo(
+                (7.280f - cx) * scale, (1.890f - cy) * scale,
+                (7.720f - cx) * scale, (0.290f - cy) * scale,
+                (8.510f - cx) * scale, (0.290f - cy) * scale,
+            )
+            cubicTo(
+                (9.300f - cx) * scale, (0.290f - cy) * scale,
+                (9.770f - cx) * scale, (1.840f - cy) * scale,
+                (9.770f - cx) * scale, (3.0f - cy) * scale,
+            )
+            lineTo((9.770f - cx) * scale, (5.630f - cy) * scale)
+            cubicTo(
+                (12.220f - cx) * scale, (7.0f - cy) * scale,
+                (15.870f - cx) * scale, (9.0f - cy) * scale,
+                (16.140f - cx) * scale, (9.130f - cy) * scale,
+            )
+            cubicTo(
+                (16.530f - cx) * scale, (9.223f - cy) * scale,
+                (16.791f - cx) * scale, (9.591f - cy) * scale,
+                (16.750f - cx) * scale, (9.990f - cy) * scale,
+            )
+            cubicTo(
+                (16.700f - cx) * scale, (10.300f - cy) * scale,
+                (16.390f - cx) * scale, (10.660f - cy) * scale,
+                (15.700f - cx) * scale, (10.660f - cy) * scale,
+            )
+            lineTo((9.770f - cx) * scale, (8.660f - cy) * scale)
+            lineTo((9.770f - cx) * scale, (13.606f - cy) * scale)
+            cubicTo(
+                (9.770f - cx) * scale, (13.606f - cy) * scale,
+                (13.070f - cx) * scale, (14.340f - cy) * scale,
+                (12.794f - cx) * scale, (15.496f - cy) * scale,
+            )
+            cubicTo(
+                (12.463f - cx) * scale, (16.880f - cy) * scale,
+                (9.964f - cx) * scale, (15.874f - cy) * scale,
+                (8.540f - cx) * scale, (15.874f - cy) * scale,
+            )
+            cubicTo(
+                (7.106f - cx) * scale, (15.874f - cy) * scale,
+                (4.590f - cx) * scale, (16.890f - cy) * scale,
+                (4.256f - cx) * scale, (15.496f - cy) * scale,
+            )
+            close()
+        }
+
+        drawPath(path, fillColor)
+        drawPath(path, strokeColor, style = Stroke(width = 1.2f))
+    }
+}
+
+/**
+ * Altitude-based color gradient matching the web view.
+ * Interpolates from red (ground) through orange, yellow, green, cyan to light blue (40,000 ft).
+ *
+ * @param altitudeFeet Altitude in feet MSL, or null for unknown
+ * @return Color for the aircraft marker
+ */
+fun getAltitudeColor(altitudeFeet: Double?): Color {
+    if (altitudeFeet == null) return Color(0xFF6B7280) // Gray for unknown
+
+    val alt = altitudeFeet.coerceIn(0.0, 40000.0)
+
+    // Gradient stops: altitude → Color
+    data class Stop(val alt: Double, val r: Int, val g: Int, val b: Int)
+
+    val stops = listOf(
+        Stop(0.0, 239, 68, 68),       // Red    #ef4444
+        Stop(5000.0, 249, 115, 22),    // Orange #f97316
+        Stop(10000.0, 234, 179, 8),    // Yellow #eab308
+        Stop(20000.0, 34, 197, 94),    // Green  #22c55e
+        Stop(30000.0, 6, 182, 212),    // Cyan   #06b6d4
+        Stop(40000.0, 56, 189, 248),   // Blue   #38bdf8
+    )
+
+    // Find bracketing stops
+    var lower = stops.first()
+    var upper = stops.last()
+    for (i in 0 until stops.size - 1) {
+        if (alt >= stops[i].alt && alt < stops[i + 1].alt) {
+            lower = stops[i]
+            upper = stops[i + 1]
+            break
+        }
+    }
+
+    val range = upper.alt - lower.alt
+    val t = if (range > 0) ((alt - lower.alt) / range).toFloat() else 0f
+
+    val r = (lower.r + (upper.r - lower.r) * t).toInt()
+    val g = (lower.g + (upper.g - lower.g) * t).toInt()
+    val b = (lower.b + (upper.b - lower.b) * t).toInt()
+
+    return Color(r, g, b)
+}

--- a/android/app/src/main/java/com/soar/tracker/ui/util/AircraftIcons.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/util/AircraftIcons.kt
@@ -8,19 +8,16 @@ import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.geometry.Offset
 
 /**
- * Aircraft icon paths and altitude-based coloring, ported from the web's aircraftIcons.ts.
- *
- * SVG paths from tar1090 project (https://github.com/wiedehopf/tar1090).
+ * Aircraft icon drawing and altitude-based coloring.
  */
 
 /**
  * Draw an aircraft icon centered at [center], rotated by [trackDegrees].
- * Uses the "unknown" aircraft silhouette from tar1090 — a generic airplane shape
- * that works well at small sizes on mobile.
+ * Uses a simple airplane silhouette: pointed nose, swept wings, tail fin.
  *
  * @param center Screen position to draw at
- * @param trackDegrees Aircraft track heading for rotation
- * @param size Icon size in pixels (height)
+ * @param trackDegrees Aircraft track heading for rotation (0 = north/up)
+ * @param size Icon size in pixels (total height nose-to-tail)
  * @param fillColor Fill color (typically altitude-based)
  * @param strokeColor Outline color
  */
@@ -35,88 +32,39 @@ fun DrawScope.drawAircraftIcon(
         translate(center.x, center.y)
         rotate(trackDegrees)
     }) {
-        // "unknown" icon from tar1090: viewBox "-2.5 -2.5 22 22" → 22x22 units, centered at ~8.5,8
-        // Scale from 22-unit viewBox to desired pixel size
-        val scale = size / 22f
-        val cx = 8.5f // Approximate center X of the path
-        val cy = 8.5f // Approximate center Y of the path
+        val h = size / 2f // Half height
+        val w = size * 0.35f // Half wingspan
 
         val path = Path().apply {
-            // Simplified "unknown" airplane silhouette
-            // Body
-            moveTo((4.256f - cx) * scale, (15.496f - cy) * scale)
-            // Left wing sweep
-            cubicTo(
-                (3.979f - cx) * scale, (14.340f - cy) * scale,
-                (7.280f - cx) * scale, (13.606f - cy) * scale,
-                (7.280f - cx) * scale, (13.606f - cy) * scale,
-            )
-            lineTo((7.280f - cx) * scale, (8.650f - cy) * scale)
-            lineTo((1.280f - cx) * scale, (10.650f - cy) * scale)
-            cubicTo(
-                (0.600f - cx) * scale, (10.650f - cy) * scale,
-                (0.280f - cx) * scale, (10.300f - cy) * scale,
-                (0.280f - cx) * scale, (9.990f - cy) * scale,
-            )
-            cubicTo(
-                (0.242f - cx) * scale, (9.595f - cy) * scale,
-                (0.496f - cx) * scale, (9.231f - cy) * scale,
-                (0.880f - cx) * scale, (9.130f - cy) * scale,
-            )
-            cubicTo(
-                (1.140f - cx) * scale, (9.0f - cy) * scale,
-                (4.800f - cx) * scale, (7.0f - cy) * scale,
-                (7.280f - cx) * scale, (5.630f - cy) * scale,
-            )
-            lineTo((7.280f - cx) * scale, (3.0f - cy) * scale)
-            cubicTo(
-                (7.280f - cx) * scale, (1.890f - cy) * scale,
-                (7.720f - cx) * scale, (0.290f - cy) * scale,
-                (8.510f - cx) * scale, (0.290f - cy) * scale,
-            )
-            cubicTo(
-                (9.300f - cx) * scale, (0.290f - cy) * scale,
-                (9.770f - cx) * scale, (1.840f - cy) * scale,
-                (9.770f - cx) * scale, (3.0f - cy) * scale,
-            )
-            lineTo((9.770f - cx) * scale, (5.630f - cy) * scale)
-            cubicTo(
-                (12.220f - cx) * scale, (7.0f - cy) * scale,
-                (15.870f - cx) * scale, (9.0f - cy) * scale,
-                (16.140f - cx) * scale, (9.130f - cy) * scale,
-            )
-            cubicTo(
-                (16.530f - cx) * scale, (9.223f - cy) * scale,
-                (16.791f - cx) * scale, (9.591f - cy) * scale,
-                (16.750f - cx) * scale, (9.990f - cy) * scale,
-            )
-            cubicTo(
-                (16.700f - cx) * scale, (10.300f - cy) * scale,
-                (16.390f - cx) * scale, (10.660f - cy) * scale,
-                (15.700f - cx) * scale, (10.660f - cy) * scale,
-            )
-            lineTo((9.770f - cx) * scale, (8.660f - cy) * scale)
-            lineTo((9.770f - cx) * scale, (13.606f - cy) * scale)
-            cubicTo(
-                (9.770f - cx) * scale, (13.606f - cy) * scale,
-                (13.070f - cx) * scale, (14.340f - cy) * scale,
-                (12.794f - cx) * scale, (15.496f - cy) * scale,
-            )
-            cubicTo(
-                (12.463f - cx) * scale, (16.880f - cy) * scale,
-                (9.964f - cx) * scale, (15.874f - cy) * scale,
-                (8.540f - cx) * scale, (15.874f - cy) * scale,
-            )
-            cubicTo(
-                (7.106f - cx) * scale, (15.874f - cy) * scale,
-                (4.590f - cx) * scale, (16.890f - cy) * scale,
-                (4.256f - cx) * scale, (15.496f - cy) * scale,
-            )
+            // Nose (top)
+            moveTo(0f, -h)
+            // Right side of fuselage to wing root
+            lineTo(w * 0.2f, -h * 0.2f)
+            // Right wing tip
+            lineTo(w, h * 0.1f)
+            // Right wing trailing edge back to fuselage
+            lineTo(w * 0.2f, h * 0.25f)
+            // Right side of fuselage to tail
+            lineTo(w * 0.2f, h * 0.65f)
+            // Right tail fin
+            lineTo(w * 0.55f, h)
+            // Tail center
+            lineTo(0f, h * 0.8f)
+            // Left tail fin
+            lineTo(-w * 0.55f, h)
+            // Left side of fuselage from tail
+            lineTo(-w * 0.2f, h * 0.65f)
+            // Left wing trailing edge
+            lineTo(-w * 0.2f, h * 0.25f)
+            // Left wing tip
+            lineTo(-w, h * 0.1f)
+            // Left side of fuselage to nose
+            lineTo(-w * 0.2f, -h * 0.2f)
             close()
         }
 
         drawPath(path, fillColor)
-        drawPath(path, strokeColor, style = Stroke(width = 1.2f))
+        drawPath(path, strokeColor, style = Stroke(width = 1.5f))
     }
 }
 

--- a/android/app/src/main/java/com/soar/tracker/ui/util/AircraftIcons.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/util/AircraftIcons.kt
@@ -120,6 +120,18 @@ fun DrawScope.drawAircraftIcon(
     }
 }
 
+/** Altitude gradient stop: altitude in feet to RGB color components. */
+private data class AltColorStop(val alt: Double, val r: Int, val g: Int, val b: Int)
+
+private val ALTITUDE_COLOR_STOPS = listOf(
+    AltColorStop(0.0, 239, 68, 68),       // Red    #ef4444
+    AltColorStop(5000.0, 249, 115, 22),    // Orange #f97316
+    AltColorStop(10000.0, 234, 179, 8),    // Yellow #eab308
+    AltColorStop(20000.0, 34, 197, 94),    // Green  #22c55e
+    AltColorStop(30000.0, 6, 182, 212),    // Cyan   #06b6d4
+    AltColorStop(40000.0, 56, 189, 248),   // Blue   #38bdf8
+)
+
 /**
  * Altitude-based color gradient matching the web view.
  * Interpolates from red (ground) through orange, yellow, green, cyan to light blue (40,000 ft).
@@ -132,19 +144,8 @@ fun getAltitudeColor(altitudeFeet: Double?): Color {
 
     val alt = altitudeFeet.coerceIn(0.0, 40000.0)
 
-    // Gradient stops: altitude → Color
-    data class Stop(val alt: Double, val r: Int, val g: Int, val b: Int)
-
-    val stops = listOf(
-        Stop(0.0, 239, 68, 68),       // Red    #ef4444
-        Stop(5000.0, 249, 115, 22),    // Orange #f97316
-        Stop(10000.0, 234, 179, 8),    // Yellow #eab308
-        Stop(20000.0, 34, 197, 94),    // Green  #22c55e
-        Stop(30000.0, 6, 182, 212),    // Cyan   #06b6d4
-        Stop(40000.0, 56, 189, 248),   // Blue   #38bdf8
-    )
-
     // Find bracketing stops
+    val stops = ALTITUDE_COLOR_STOPS
     var lower = stops.first()
     var upper = stops.last()
     for (i in 0 until stops.size - 1) {

--- a/android/app/src/main/java/com/soar/tracker/ui/util/Geo.kt
+++ b/android/app/src/main/java/com/soar/tracker/ui/util/Geo.kt
@@ -1,5 +1,7 @@
 package com.soar.tracker.ui.util
 
+const val NM_TO_METERS = 1852.0
+
 fun calculateBearing(lat1: Double, lon1: Double, lat2: Double, lon2: Double): Double {
     val lat1Rad = Math.toRadians(lat1)
     val lat2Rad = Math.toRadians(lat2)

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ navigation = "2.8.5"
 playServicesLocation = "21.3.0"
 securityCrypto = "1.1.0-alpha06"
 camerax = "1.4.1"
+arcore = "1.46.0"
 ksp = "2.1.0-1.0.29"
 
 [libraries]
@@ -44,6 +45,7 @@ androidx-camera-core = { group = "androidx.camera", name = "camera-core", versio
 androidx-camera-camera2 = { group = "androidx.camera", name = "camera-camera2", version.ref = "camerax" }
 androidx-camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "camerax" }
 androidx-camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "camerax" }
+arcore = { group = "com.google.ar", name = "core", version.ref = "arcore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ coroutines = "1.9.0"
 navigation = "2.8.5"
 playServicesLocation = "21.3.0"
 securityCrypto = "1.1.0-alpha06"
+camerax = "1.4.1"
 ksp = "2.1.0-1.0.29"
 
 [libraries]
@@ -39,6 +40,10 @@ moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.re
 moshi-kotlin-codegen = { group = "com.squareup.moshi", name = "moshi-kotlin-codegen", version.ref = "moshi" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
+androidx-camera-core = { group = "androidx.camera", name = "camera-core", version.ref = "camerax" }
+androidx-camera-camera2 = { group = "androidx.camera", name = "camera-camera2", version.ref = "camerax" }
+androidx-camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "camerax" }
+androidx-camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "camerax" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/web/e2e/auth/register.test.ts
+++ b/web/e2e/auth/register.test.ts
@@ -110,7 +110,7 @@ test.describe('Registration', () => {
 		console.log('Current URL after registration:', page.url());
 
 		// Should be redirected to login page with success message
-		await expect(page).toHaveURL(/\/login/);
+		await expect(page).toHaveURL(/\/login/, { timeout: 15000 });
 		await expect(page.getByText(/registration successful.*check your email/i)).toBeVisible();
 
 		// Verify that verification email was sent via Mailpit

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -49,7 +49,8 @@
 		Info,
 		Eye,
 		Binoculars,
-		Shield
+		Shield,
+		Smartphone
 	} from '@lucide/svelte';
 
 	const base = resolve('/');
@@ -409,6 +410,15 @@
 											>
 												<Info size={16} /> Info
 											</a>
+											<a
+												href="https://nightly.link/hut8/soar/workflows/ci.yml/main/soar-tracker-debug.zip"
+												class="btn w-full justify-start preset-filled-primary-500 btn-sm"
+												onclick={() => (showDesktopMenu = false)}
+												target="_blank"
+												rel="noopener noreferrer"
+											>
+												<Smartphone size={16} /> Android App
+											</a>
 										</div>
 									</div>
 								{/if}
@@ -632,6 +642,15 @@
 						onclick={() => (showMobileMenu = false)}
 					>
 						<Info size={16} /> System Info
+					</a>
+					<a
+						href="https://nightly.link/hut8/soar/workflows/ci.yml/main/soar-tracker-debug.zip"
+						class="btn w-full justify-start preset-filled-primary-500"
+						onclick={() => (showMobileMenu = false)}
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						<Smartphone size={16} /> Android App
 					</a>
 
 					{#if $auth.isAuthenticated}


### PR DESCRIPTION
## Summary
- Adds a third **AR** tab to the Android app that overlays nearby aircraft markers on a live camera feed
- Uses CameraX for the rear camera preview and Compose Canvas for the 2D overlay — no ARCore dependency
- Ports the web AR view's linear FOV projection math (`projection.ts` / `calculations.ts`) to Kotlin
- Extracts pitch and roll from `SensorCollector`'s existing rotation vector sensor and forwards them through `TrackingService` companion StateFlows (same pattern as live heading)
- Aircraft markers are white triangles with green stroke, rotated by track, with dark pill labels showing registration, altitude, and distance
- Includes compass heading overlay (top-center) and range preset buttons (10/25/50/100 NM)
- EMA smoothing (alpha=0.3) applied in the composable for smooth heading/pitch transitions

## Files changed
| File | Change |
|------|--------|
| `libs.versions.toml` / `build.gradle.kts` | CameraX 1.4.1 dependencies |
| `AndroidManifest.xml` | CAMERA permission, camera uses-feature (required=false) |
| `SensorCollector.kt` | Add `livePitchDegrees` / `liveRollDegrees` StateFlows |
| `TrackingService.kt` | Forward pitch/roll with same pattern as heading |
| `NavGraph.kt` | Third nav tab (CameraAlt icon → ARScreen) |
| `ARProjection.kt` | **New** — projection math ported from web |
| `ARScreen.kt` | **New** — CameraX preview + Canvas overlay composable |

## Test plan
- [ ] Build: `cd android && ./gradlew assembleDebug` — verified, passes clean
- [ ] Install on device, start tracking, switch to AR tab
- [ ] Verify camera preview renders and aircraft markers overlay at correct positions
- [ ] Pan phone left/right — markers should stay fixed relative to compass directions
- [ ] Tilt phone up/down — markers should move vertically based on elevation angle
- [ ] Compass overlay shows current heading and rotates smoothly
- [ ] Range buttons filter aircraft by distance
- [ ] Camera permission denial shows appropriate message
- [ ] Camera unbinds when navigating away from AR tab