### PR TITLE
Fix Android Gradle build for Java 25

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,13 +1,12 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
 }
 
 android {
     namespace = "com.soar.tracker"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.soar.tracker"
@@ -29,12 +28,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
+    kotlin {
+        jvmToolchain(21)
     }
 
     buildFeatures {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.ksp) apply false
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,4 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
+android.disallowKotlinSourceSets=false

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-agp = "8.7.3"
-kotlin = "2.1.0"
+agp = "9.0.1"
+kotlin = "2.2.10"
 coreKtx = "1.15.0"
 lifecycleRuntime = "2.8.7"
 activityCompose = "1.9.3"
@@ -12,7 +12,7 @@ coroutines = "1.9.0"
 navigation = "2.8.5"
 playServicesLocation = "21.3.0"
 securityCrypto = "1.1.0-alpha06"
-ksp = "2.1.0-1.0.29"
+ksp = "2.2.10-2.0.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -42,6 +42,5 @@ play-services-location = { group = "com.google.android.gms", name = "play-servic
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Upgrade Gradle 8.9 → 9.1.0 (first version with full Java 25 support)
- Upgrade AGP 8.7.3 → 9.0.1, Kotlin 2.1.0 → 2.2.10, KSP 2.1.0-1.0.29 → 2.2.10-2.0.2
- Remove separate `kotlin-android` plugin (AGP 9 has built-in Kotlin)
- Replace deprecated `kotlinOptions` with `jvmToolchain(21)` and bump compileSdk to 36
- Add `android.disallowKotlinSourceSets=false` for KSP compatibility with AGP 9

## Context
The build was failing with the cryptic error `25.0.2` because Gradle 8.9's embedded Kotlin compiler couldn't parse the Java 25 version string. GraalVM 25's `jlink` also has a missing `jdk.internal.vm.ci` module that breaks Android's JDK image transform, so a JDK 21 toolchain is used for compilation.

## Test plan
- [x] `./gradlew assembleDebug` builds successfully
- [ ] Verify on CI